### PR TITLE
Add concord CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,11 @@ authors = [{ name = "John Campbell" }]
 dependencies = [
     "httpx>=0.28.1",
     "pydantic>=2.13.4",
+    "typer>=0.25.1",
 ]
+
+[project.scripts]
+concord = "concord.cli:main"
 
 [dependency-groups]
 dev = [

--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -1,0 +1,119 @@
+"""Command-line interface for Concord.
+
+One command today — ``concord pull`` — that wires the API client, text
+fetcher, and JSONL storage together for a given inclusive date range.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Annotated
+
+import httpx
+import typer
+
+from .api import ENV_API_KEY, ApiError, Client
+from .pipeline import pull
+from .storage import JsonlStorage
+from .text import fetch_text
+
+app = typer.Typer(
+    no_args_is_help=True,
+    add_completion=False,
+    help="Pull Congressional Record articles from api.congress.gov.",
+)
+
+
+@app.callback()
+def _root() -> None:
+    """Concord — Congressional Record collection pipeline.
+
+    The empty callback exists so Typer treats this as a multi-command app
+    (with ``pull`` as a real subcommand) rather than collapsing the lone
+    command into the root.
+    """
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise typer.BadParameter(f"expected YYYY-MM-DD, got {value!r}") from exc
+
+
+@app.command("pull")
+def pull_command(
+    from_: Annotated[
+        str,
+        typer.Option(
+            "--from",
+            help="Start date YYYY-MM-DD (inclusive).",
+            show_default=False,
+        ),
+    ],
+    to: Annotated[
+        str,
+        typer.Option(
+            "--to",
+            help="End date YYYY-MM-DD (inclusive).",
+            show_default=False,
+        ),
+    ],
+    storage_path: Annotated[
+        Path,
+        typer.Option(
+            "--storage",
+            help="JSONL output file. Created if missing.",
+        ),
+    ] = Path("./proceedings.jsonl"),
+    limit: Annotated[
+        int | None,
+        typer.Option(
+            "--limit",
+            help="Maximum number of new proceedings to write.",
+        ),
+    ] = None,
+) -> None:
+    """Pull every article in every issue between --from and --to (inclusive)."""
+    start = _parse_date(from_)
+    end = _parse_date(to)
+
+    try:
+        api_client = Client()  # reads CONGRESS_API_KEY from env
+    except ApiError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    storage = JsonlStorage(storage_path)
+    http_client = httpx.Client()
+
+    try:
+        with api_client:
+            result = pull(
+                start,
+                end,
+                client=api_client,
+                fetch=lambda url: fetch_text(url, http_client),
+                storage=storage,
+                limit=limit,
+            )
+    finally:
+        http_client.close()
+
+    typer.echo(
+        f"Wrote {result.written} new proceedings to {storage_path} "
+        f"(skipped {result.skipped} already present)"
+    )
+
+
+def main() -> None:  # pragma: no cover - entry point shim
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+
+
+# re-export for any callers who want to introspect the env-var name
+__all__ = ["ENV_API_KEY", "app", "main", "pull_command"]

--- a/src/concord/pipeline.py
+++ b/src/concord/pipeline.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import UTC, date, datetime
+from typing import NamedTuple
 
 from .api import Client
 from .models import Proceeding
@@ -35,6 +36,19 @@ from .storage.base import Storage
 #: Per-page size when paginating ``list_issues``. The API caps at 250;
 #: using the max minimizes round trips on long-range pulls.
 LIST_PAGE_SIZE = 250
+
+
+class PullResult(NamedTuple):
+    """Outcome of a single :func:`pull` invocation.
+
+    ``written`` is the count of new :class:`Proceeding` records persisted to
+    storage during this call. ``skipped`` is the count of articles that were
+    already present in storage (matched by ``granule_id``) and whose text
+    fetch was therefore avoided.
+    """
+
+    written: int
+    skipped: int
 
 
 def pull(
@@ -46,15 +60,15 @@ def pull(
     storage: Storage,
     limit: int | None = None,
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
-) -> int:
+) -> PullResult:
     """Pull every in-range article and persist it as a :class:`Proceeding`.
 
     Parameters
     ----------
     start, end:
         Inclusive date bounds. ``end >= start`` is the caller's responsibility;
-        if ``end < start`` the function returns 0 without making any API calls
-        that would produce work.
+        if ``end < start`` the function returns ``PullResult(0, 0)`` without
+        making any API calls.
     client:
         Wired :class:`concord.api.Client`.
     fetch:
@@ -74,13 +88,14 @@ def pull(
 
     Returns
     -------
-    int
-        The number of *new* :class:`Proceeding` records written.
+    PullResult
+        ``(written, skipped)`` counts for this call.
     """
     if end < start:
-        return 0
+        return PullResult(written=0, skipped=0)
 
     written = 0
+    skipped = 0
     offset = 0
     while True:
         issues, next_offset = client.list_issues(limit=LIST_PAGE_SIZE, offset=offset)
@@ -89,6 +104,7 @@ def pull(
                 continue
             for article in client.list_articles(issue.volume, issue.issue_number):
                 if storage.has(article.granule_id):
+                    skipped += 1
                     continue
                 text = fetch(str(article.text_url))
                 proceeding = Proceeding.build(
@@ -100,7 +116,7 @@ def pull(
                 storage.write(proceeding)
                 written += 1
                 if limit is not None and written >= limit:
-                    return written
+                    return PullResult(written=written, skipped=skipped)
         if next_offset is None:
-            return written
+            return PullResult(written=written, skipped=skipped)
         offset = next_offset

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ the CLI does the right thing around it.
 
 from __future__ import annotations
 
+import re
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,17 @@ from typer.testing import CliRunner
 import concord.cli as cli_module
 from concord.api import ENV_API_KEY, ApiError
 from concord.pipeline import PullResult
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(text: str) -> str:
+    """Drop ANSI color/style escapes so assertions don't depend on the terminal.
+
+    Locally, CliRunner produces plain text; on CI runners Rich detects color
+    support and injects escapes that break naive substring checks.
+    """
+    return _ANSI.sub("", text)
 
 
 @pytest.fixture
@@ -51,8 +63,9 @@ class TestHelp:
         result = runner.invoke(cli_module.app, ["pull", "--help"])
         assert result.exit_code == 0
         # All four flags must appear in --help.
+        plain = _strip(result.output)
         for flag in ["--from", "--to", "--storage", "--limit"]:
-            assert flag in result.output
+            assert flag in plain
 
 
 class TestArgParsing:
@@ -121,7 +134,7 @@ class TestArgParsing:
         )
         assert result.exit_code == 0, result.output
         # Default path is ./proceedings.jsonl
-        assert "proceedings.jsonl" in result.output
+        assert "proceedings.jsonl" in _strip(result.output)
 
     @pytest.mark.parametrize("bad_date", ["yesterday", "05/22/2026", "2026-13-01"])
     def test_pull_rejects_bad_date(
@@ -166,9 +179,10 @@ class TestSuccessOutput:
         )
         assert result.exit_code == 0, result.output
         # PullResult(written=3, skipped=1) from the stub.
-        assert "Wrote 3 new proceedings" in result.output
-        assert str(out_path) in result.output
-        assert "skipped 1" in result.output
+        plain = _strip(result.output)
+        assert "Wrote 3 new proceedings" in plain
+        assert str(out_path) in plain
+        assert "skipped 1" in plain
 
 
 # -- missing API key ---------------------------------------------------------
@@ -198,10 +212,11 @@ class TestMissingApiKey:
         )
         # Non-zero exit, error message on stderr, no traceback.
         assert result.exit_code == 2
+        plain = _strip(result.output) + _strip(result.stderr or "")
         # The error message mentions the env var so the user knows what to set.
-        assert ENV_API_KEY in result.output or ENV_API_KEY in (result.stderr or "")
+        assert ENV_API_KEY in plain
         # Ensure we don't accidentally let an unhandled exception through.
-        assert "Traceback" not in result.output
+        assert "Traceback" not in plain
 
     def test_apierror_during_client_init_surfaces_as_exit_code_2(
         self,
@@ -229,4 +244,4 @@ class TestMissingApiKey:
             ],
         )
         assert result.exit_code == 2
-        assert "simulated init failure" in result.output
+        assert "simulated init failure" in _strip(result.output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,232 @@
+"""Tests for the ``concord`` CLI.
+
+The CLI's responsibilities are: parse flags, surface clear errors on missing
+API key, wire the pipeline, and format the success summary. The orchestrator
+itself is covered by tests/test_pipeline.py — here we stub it out and verify
+the CLI does the right thing around it.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+import concord.cli as cli_module
+from concord.api import ENV_API_KEY, ApiError
+from concord.pipeline import PullResult
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_API_KEY, "test-key")
+
+
+@pytest.fixture
+def stub_pull(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace ``concord.cli.pull`` with a recorder; return the call log."""
+    calls: list[dict[str, Any]] = []
+
+    def fake_pull(start: date, end: date, **kwargs: Any) -> PullResult:
+        calls.append({"start": start, "end": end, **kwargs})
+        return PullResult(written=3, skipped=1)
+
+    monkeypatch.setattr(cli_module, "pull", fake_pull)
+    return calls
+
+
+# -- help & arg parsing -------------------------------------------------------
+
+
+class TestHelp:
+    def test_help_lists_all_flags(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli_module.app, ["pull", "--help"])
+        assert result.exit_code == 0
+        # All four flags must appear in --help.
+        for flag in ["--from", "--to", "--storage", "--limit"]:
+            assert flag in result.output
+
+
+class TestArgParsing:
+    def test_pull_parses_dates(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        stub_pull: list[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "pull",
+                "--from",
+                "2026-05-22",
+                "--to",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert len(stub_pull) == 1
+        call = stub_pull[0]
+        assert call["start"] == date(2026, 5, 22)
+        assert call["end"] == date(2026, 5, 22)
+
+    def test_pull_passes_limit(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        stub_pull: list[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "pull",
+                "--from",
+                "2026-05-01",
+                "--to",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+                "--limit",
+                "5",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert stub_pull[0]["limit"] == 5
+
+    def test_pull_default_storage_path(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        stub_pull: list[dict[str, Any]],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Run with no --storage flag; default should land in CWD.
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            cli_module.app,
+            ["pull", "--from", "2026-05-22", "--to", "2026-05-22"],
+        )
+        assert result.exit_code == 0, result.output
+        # Default path is ./proceedings.jsonl
+        assert "proceedings.jsonl" in result.output
+
+    @pytest.mark.parametrize("bad_date", ["yesterday", "05/22/2026", "2026-13-01"])
+    def test_pull_rejects_bad_date(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        stub_pull: list[dict[str, Any]],
+        bad_date: str,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            ["pull", "--from", bad_date, "--to", "2026-05-22"],
+        )
+        assert result.exit_code != 0
+        # stub_pull should not have been called.
+        assert len(stub_pull) == 0
+
+
+# -- success summary ---------------------------------------------------------
+
+
+class TestSuccessOutput:
+    def test_prints_written_and_skipped_counts(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        stub_pull: list[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        out_path = tmp_path / "out.jsonl"
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "pull",
+                "--from",
+                "2026-05-22",
+                "--to",
+                "2026-05-22",
+                "--storage",
+                str(out_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # PullResult(written=3, skipped=1) from the stub.
+        assert "Wrote 3 new proceedings" in result.output
+        assert str(out_path) in result.output
+        assert "skipped 1" in result.output
+
+
+# -- missing API key ---------------------------------------------------------
+
+
+class TestMissingApiKey:
+    def test_missing_key_exits_cleanly(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        # Ensure no key in env.
+        monkeypatch.delenv(ENV_API_KEY, raising=False)
+
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "pull",
+                "--from",
+                "2026-05-22",
+                "--to",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+            ],
+        )
+        # Non-zero exit, error message on stderr, no traceback.
+        assert result.exit_code == 2
+        # The error message mentions the env var so the user knows what to set.
+        assert ENV_API_KEY in result.output or ENV_API_KEY in (result.stderr or "")
+        # Ensure we don't accidentally let an unhandled exception through.
+        assert "Traceback" not in result.output
+
+    def test_apierror_during_client_init_surfaces_as_exit_code_2(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Even if Client() raises ApiError for some other reason, exit 2."""
+        monkeypatch.setenv(ENV_API_KEY, "test")
+
+        def boom(**_: Any) -> Any:
+            raise ApiError("simulated init failure")
+
+        monkeypatch.setattr(cli_module, "Client", boom)
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "pull",
+                "--from",
+                "2026-05-22",
+                "--to",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+            ],
+        )
+        assert result.exit_code == 2
+        assert "simulated init failure" in result.output

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -115,7 +115,7 @@ class TestRangeFiltering:
     def test_empty_range_returns_zero(self) -> None:
         client = _StubClient(pages=[], articles_by_issue={})
         storage = _InMemoryStorage()
