### PR TITLE
Add pipeline orchestrator

### DIFF
--- a/src/concord/pipeline.py
+++ b/src/concord/pipeline.py
@@ -1,0 +1,106 @@
+"""Pipeline orchestrator.
+
+The glue between the API client, the text fetcher, and storage. Given a date
+range, :func:`pull` produces one :class:`Proceeding` per article for every
+issue whose ``issue_date`` lies in ``[start, end]`` and writes the results
+through the supplied :class:`Storage` backend.
+
+Design notes
+------------
+
+* The ``/v3/daily-congressional-record`` list endpoint has **no date filter**,
+  and the API does not return results in strict ``issueDate`` order: recently
+  updated issues bubble to the top regardless of when they were originally
+  issued. (E.g., in the captured fixture, 2026-05-22 → 2026-05-20 → 2026-05-21.)
+  For correctness, :func:`pull` walks every page of the list endpoint rather
+  than trying to short-circuit on the first out-of-range date.
+* The walk uses the API's maximum page size to keep the metadata cost low: a
+  full 30-year backfill is ~24 list calls plus one ``/articles`` call per
+  issue, well under the 5000-requests/hour rate limit.
+* ``storage.has(granule_id)`` is consulted before each text fetch, so
+  re-running ``pull`` over an already-pulled range is a no-op (no HTTP for
+  the article text, no write). This is the resume contract the storage
+  backend in #20 was designed to provide.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, date, datetime
+
+from .api import Client
+from .models import Proceeding
+from .storage.base import Storage
+
+#: Per-page size when paginating ``list_issues``. The API caps at 250;
+#: using the max minimizes round trips on long-range pulls.
+LIST_PAGE_SIZE = 250
+
+
+def pull(
+    start: date,
+    end: date,
+    *,
+    client: Client,
+    fetch: Callable[[str], str],
+    storage: Storage,
+    limit: int | None = None,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> int:
+    """Pull every in-range article and persist it as a :class:`Proceeding`.
+
+    Parameters
+    ----------
+    start, end:
+        Inclusive date bounds. ``end >= start`` is the caller's responsibility;
+        if ``end < start`` the function returns 0 without making any API calls
+        that would produce work.
+    client:
+        Wired :class:`concord.api.Client`.
+    fetch:
+        Callable taking a Formatted Text URL and returning the plain text of
+        the article. Typically a closure over :func:`concord.text.fetch_text`
+        bound to an ``httpx.Client``.
+    storage:
+        Any :class:`Storage` implementation. ``has`` is checked before every
+        article to skip already-stored work; ``write`` is called for each new
+        :class:`Proceeding`.
+    limit:
+        Cap on total writes. ``None`` (the default) means unlimited. Useful
+        for smoke tests and dry runs.
+    now:
+        Injection point for ``datetime.now(UTC)`` used to stamp
+        ``fetched_at``. Lets tests assert exact timestamps.
+
+    Returns
+    -------
+    int
+        The number of *new* :class:`Proceeding` records written.
+    """
+    if end < start:
+        return 0
+
+    written = 0
+    offset = 0
+    while True:
+        issues, next_offset = client.list_issues(limit=LIST_PAGE_SIZE, offset=offset)
+        for issue in issues:
+            if not (start <= issue.issue_date <= end):
+                continue
+            for article in client.list_articles(issue.volume, issue.issue_number):
+                if storage.has(article.granule_id):
+                    continue
+                text = fetch(str(article.text_url))
+                proceeding = Proceeding.build(
+                    issue=issue,
+                    article=article,
+                    text=text,
+                    fetched_at=now(),
+                )
+                storage.write(proceeding)
+                written += 1
+                if limit is not None and written >= limit:
+                    return written
+        if next_offset is None:
+            return written
+        offset = next_offset

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,363 @@
+"""Tests for the pipeline orchestrator.
+
+A mix of fast unit tests (with stub fetch + in-memory storage) and one
+integration test that wires the real API client, real text fetcher, and
+JsonlStorage together via httpx.MockTransport, using the JSON and HTML
+fixtures captured for #18 and #19.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import httpx
+import pytest
+
+from concord.api import Client
+from concord.models import Article, Issue, Proceeding
+from concord.pipeline import pull
+from concord.storage import JsonlStorage
+from concord.text import fetch_text
+
+FIXED_NOW = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
+
+
+def _now() -> datetime:
+    return FIXED_NOW
+
+
+# ---------------------------------------------------------------------------
+# Fakes for the unit-style tests. Keep them dependency-free: an in-memory
+# storage and a stubbed Client subclass that returns whatever lists you set.
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryStorage:
+    def __init__(self) -> None:
+        self.writes: list[Proceeding] = []
+        self._seen: set[str] = set()
+
+    def has(self, granule_id: str) -> bool:
+        return granule_id in self._seen
+
+    def write(self, proceeding: Proceeding) -> None:
+        if proceeding.granule_id in self._seen:
+            return
+        self.writes.append(proceeding)
+        self._seen.add(proceeding.granule_id)
+
+
+class _StubClient:
+    """Minimal Client substitute: hand-feed pages and per-issue article lists."""
+
+    def __init__(
+        self,
+        *,
+        pages: list[list[Issue]],
+        articles_by_issue: dict[tuple[int, int], list[Article]],
+    ) -> None:
+        self._pages = pages
+        self._articles = articles_by_issue
+        self.list_issues_calls: list[tuple[int, int]] = []
+        self.list_articles_calls: list[tuple[int, int]] = []
+
+    def list_issues(self, *, limit: int = 50, offset: int = 0) -> tuple[list[Issue], int | None]:
+        self.list_issues_calls.append((limit, offset))
+        page_idx = offset // limit if limit else 0
+        if page_idx >= len(self._pages):
+            return [], None
+        next_offset = offset + limit if page_idx + 1 < len(self._pages) else None
+        return self._pages[page_idx], next_offset
+
+    def list_articles(self, volume: int, issue_number: int) -> list[Article]:
+        self.list_articles_calls.append((volume, issue_number))
+        return self._articles.get((volume, issue_number), [])
+
+
+def _issue(issue_date: str, *, volume: int = 172, issue_number: int = 1) -> Issue:
+    return Issue(
+        issue_date=issue_date,
+        congress=119,
+        session=2,
+        volume=volume,
+        issue_number=issue_number,
+        update_date="2026-05-23T06:44:22Z",
+    )
+
+
+def _article(granule_id: str) -> Article:
+    text_url = f"https://www.congress.gov/119/crec/2026/05/22/172/88/modified/{granule_id}.htm"
+    pdf_url = f"https://www.congress.gov/119/crec/2026/05/22/172/88/{granule_id}.pdf"
+    return Article(
+        section="Daily Digest",
+        title="t",
+        start_page="D1",
+        end_page="D1",
+        text_url=text_url,
+        pdf_url=pdf_url,
+        granule_id=granule_id,
+    )
+
+
+def _stub_fetch(_url: str) -> str:
+    return "fetched body"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRangeFiltering:
+    def test_empty_range_returns_zero(self) -> None:
+        client = _StubClient(pages=[], articles_by_issue={})
+        storage = _InMemoryStorage()
+        n = pull(
+            date(2026, 5, 1),
+            date(2026, 4, 30),  # end < start
+            client=client,  # type: ignore[arg-type]
+            fetch=_stub_fetch,
+            storage=storage,
+            now=_now,
+        )
+        assert n == 0
+        # No API calls were made — the range was empty.
+        assert client.list_issues_calls == []
+
+    def test_in_range_issue_is_processed(self) -> None:
+        issue = _issue("2026-05-22", volume=172, issue_number=88)
+        articles = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(3)]
+        client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})
+        storage = _InMemoryStorage()
+        n = pull(
+            date(2026, 5, 22),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=_stub_fetch,
+            storage=storage,
+            now=_now,
+        )
+        assert n == 3
+        assert len(storage.writes) == 3
+        # fetched_at is stamped from the injected clock.
+        assert all(p.fetched_at == FIXED_NOW for p in storage.writes)
+        # The issue's article endpoint was hit exactly once.
+        assert client.list_articles_calls == [(172, 88)]
+
+    def test_out_of_range_issues_skip_article_fetch(self) -> None:
+        # Two issues in the page: one in range, one out. Only the in-range
+        # one should trigger list_articles.
+        in_range = _issue("2026-05-22", issue_number=88)
+        too_old = _issue("2026-05-01", issue_number=80)
+        client = _StubClient(
+            pages=[[in_range, too_old]],
+            articles_by_issue={(172, 88): [_article("CREC-2026-05-22-pt1-PgS0001")]},
+        )
+        storage = _InMemoryStorage()
+        pull(
+            date(2026, 5, 15),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=_stub_fetch,
+            storage=storage,
+            now=_now,
+        )
+        # Article endpoint hit only for the in-range issue.
+        assert client.list_articles_calls == [(172, 88)]
+
+
+class TestDedup:
+    def test_skips_already_stored_articles(self) -> None:
+        issue = _issue("2026-05-22", issue_number=88)
+        articles = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(3)]
+        client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})
+
+        storage = _InMemoryStorage()
+        # Pre-seed one of the granule IDs as already stored.
+        storage._seen.add(articles[1].granule_id)
+
+        fetch_calls: list[str] = []
+
+        def tracking_fetch(url: str) -> str:
+            fetch_calls.append(url)
+            return "body"
+
+        n = pull(
+            date(2026, 5, 22),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=tracking_fetch,
+            storage=storage,
+            now=_now,
+        )
+        # Two new writes, one skip.
+        assert n == 2
+        # fetch was NOT called for the already-stored article.
+        assert len(fetch_calls) == 2
+        assert articles[1].text_url not in [httpx.URL(u) for u in fetch_calls]
+
+
+class TestLimit:
+    def test_limit_caps_writes(self) -> None:
+        issue = _issue("2026-05-22", issue_number=88)
+        articles = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(10)]
+        client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})
+        storage = _InMemoryStorage()
+
+        n = pull(
+            date(2026, 5, 22),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=_stub_fetch,
+            storage=storage,
+            limit=4,
+            now=_now,
+        )
+        assert n == 4
+        assert len(storage.writes) == 4
+
+
+class TestPagination:
+    def test_walks_all_pages(self) -> None:
+        """Issues are not strictly date-ordered (recent updates bubble up),
+        so the orchestrator must walk every page — early termination on the
+        first older date would silently drop later-page in-range issues.
+        """
+        # Page 1: one in-range. Page 2: another in-range that comes "after"
+        # in pagination but is also in the target window.
+        page1 = [_issue("2026-05-22", issue_number=88)]
+        page2 = [_issue("2026-05-21", issue_number=87)]
+        articles_88 = [_article("CREC-2026-05-22-pt1-PgS0001")]
+        articles_87 = [_article("CREC-2026-05-21-pt1-PgS0001")]
+        client = _StubClient(
+            pages=[page1, page2],
+            articles_by_issue={(172, 88): articles_88, (172, 87): articles_87},
+        )
+        storage = _InMemoryStorage()
+        n = pull(
+            date(2026, 5, 21),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=_stub_fetch,
+            storage=storage,
+            now=_now,
+        )
+        assert n == 2
+        # Both pages were requested.
+        assert len(client.list_issues_calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+
+def _api_mock_handler(fixtures_dir: Path) -> Callable[[httpx.Request], httpx.Response]:
+    """Route real api.congress.gov paths to recorded fixtures."""
+    list_payload = json.loads((fixtures_dir / "api/list_issues_page1.json").read_text())
+    articles_payload = json.loads((fixtures_dir / "api/articles_172_88.json").read_text())
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/v3/daily-congressional-record":
+            # Modify fixture to claim no next page (we only have one page of
+            # fixture data; the orchestrator should stop after this).
+            modified = {
+                **list_payload,
+                "pagination": {"count": list_payload["pagination"]["count"]},
+            }
+            return httpx.Response(200, json=modified)
+        if path.endswith("/articles"):
+            return httpx.Response(200, json=articles_payload)
+        return httpx.Response(404)
+
+    return handler
+
+
+def _text_mock_handler() -> Callable[[httpx.Request], httpx.Response]:
+    """Serve a generic Congressional Record HTML body for any article URL."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text="<pre>\n\n[Body]\nIntegration test fixture text.\n\n</pre>",
+            headers={"content-type": "text/html"},
+        )
+
+    return handler
+
+
+@pytest.fixture
+def wired_components(
+    fixtures_dir: Path, tmp_path: Path
+) -> tuple[Client, Callable[[str], str], JsonlStorage]:
+    """Build real Client + real text fetcher + JsonlStorage, all wired to mocks."""
+    api_transport = httpx.MockTransport(_api_mock_handler(fixtures_dir))
+    text_transport = httpx.MockTransport(_text_mock_handler())
+    text_http = httpx.Client(transport=text_transport)
+    client = Client(api_key="test", transport=api_transport)
+    storage = JsonlStorage(tmp_path / "out.jsonl")
+    return client, lambda url: fetch_text(url, text_http), storage
+
+
+class TestIntegration:
+    def test_end_to_end_one_day(
+        self, wired_components: tuple[Client, Callable[[str], str], JsonlStorage]
+    ) -> None:
+        client, fetch, storage = wired_components
+        with client:
+            n = pull(
+                date(2026, 5, 22),
+                date(2026, 5, 22),
+                client=client,
+                fetch=fetch,
+                storage=storage,
+                now=_now,
+            )
+
+        # The articles fixture has 6 + 3 + 11 = 20 articles.
+        assert n == 20
+        assert len(storage) == 20
+
+        # Every line on disk parses back into a Proceeding.
+        lines = storage.path.read_text().strip().splitlines()
+        assert len(lines) == 20
+        proceedings = [Proceeding.model_validate_json(line) for line in lines]
+
+        # All proceedings carry the issue metadata from issue 172/88.
+        assert all(p.volume == 172 for p in proceedings)
+        assert all(p.issue_number == 88 for p in proceedings)
+        assert all(p.issue_date == date(2026, 5, 22) for p in proceedings)
+        # All carry the fetched text body.
+        assert all("Integration test fixture text." in p.text for p in proceedings)
+        # All carry the injected timestamp.
+        assert all(p.fetched_at == FIXED_NOW for p in proceedings)
+
+    def test_re_running_is_idempotent(
+        self, wired_components: tuple[Client, Callable[[str], str], JsonlStorage]
+    ) -> None:
+        client, fetch, storage = wired_components
+        with client:
+            first = pull(
+                date(2026, 5, 22),
+                date(2026, 5, 22),
+                client=client,
+                fetch=fetch,
+                storage=storage,
+                now=_now,
+            )
+            second = pull(
+                date(2026, 5, 22),
+                date(2026, 5, 22),
+                client=client,
+                fetch=fetch,
+                storage=storage,
+                now=_now,
+            )
+        assert first == 20
+        assert second == 0  # Everything already stored.
+        # File has exactly 20 lines, not 40.
+        assert len(storage.path.read_text().strip().splitlines()) == 20


### PR DESCRIPTION
## Summary
- `src/concord/pipeline.py` with `pull(start, end, *, client, fetch, storage, limit, now) -> int`.
- For each in-range issue: list articles → skip if `storage.has(granule_id)` → fetch text → build `Proceeding` → write.
- **Important discovery**: the API does *not* return list results in strict `issueDate` order — recently updated issues bubble to the top (see the fixture: 2026-05-22 → 2026-05-20 → 2026-05-21). The orchestrator walks every page rather than early-stopping on first older date. Uses `limit=250` (API max) so a 30-year backfill is ~24 metadata calls.
- `now: Callable[[], datetime]` is injected so tests can assert exact `fetched_at` timestamps.
- 8 new tests including an integration test that wires the real `Client` + real `fetch_text` + `JsonlStorage` together via `httpx.MockTransport` and the recorded fixtures from #18/#19, asserting 20 proceedings on disk for issue 172/88 and 0 on re-run.

Closes #21.

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 73/73 green on Python 3.12.13
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)