### PR TITLE
Add API client for api.congress.gov

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 license = { text = "MIT" }
 authors = [{ name = "John Campbell" }]
 dependencies = [
+    "httpx>=0.28.1",
     "pydantic>=2.13.4",
 ]
 

--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -1,0 +1,182 @@
+"""Typed client for `api.congress.gov <https://api.congress.gov/>`_.
+
+All HTTP and JSON-parsing concerns live here. Callers receive validated
+Pydantic models (:class:`Issue`, :class:`Article`) and never touch the
+raw camelCase payload shape.
+
+Rate-limit and retry handling are intentionally absent — they land in #23
+once the client is in use. Today, transient failures surface as
+:class:`ApiError`.
+"""
+
+from __future__ import annotations
+
+import os
+from types import TracebackType
+from typing import Any
+
+import httpx
+
+from . import __version__
+from .models import Article, Issue
+
+API_BASE = "https://api.congress.gov/v3"
+USER_AGENT = f"concord/{__version__} (+https://github.com/johnmarcampbell/concord)"
+ENV_API_KEY = "CONGRESS_API_KEY"
+
+
+class ApiError(Exception):
+    """Raised when api.congress.gov returns a non-success status or a transport error.
+
+    ``status_code`` is the HTTP status when the failure was an HTTP response,
+    or ``None`` for transport-level failures (DNS, timeout, connection reset).
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class Client:
+    """Typed wrapper over ``api.congress.gov``.
+
+    The client owns an ``httpx.Client`` underneath; pass a custom ``transport``
+    (e.g. :class:`httpx.MockTransport`) to intercept requests in tests.
+
+    Use as a context manager so the underlying connection pool is closed::
+
+        with Client(api_key="...") as client:
+            issues, next_offset = client.list_issues()
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        transport: httpx.BaseTransport | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        resolved = api_key if api_key is not None else os.environ.get(ENV_API_KEY)
+        if not resolved:
+            raise ApiError(f"API key required: pass api_key=... or set {ENV_API_KEY}")
+        self._api_key = resolved
+        self._client = httpx.Client(
+            base_url=API_BASE,
+            transport=transport,
+            timeout=timeout,
+            headers={"User-Agent": USER_AGENT},
+        )
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> Client:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    # -- endpoints -----------------------------------------------------------
+
+    def list_issues(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Issue], int | None]:
+        """List daily Congressional Record issues, newest first.
+
+        Returns ``(issues, next_offset)``. ``next_offset`` is ``None`` once the
+        last page has been served (the API omits ``pagination.next``).
+
+        The API does not support a date filter on this endpoint; callers
+        paginate until they walk past their target date.
+        """
+        payload = self._get(
+            "/daily-congressional-record",
+            params={"limit": limit, "offset": offset},
+        )
+        rows = payload.get("dailyCongressionalRecord", [])
+        issues = [_parse_issue(row) for row in rows]
+        has_next = "next" in payload.get("pagination", {})
+        next_offset = offset + limit if has_next else None
+        return issues, next_offset
+
+    def list_articles(self, volume: int, issue_number: int) -> list[Article]:
+        """List all articles in one issue, flattening the section nesting.
+
+        The API groups articles by section (``Senate Section``, ``House
+        Section``, ``Extensions of Remarks Section``, ``Daily Digest``). This
+        method flattens them into a single list, populating each
+        :class:`Article`'s ``section`` from the parent ``name``.
+        """
+        payload = self._get(
+            f"/daily-congressional-record/{volume}/{issue_number}/articles",
+        )
+        out: list[Article] = []
+        for section in payload.get("articles", []):
+            section_name = section["name"]
+            for art in section.get("sectionArticles", []):
+                out.append(_parse_article(section_name, art))
+        return out
+
+    # -- internals -----------------------------------------------------------
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        merged: dict[str, Any] = {"format": "json", "api_key": self._api_key}
+        if params:
+            merged.update(params)
+        try:
+            response = self._client.get(path, params=merged)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise ApiError(
+                f"{exc.response.status_code} {exc.response.reason_phrase} from {path}",
+                status_code=exc.response.status_code,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise ApiError(f"transport error calling {path}: {exc}") from exc
+        data: Any = response.json()
+        if not isinstance(data, dict):
+            raise ApiError(f"expected JSON object from {path}, got {type(data).__name__}")
+        return data
+
+
+# -- payload -> model -------------------------------------------------------
+
+
+def _parse_issue(row: dict[str, Any]) -> Issue:
+    return Issue(
+        issue_date=row["issueDate"],
+        congress=row["congress"],
+        session=row["sessionNumber"],
+        volume=row["volumeNumber"],
+        issue_number=row["issueNumber"],
+        update_date=row["updateDate"],
+    )
+
+
+def _parse_article(section_name: str, art: dict[str, Any]) -> Article:
+    urls = {t["type"]: t["url"] for t in art.get("text", [])}
+    try:
+        text_url = urls["Formatted Text"]
+        pdf_url = urls["PDF"]
+    except KeyError as exc:
+        raise ApiError(
+            f"article {art.get('title', '?')!r} missing text format {exc.args[0]!r}"
+        ) from exc
+    return Article(
+        section=section_name,
+        title=art["title"],
+        start_page=art["startPage"],
+        end_page=art["endPage"],
+        text_url=text_url,
+        pdf_url=pdf_url,
+    )  # type: ignore[call-arg]

--- a/tests/fixtures/api/articles_172_88.json
+++ b/tests/fixtures/api/articles_172_88.json
@@ -1,0 +1,329 @@
+{
+    "articles": [
+        {
+            "name": "Daily Digest",
+            "sectionArticles": [
+                {
+                    "endPage": "D552",
+                    "startPage": "D551",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgD551-6.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgD551-6.pdf"
+                        }
+                    ],
+                    "title": "Daily Digest/Next Meeting of the SENATE + Next Meeting of the HOUSE OF REPRESENTATIVES + Other End Matter; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "D551",
+                    "startPage": "D551",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgD551-5.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgD551-5.pdf"
+                        }
+                    ],
+                    "title": "Daily Digest/COMMITTEE MEETINGS FOR 2026-05-26; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "D551",
+                    "startPage": "D551",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgD551-4.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgD551-4.pdf"
+                        }
+                    ],
+                    "title": "Daily Digest/House Committee Meetings; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "D551",
+                    "startPage": "D551",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgD551-3.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgD551-3.pdf"
+                        }
+                    ],
+                    "title": "Daily Digest/House of Representatives; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "D551",
+                    "startPage": "D551",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgD551-2.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgD551-2.pdf"
+                        }
+                    ],
+                    "title": "Daily Digest/Senate Committee Meetings; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "D551",
+                    "startPage": "D551",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgD551.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgD551.pdf"
+                        }
+                    ],
+                    "title": "Daily Digest/Senate; Congressional Record Vol. 172, No. 88"
+                }
+            ]
+        },
+        {
+            "name": "Extensions of Remarks Section",
+            "sectionArticles": [
+                {
+                    "endPage": "E485",
+                    "startPage": "E485",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgE485-4.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgE485-4.pdf"
+                        }
+                    ],
+                    "title": "INTRODUCTION OF THE FIREWORKS TRAFFICKING AND MONEY LAUNDERING PREVENTION ACT; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "E485",
+                    "startPage": "E485",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgE485-3.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgE485-3.pdf"
+                        }
+                    ],
+                    "title": "RECOGNIZING RITA FORRESTER, A HEART STONE OF OUR CULTURE; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "E485",
+                    "startPage": "E485",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgE485-2.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgE485-2.pdf"
+                        }
+                    ],
+                    "title": "COMMEMORATING THE WORLD'S OLDEST PURPOSE-BUILT MOVIE THEATER; Congressional Record Vol. 172, No. 88"
+                }
+            ]
+        },
+        {
+            "name": "House Section",
+            "sectionArticles": [
+                {
+                    "endPage": "H3731",
+                    "startPage": "H3731",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3731-3.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3731-3.pdf"
+                        }
+                    ],
+                    "title": "DISCHARGE PETITIONS-- ADDITIONS AND WITHDRAWALS; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3731",
+                    "startPage": "H3731",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3731-2.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3731-2.pdf"
+                        }
+                    ],
+                    "title": "DISCHARGE PETITIONS; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3731",
+                    "startPage": "H3731",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3731.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3731.pdf"
+                        }
+                    ],
+                    "title": "ADDITIONAL SPONSORS; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3731",
+                    "startPage": "H3730",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3730-2.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3730-2.pdf"
+                        }
+                    ],
+                    "title": "PUBLIC BILLS AND RESOLUTIONS; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3730",
+                    "startPage": "H3730",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3730.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3730.pdf"
+                        }
+                    ],
+                    "title": "REPORTS OF COMMITTEES ON PUBLIC BILLS AND RESOLUTIONS; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3730",
+                    "startPage": "H3729",
+                    "text": [
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3729-7.pdf"
+                        },
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3729-7.htm"
+                        }
+                    ],
+                    "title": "EXECUTIVE COMMUNICATIONS, ETC.; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3729",
+                    "startPage": "H3729",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3729-6.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3729-6.pdf"
+                        }
+                    ],
+                    "title": "ADJOURNMENT; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3729",
+                    "startPage": "H3729",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3729-5.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3729-5.pdf"
+                        }
+                    ],
+                    "title": "PLEDGE OF ALLEGIANCE; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3729",
+                    "startPage": "H3729",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3729-4.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3729-4.pdf"
+                        }
+                    ],
+                    "title": "THE JOURNAL; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3729",
+                    "startPage": "H3729",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3729-3.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3729-3.pdf"
+                        }
+                    ],
+                    "title": "PRAYER; Congressional Record Vol. 172, No. 88"
+                },
+                {
+                    "endPage": "H3729",
+                    "startPage": "H3729",
+                    "text": [
+                        {
+                            "type": "Formatted Text",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgH3729-2.htm"
+                        },
+                        {
+                            "type": "PDF",
+                            "url": "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgH3729-2.pdf"
+                        }
+                    ],
+                    "title": "DESIGNATION OF THE SPEAKER PRO TEMPORE; Congressional Record Vol. 172, No. 88"
+                }
+            ]
+        }
+    ],
+    "pagination": {
+        "count": 24,
+        "next": "https://api.congress.gov/v3/daily-congressional-record/172/88/articles?offset=20&limit=20&format=json"
+    },
+    "request": {
+        "contentType": "application/json",
+        "format": "json",
+        "issueNumber": "88",
+        "volumeNumber": "172"
+    }
+}