-        n = pull(
+        result = pull(
             date(2026, 5, 1),
             date(2026, 4, 30),  # end < start
             client=client,  # type: ignore[arg-type]
@@ -123,7 +123,7 @@ class TestRangeFiltering:
             storage=storage,
             now=_now,
         )
-        assert n == 0
+        assert result.written == 0
         # No API calls were made — the range was empty.
         assert client.list_issues_calls == []
 
@@ -132,7 +132,7 @@ class TestRangeFiltering:
         articles = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(3)]
         client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})
         storage = _InMemoryStorage()
-        n = pull(
+        result = pull(
             date(2026, 5, 22),
             date(2026, 5, 22),
             client=client,  # type: ignore[arg-type]
@@ -140,7 +140,7 @@ class TestRangeFiltering:
             storage=storage,
             now=_now,
         )
-        assert n == 3
+        assert result.written == 3
         assert len(storage.writes) == 3
         # fetched_at is stamped from the injected clock.
         assert all(p.fetched_at == FIXED_NOW for p in storage.writes)
@@ -185,7 +185,7 @@ class TestDedup:
             fetch_calls.append(url)
             return "body"
 
-        n = pull(
+        result = pull(
             date(2026, 5, 22),
             date(2026, 5, 22),
             client=client,  # type: ignore[arg-type]
@@ -194,7 +194,8 @@ class TestDedup:
             now=_now,
         )
         # Two new writes, one skip.
-        assert n == 2
+        assert result.written == 2
+        assert result.skipped == 1
         # fetch was NOT called for the already-stored article.
         assert len(fetch_calls) == 2
         assert articles[1].text_url not in [httpx.URL(u) for u in fetch_calls]
@@ -207,7 +208,7 @@ class TestLimit:
         client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})
         storage = _InMemoryStorage()
 
