### PR TITLE
Add JSONL storage backend

### DIFF
--- a/src/concord/storage/__init__.py
+++ b/src/concord/storage/__init__.py
@@ -1,0 +1,11 @@
+"""Storage backends for Concord.
+
+The :class:`Storage` Protocol is the contract every backend implements.
+:class:`JsonlStorage` is the default — a single append-only ``.jsonl`` file
+with no infrastructure requirements.
+"""
+
+from .base import Storage
+from .jsonl import JsonlStorage
+
+__all__ = ["JsonlStorage", "Storage"]

--- a/src/concord/storage/base.py
+++ b/src/concord/storage/base.py
@@ -1,0 +1,30 @@
+"""Storage Protocol shared by every backend.
+
+A backend is anything that can answer ``has(granule_id)`` and accept
+``write(proceeding)``. Both methods are idempotent: re-writing a Proceeding
+that has already been stored is a no-op, so the orchestrator can loop blindly
+over articles without ever checking — though it's still expected to call
+``has`` first to skip the text-fetch HTTP for already-stored articles.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..models import Proceeding
+
+
+class Storage(Protocol):
+    """A persistence target for :class:`Proceeding` records.
+
+    Implementations must guarantee:
+
+    - ``has(granule_id)`` returns ``True`` if a Proceeding with that granule
+      ID has been written by this or any previous process, ``False`` otherwise.
+    - ``write(proceeding)`` persists the Proceeding. Writing a Proceeding
+      whose ``granule_id`` is already stored is a no-op (idempotent).
+    """
+
+    def has(self, granule_id: str) -> bool: ...
+
+    def write(self, proceeding: Proceeding) -> None: ...

--- a/src/concord/storage/jsonl.py
+++ b/src/concord/storage/jsonl.py
@@ -1,0 +1,80 @@
+"""JSONL file storage — the default backend.
+
+One Proceeding per line, serialized via :meth:`Proceeding.model_dump_json`.
+No external infrastructure required; the only state is a single file path.
+
+The class scans the file on construction to populate an in-memory set of
+already-stored ``granule_id``s. Lines that fail to parse (e.g. truncated
+writes from a previous crash) are skipped quietly rather than crashing the
+load — losing one record from a long backfill is better than losing the
+ability to resume the whole thing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..models import Proceeding
+
+
+class JsonlStorage:
+    """Append-only JSON-Lines storage for :class:`Proceeding` records.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path for the ``.jsonl`` file. Created lazily on first
+        write; missing parent directories are created automatically.
+    """
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+        self._seen: set[str] = self._load_seen_granule_ids()
+
+    # -- Storage Protocol -------------------------------------------------
+
+    def has(self, granule_id: str) -> bool:
+        return granule_id in self._seen
+
+    def write(self, proceeding: Proceeding) -> None:
+        if proceeding.granule_id in self._seen:
+            return  # idempotent: skip already-stored granule
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = proceeding.model_dump_json()
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+        self._seen.add(proceeding.granule_id)
+
+    # -- introspection ----------------------------------------------------
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def __len__(self) -> int:
+        """Number of distinct Proceedings currently stored."""
+        return len(self._seen)
+
+    # -- internals --------------------------------------------------------
+
+    def _load_seen_granule_ids(self) -> set[str]:
+        if not self._path.exists():
+            return set()
+        seen: set[str] = set()
+        with self._path.open("r", encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                    granule_id = record["granule_id"]
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    # Crashed-mid-write or otherwise unparseable; skip without
+                    # killing the whole load. The orchestrator will re-fetch
+                    # this article on the next run since `has` returns False.
+                    continue
+                if isinstance(granule_id, str):
+                    seen.add(granule_id)
+        return seen

--- a/tests/test_storage_jsonl.py
+++ b/tests/test_storage_jsonl.py
@@ -1,0 +1,198 @@
+"""Tests for the JSONL storage backend."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from concord.models import Article, Issue, Proceeding
+from concord.storage import JsonlStorage, Storage
+
+DEFAULT_GRANULE = "CREC-2026-05-22-pt1-PgD551-6"
+
+
+def _sample_proceeding(*, granule_id: str = DEFAULT_GRANULE, text: str = "body") -> Proceeding:
+    """Build a Proceeding whose URLs are derived from the granule ID.
+
+    The Article model verifies that the explicit granule_id matches the
+    granule embedded in both text_url and pdf_url, so the URLs have to be
+    constructed from the same granule ID.
+    """
+    text_url = f"https://www.congress.gov/119/crec/2026/05/22/172/88/modified/{granule_id}.htm"
+    pdf_url = f"https://www.congress.gov/119/crec/2026/05/22/172/88/{granule_id}.pdf"
+    issue = Issue(
+        issue_date="2026-05-22",
+        congress=119,
+        session=2,
+        volume=172,
+        issue_number=88,
+        update_date="2026-05-23T06:44:22Z",
+    )
+    article = Article(
+        section="Daily Digest",
+        title="Sample",
+        start_page="D551",
+        end_page="D552",
+        text_url=text_url,
+        pdf_url=pdf_url,
+        granule_id=granule_id,
+    )
+    return Proceeding.build(
+        issue=issue,
+        article=article,
+        text=text,
+        fetched_at=datetime(2026, 5, 24, tzinfo=UTC),
+    )
+
+
+# -- protocol conformance ------------------------------------------------------
+
+
+class TestProtocol:
+    def test_jsonl_storage_satisfies_storage_protocol(self, tmp_path: Path) -> None:
+        # This is a runtime check at instance level — Protocol with @runtime_checkable
+        # would be needed for isinstance(), but the type signature alone is what
+        # callers depend on. Keeping it as a structural assertion.
+        storage: Storage = JsonlStorage(tmp_path / "out.jsonl")
+        assert hasattr(storage, "has")
+        assert hasattr(storage, "write")
+
+
+# -- basic write / has ---------------------------------------------------------
+
+
+class TestWriteAndHas:
+    def test_has_returns_false_for_unseen(self, tmp_path: Path) -> None:
+        storage = JsonlStorage(tmp_path / "out.jsonl")
+        assert storage.has("CREC-never-seen") is False
+
+    def test_has_returns_true_after_write(self, tmp_path: Path) -> None:
+        storage = JsonlStorage(tmp_path / "out.jsonl")
+        p = _sample_proceeding()
+        storage.write(p)
+        assert storage.has(p.granule_id) is True
+
+    def test_write_creates_file_and_parents(self, tmp_path: Path) -> None:
+        path = tmp_path / "subdir/nested/out.jsonl"
+        storage = JsonlStorage(path)
+        storage.write(_sample_proceeding())
+        assert path.exists()
+        assert path.read_text().count("\n") == 1
+
+    def test_len_tracks_written_count(self, tmp_path: Path) -> None:
+        storage = JsonlStorage(tmp_path / "out.jsonl")
+        assert len(storage) == 0
+        storage.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-1"))
+        storage.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-2"))
+        assert len(storage) == 2
+
+
+# -- dedup --------------------------------------------------------------------
+
+
+class TestDedup:
+    def test_writing_same_granule_twice_is_noop(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.jsonl"
+        storage = JsonlStorage(path)
+        p = _sample_proceeding()
+        storage.write(p)
+        storage.write(p)  # idempotent
+        assert path.read_text().count("\n") == 1
+        assert len(storage) == 1
+
+    def test_dedup_persists_across_instances(self, tmp_path: Path) -> None:
+        """Re-opening the same file should rebuild the seen-set from disk.
+
+        This is the resume contract that #21 (orchestrator) depends on.
+        """
+        path = tmp_path / "out.jsonl"
+        first = JsonlStorage(path)
+        first.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-1"))
+        first.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-2"))
+
+        second = JsonlStorage(path)
+        assert second.has("CREC-2026-05-22-pt1-PgD551-1")
+        assert second.has("CREC-2026-05-22-pt1-PgD551-2")
+        assert not second.has("CREC-2026-05-22-pt1-PgD551-3")
+
+        # Writing an already-stored granule via the second instance is a no-op.
+        second.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-1"))
+        assert path.read_text().count("\n") == 2
+
+
+# -- round-trip integrity ------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_written_proceeding_can_be_read_back(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.jsonl"
+        original = _sample_proceeding(text="some content body")
+        JsonlStorage(path).write(original)
+
+        line = path.read_text().strip()
+        roundtripped = Proceeding.model_validate_json(line)
+        assert roundtripped == original
+
+
+# -- malformed-line recovery --------------------------------------------------
+
+
+class TestMalformedLineRecovery:
+    def test_partial_write_line_is_skipped(self, tmp_path: Path) -> None:
+        """A crash mid-write leaves a half-line; load shouldn't choke."""
+        path = tmp_path / "out.jsonl"
+        good = _sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-1")
+        another_good = _sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-2")
+        # Hand-author the file: one good line, then a truncated record, then
+        # another good line. Simulates a crash in the middle.
+        path.write_text(
+            good.model_dump_json()
+            + "\n"
+            + '{"granule_id": "CREC-truncated", "text": "oops no closing\n'  # partial JSON
+            + another_good.model_dump_json()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        storage = JsonlStorage(path)
+        assert storage.has(good.granule_id)
+        assert storage.has(another_good.granule_id)
+        # Truncated record didn't poison the load.
+        assert not storage.has("CREC-truncated")
+
+    def test_blank_lines_are_skipped(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.jsonl"
+        good = _sample_proceeding()
+        path.write_text("\n\n" + good.model_dump_json() + "\n\n", encoding="utf-8")
+        storage = JsonlStorage(path)
+        assert storage.has(good.granule_id)
+        assert len(storage) == 1
+
+    def test_missing_granule_id_field_is_skipped(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.jsonl"
+        # Valid JSON but missing the field we key on.
+        path.write_text('{"text": "no granule_id here"}\n', encoding="utf-8")
+        storage = JsonlStorage(path)
+        assert len(storage) == 0
+
+
+# -- empty / missing file ------------------------------------------------------
+
+
+class TestEmptyFile:
+    def test_missing_file_treated_as_empty(self, tmp_path: Path) -> None:
+        storage = JsonlStorage(tmp_path / "does-not-exist.jsonl")
+        assert len(storage) == 0
+        assert not storage.has("anything")
+
+    def test_existing_empty_file_treated_as_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.jsonl"
+        path.touch()
+        storage = JsonlStorage(path)
+        assert len(storage) == 0
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        """Convenience: pass a str instead of Path."""
+        storage = JsonlStorage(str(tmp_path / "out.jsonl"))
+        storage.write(_sample_proceeding())
+        assert len(storage) == 1


### PR DESCRIPTION
## Summary
- `src/concord/storage/base.py` defines the `Storage` Protocol: `has(granule_id) -> bool`, `write(proceeding) -> None`. Both idempotent.
- `src/concord/storage/jsonl.py` is the default backend: one Proceeding per line. On construction it scans the file to rebuild an in-memory granule-ID set so dedup persists across restarts (the resume contract for the orchestrator).
- Crash recovery: malformed lines (truncated writes, missing fields, junk) are silently skipped during load so a previous crash leaves at most one re-fetchable record, not a permanently broken state.
- 14 tests cover write/has, idempotent dedup within and across instances, JSON round-trip equality, partial-write recovery, blank lines, missing/empty files, and str-path acceptance.

Closes #20.

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 65/65 green on Python 3.12.13
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)