--- a/tests/fixtures/api/list_issues_last_page.json
+++ b/tests/fixtures/api/list_issues_last_page.json
@@ -1,0 +1,102 @@
+{
+    "dailyCongressionalRecord": [
+        {
+            "congress": 111,
+            "issueDate": "2009-05-07T04:00:00Z",
+            "issueNumber": "70",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:08:33Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/70?format=json",
+            "volumeNumber": 155
+        },
+        {
+            "congress": 111,
+            "issueDate": "2009-05-04T04:00:00Z",
+            "issueNumber": "67",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:08:25Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/67?format=json",
+            "volumeNumber": 155
+        },
+        {
+            "congress": 111,
+            "issueDate": "2009-05-13T04:00:00Z",
+            "issueNumber": "73",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:08:14Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/73?format=json",
+            "volumeNumber": 155
+        },
+        {
+            "congress": 111,
+            "issueDate": "2009-01-12T05:00:00Z",
+            "issueNumber": "6",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:08:10Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/6?format=json",
+            "volumeNumber": 155
+        },
+        {
+            "congress": 111,
+            "issueDate": "2009-11-17T05:00:00Z",
+            "issueNumber": "170",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:08:00Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/170?format=json",
+            "volumeNumber": 155
+        },
+        {
+            "congress": 111,
+            "issueDate": "2009-09-10T04:00:00Z",
+            "issueNumber": "127",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:07:49Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/127?format=json",
+            "volumeNumber": 155
+        },
+        {
+            "congress": 111,
+            "issueDate": "2009-01-28T05:00:00Z",
+            "issueNumber": "17",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:07:39Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/17?format=json",
+            "volumeNumber": 155
+        },
+        {
+            "congress": 111,
+            "issueDate": "2009-03-16T04:00:00Z",
+            "issueNumber": "45",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:07:31Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/45?format=json",
+            "volumeNumber": 155
+        },
+        {
+            "congress": 111,
+            "issueDate": "2009-10-08T04:00:00Z",
+            "issueNumber": "145",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:07:19Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/145?format=json",
+            "volumeNumber": 155
+        },
+        {
+            "congress": 111,
+            "issueDate": "2009-08-03T04:00:00Z",
+            "issueNumber": "119",
+            "sessionNumber": 1,
+            "updateDate": "2013-04-10T08:07:15Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/155/119?format=json",
+            "volumeNumber": 155
+        }
+    ],
+    "pagination": {
+        "count": 5810,
+        "prev": "https://api.congress.gov/v3/daily-congressional-record?offset=5790&limit=10&format=json"
+    },
+    "request": {
+        "contentType": "application/json",
+        "format": "json"
+    }
+}