-        n = pull(
+        result = pull(
             date(2026, 5, 22),
             date(2026, 5, 22),
             client=client,  # type: ignore[arg-type]
@@ -216,7 +217,7 @@ class TestLimit:
             limit=4,
             now=_now,
         )
-        assert n == 4
+        assert result.written == 4
         assert len(storage.writes) == 4
 
 
@@ -237,7 +238,7 @@ class TestPagination:
             articles_by_issue={(172, 88): articles_88, (172, 87): articles_87},
         )
         storage = _InMemoryStorage()
-        n = pull(
+        result = pull(
             date(2026, 5, 21),
             date(2026, 5, 22),
             client=client,  # type: ignore[arg-type]
@@ -245,7 +246,7 @@ class TestPagination:
             storage=storage,
             now=_now,
         )
-        assert n == 2
+        assert result.written == 2
         # Both pages were requested.
         assert len(client.list_issues_calls) == 2
 
@@ -309,7 +310,7 @@ class TestIntegration:
     ) -> None:
         client, fetch, storage = wired_components
         with client:
-            n = pull(
+            result = pull(
                 date(2026, 5, 22),
                 date(2026, 5, 22),
                 client=client,
@@ -319,7 +320,8 @@ class TestIntegration:
             )
 
         # The articles fixture has 6 + 3 + 11 = 20 articles.
-        assert n == 20
+        assert result.written == 20
+        assert result.skipped == 0
         assert len(storage) == 20
 
         # Every line on disk parses back into a Proceeding.
@@ -357,7 +359,9 @@ class TestIntegration:
                 storage=storage,
                 now=_now,
             )