--- a/tests/fixtures/api/list_issues_page1.json
+++ b/tests/fixtures/api/list_issues_page1.json
@@ -1,0 +1,102 @@
+{
+    "dailyCongressionalRecord": [
+        {
+            "congress": 119,
+            "issueDate": "2026-05-22T04:00:00Z",
+            "issueNumber": "88",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-23T06:44:22Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/88?format=json",
+            "volumeNumber": 172
+        },
+        {
+            "congress": 119,
+            "issueDate": "2026-05-20T04:00:00Z",
+            "issueNumber": "86",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-22T14:25:02Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/86?format=json",
+            "volumeNumber": 172
+        },
+        {
+            "congress": 119,
+            "issueDate": "2026-05-21T04:00:00Z",
+            "issueNumber": "87",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-22T12:59:29Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/87?format=json",
+            "volumeNumber": 172
+        },
+        {
+            "congress": 119,
+            "issueDate": "2026-05-19T04:00:00Z",
+            "issueNumber": "85",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-20T16:29:23Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/85?format=json",
+            "volumeNumber": 172
+        },
+        {
+            "congress": 119,
+            "issueDate": "2026-05-18T04:00:00Z",
+            "issueNumber": "84",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-19T09:59:20Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/84?format=json",
+            "volumeNumber": 172
+        },
+        {
+            "congress": 119,
+            "issueDate": "2026-05-15T04:00:00Z",
+            "issueNumber": "83",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-16T11:14:22Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/83?format=json",
+            "volumeNumber": 172
+        },
+        {
+            "congress": 119,
+            "issueDate": "2026-05-14T04:00:00Z",
+            "issueNumber": "82",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-15T16:18:26Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/82?format=json",
+            "volumeNumber": 172
+        },
+        {
+            "congress": 119,
+            "issueDate": "2026-05-13T04:00:00Z",
+            "issueNumber": "81",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-14T16:18:25Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/81?format=json",
+            "volumeNumber": 172
+        },
+        {
+            "congress": 119,
+            "issueDate": "2026-05-12T04:00:00Z",
+            "issueNumber": "80",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-13T15:44:21Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/80?format=json",
+            "volumeNumber": 172
+        },
+        {
+            "congress": 119,
+            "issueDate": "2026-05-11T04:00:00Z",
+            "issueNumber": "79",
+            "sessionNumber": 2,
+            "updateDate": "2026-05-12T18:18:20Z",
+            "url": "https://api.congress.gov/v3/daily-congressional-record/172/79?format=json",
+            "volumeNumber": 172
+        }
+    ],
+    "pagination": {
+        "count": 5810,
+        "next": "https://api.congress.gov/v3/daily-congressional-record?offset=10&limit=10&format=json"
+    },
+    "request": {
+        "contentType": "application/json",
+        "format": "json"
+    }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,203 @@
+"""Tests for the api.congress.gov client.
+
+All tests inject an ``httpx.MockTransport`` so nothing leaves the process.
+JSON responses are real captures from the live API, stored under
+``tests/fixtures/api/``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from concord.api import ENV_API_KEY, ApiError, Client
+
+
+def _mock_transport(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> httpx.MockTransport:
+    return httpx.MockTransport(handler)
+
+
+def _json_response(payload: Any, status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status, content=json.dumps(payload), headers={"content-type": "application/json"}
+    )
+
+
+def _make_client(handler: Callable[[httpx.Request], httpx.Response]) -> Client:
+    return Client(api_key="test-key", transport=_mock_transport(handler))
+
+
+# -- construction -------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_uses_explicit_api_key(self) -> None:
+        client = Client(api_key="explicit", transport=_mock_transport(lambda r: _json_response({})))
+        assert client._api_key == "explicit"
+
+    def test_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_API_KEY, "from-env")
+        client = Client(transport=_mock_transport(lambda r: _json_response({})))
+        assert client._api_key == "from-env"
+
+    def test_missing_key_raises_apierror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_API_KEY, raising=False)
+        with pytest.raises(ApiError, match="API key required"):
+            Client(transport=_mock_transport(lambda r: _json_response({})))
+
+    def test_context_manager_closes_underlying_client(self) -> None:
+        with _make_client(lambda r: _json_response({})) as client:
+            assert not client._client.is_closed
+        assert client._client.is_closed
+
+
+# -- list_issues --------------------------------------------------------------
+
+
+class TestListIssues:
+    def test_parses_first_page(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/list_issues_page1.json").read_text())
+
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return _json_response(payload)
+
+        with _make_client(handler) as client:
+            issues, next_offset = client.list_issues(limit=10, offset=0)
+
+        assert len(issues) == 10
+        # First entry in the captured fixture is volume 172, issue 88.
+        assert issues[0].volume == 172
+        assert issues[0].issue_number == 88
+        # Page 1 with more behind it -> next_offset = limit
+        assert next_offset == 10
+
+        # Verify request shape: correct path, JSON format, api_key, limit, offset.
+        req = captured[0]
+        assert req.url.path == "/v3/daily-congressional-record"
+        params = dict(req.url.params)
+        assert params["format"] == "json"
+        assert params["api_key"] == "test-key"
+        assert params["limit"] == "10"
+        assert params["offset"] == "0"
+
+    def test_last_page_returns_none_next_offset(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/list_issues_last_page.json").read_text())
+        with _make_client(lambda r: _json_response(payload)) as client:
+            issues, next_offset = client.list_issues(limit=10, offset=5800)
+
+        assert len(issues) == 10
+        assert next_offset is None
+
+    def test_passes_through_offset_for_pagination(self) -> None:
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return _json_response({"dailyCongressionalRecord": [], "pagination": {"count": 0}})
+
+        with _make_client(handler) as client:
+            client.list_issues(limit=25, offset=100)
+
+        params = dict(captured[0].url.params)
+        assert params["limit"] == "25"
+        assert params["offset"] == "100"
+
+
+# -- list_articles ------------------------------------------------------------
+
+
+class TestListArticles:
+    def test_flattens_sections(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/articles_172_88.json").read_text())
+
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return _json_response(payload)
+
+        with _make_client(handler) as client:
+            articles = client.list_articles(volume=172, issue_number=88)
+
+        # Fixture has 6 + 3 + 11 = 20 articles across 3 sections.
+        assert len(articles) == 20
+        sections = {a.section for a in articles}
+        assert sections == {"Daily Digest", "Extensions of Remarks Section", "House Section"}
+
+        # Section names propagate from the parent payload, not the article.
+        assert all(a.section in sections for a in articles)
+
+        # Every article has a granule_id derived from its text_url.
+        assert all(a.granule_id.startswith("CREC-") for a in articles)
+
+        req = captured[0]
+        assert req.url.path == "/v3/daily-congressional-record/172/88/articles"
+
+    def test_missing_text_format_raises(self) -> None:
+        # An article entry without the required "Formatted Text" URL is a
+        # contract violation worth surfacing clearly rather than silently
+        # producing a half-built Article.
+        payload = {
+            "articles": [
+                {
+                    "name": "Senate Section",
+                    "sectionArticles": [
+                        {
+                            "title": "Bad article",
+                            "startPage": "S1",
+                            "endPage": "S1",
+                            "text": [
+                                {"type": "PDF", "url": "https://example.com/x.pdf"},
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+        with (
+            _make_client(lambda r: _json_response(payload)) as client,
+            pytest.raises(ApiError, match="missing text format"),
+        ):
+            client.list_articles(volume=1, issue_number=1)
+
+
+# -- error handling -----------------------------------------------------------
+
+
+class TestErrors:
+    @pytest.mark.parametrize("status", [401, 403, 404, 500, 502, 503])
+    def test_http_error_raises_apierror(self, status: int) -> None:
+        with (
+            _make_client(lambda r: httpx.Response(status, json={"error": "x"})) as client,
+            pytest.raises(ApiError) as exc,
+        ):
+            client.list_issues()
+        assert exc.value.status_code == status
+
+    def test_transport_error_raises_apierror(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("simulated")
+
+        with (
+            _make_client(handler) as client,
+            pytest.raises(ApiError, match="transport error") as exc,
+        ):
+            client.list_issues()
+        assert exc.value.status_code is None
+
+    def test_non_object_json_raises(self) -> None:
+        with (
+            _make_client(lambda r: _json_response(["not", "an", "object"])) as client,
+            pytest.raises(ApiError, match="expected JSON object"),
+        ):
+            client.list_issues()

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,19 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -56,6 +69,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -69,6 +91,7 @@ name = "concord"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "pydantic" },
 ]
 
@@ -80,13 +103,62 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.13.4" }]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pydantic", specifier = ">=2.13.4" },
+]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.11" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.6" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `src/concord/api.py` with `Client.list_issues()` and `Client.list_articles()`, both returning validated Pydantic models.
- `list_issues()` returns `(issues, next_offset)` so the pipeline can paginate without re-parsing the API's `pagination.next` URL.
- `list_articles()` flattens the API's section/sectionArticles nesting into a flat `list[Article]`.
- All errors funnel through one typed `ApiError`. Retry/rate-limit handling is deferred to #23.
- Tests use `httpx.MockTransport` with real-capture JSON fixtures (`tests/fixtures/api/`). 17 new tests covering construction, parsing, pagination boundary, HTTP error mapping for 4xx/5xx, transport errors, and a missing-text-format contract check.

Closes #18.

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 37/37 green on Python 3.12.13
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)