-        assert first == 20
-        assert second == 0  # Everything already stored.
+        assert first.written == 20
+        assert first.skipped == 0
+        assert second.written == 0  # Everything already stored.
+        assert second.skipped == 20  # ...and all of them counted as skipped.
         # File has exactly 20 lines, not 40.
         assert len(storage.path.read_text().strip().splitlines()) == 20

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -78,6 +87,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -93,6 +114,7 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -106,6 +128,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.13.4" },
+    { name = "typer", specifier = ">=0.25.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -228,6 +251,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
     { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
     { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -426,6 +470,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.14"
 source = { registry = "https://pypi.org/simple" }
@@ -448,6 +505,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
     { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `concord pull --from YYYY-MM-DD --to YYYY-MM-DD [--storage PATH] [--limit N]` — the top-level entry point.
- API key from `CONGRESS_API_KEY`. Missing key exits 2 with a clear message naming the env var (no traceback).
- Success summary: `Wrote N new proceedings to PATH (skipped M already present)`.
- Empty `@app.callback()` keeps Typer in multi-command mode (otherwise it collapses single-command apps and ambiguates `concord pull --from ...`).
- Extends `pipeline.pull` to return a `PullResult` NamedTuple with both `written` and `skipped` counts (previously just `int`); existing pipeline tests updated.
- Entry point in `[project.scripts]` so `uv run concord pull ...` works.
- 10 new CLI tests via `typer.testing.CliRunner`.

Closes #22.

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 83/83 green on Python 3.12.13
- [x] `uv run concord pull --help` renders cleanly
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)