### PR TITLE
Add retry + rate-limit handling to API client

### DIFF
--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -4,14 +4,29 @@ All HTTP and JSON-parsing concerns live here. Callers receive validated
 Pydantic models (:class:`Issue`, :class:`Article`) and never touch the
 raw camelCase payload shape.
 
-Rate-limit and retry handling are intentionally absent — they land in #23
-once the client is in use. Today, transient failures surface as
-:class:`ApiError`.
+Retry policy
+------------
+
+Transient failures are retried automatically:
+
+* HTTP 429 ("Too Many Requests"): retry **indefinitely**, respecting any
+  ``Retry-After`` header and otherwise backing off exponentially capped at
+  :data:`MAX_BACKOFF`. Rate-limited is not broken — we wait.
+* HTTP 5xx, connection errors, read/write/connect timeouts: retry up to
+  :data:`MAX_5XX_RETRIES` times with exponential backoff. After that, the
+  failure surfaces as an :class:`ApiError`.
+
+Every retry decision is logged to ``stderr`` via :mod:`logging` (logger
+``concord.api``) at WARNING level so multi-hour pulls have a visible
+heartbeat.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import time
+from collections.abc import Callable
 from types import TracebackType
 from typing import Any
 
@@ -23,6 +38,20 @@ from .models import Article, Issue
 API_BASE = "https://api.congress.gov/v3"
 USER_AGENT = f"concord/{__version__} (+https://github.com/johnmarcampbell/concord)"
 ENV_API_KEY = "CONGRESS_API_KEY"
+
+#: Cap on a single backoff delay, in seconds. Applied to both the exponential
+#: schedule and Retry-After values so a server-suggested 1-hour wait can't
+#: silently stall the pipeline.
+MAX_BACKOFF = 60.0
+
+#: Maximum retries for transient 5xx / transport failures before surfacing
+#: an :class:`ApiError`. 429s are retried indefinitely separately.
+MAX_5XX_RETRIES = 5
+
+#: Exponential schedule for transient backoff: 1s, 2s, 4s, 8s, 16s (capped).
+_BACKOFF_BASE = 2.0
+
+_log = logging.getLogger("concord.api")
 
 
 class ApiError(Exception):
@@ -55,11 +84,13 @@ class Client:
         api_key: str | None = None,
         transport: httpx.BaseTransport | None = None,
         timeout: float = 30.0,
+        sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         resolved = api_key if api_key is not None else os.environ.get(ENV_API_KEY)
         if not resolved:
             raise ApiError(f"API key required: pass api_key=... or set {ENV_API_KEY}")
         self._api_key = resolved
+        self._sleep = sleep
         self._client = httpx.Client(
             base_url=API_BASE,
             transport=transport,
@@ -133,20 +164,92 @@ class Client:
         merged: dict[str, Any] = {"format": "json", "api_key": self._api_key}
         if params:
             merged.update(params)
-        try:
-            response = self._client.get(path, params=merged)
-            response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            raise ApiError(
-                f"{exc.response.status_code} {exc.response.reason_phrase} from {path}",
-                status_code=exc.response.status_code,
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise ApiError(f"transport error calling {path}: {exc}") from exc
-        data: Any = response.json()
-        if not isinstance(data, dict):
-            raise ApiError(f"expected JSON object from {path}, got {type(data).__name__}")
-        return data
+
+        transient_attempts = 0
+        while True:
+            try:
+                response = self._client.get(path, params=merged)
+            except httpx.HTTPError as exc:
+                # Transport-level failure (DNS, timeout, connection reset).
+                # Treat as a retryable transient.
+                if transient_attempts >= MAX_5XX_RETRIES:
+                    raise ApiError(
+                        f"transport error calling {path} "
+                        f"(gave up after {MAX_5XX_RETRIES} attempts): {exc}"
+                    ) from exc
+                delay = _backoff_seconds(transient_attempts)
+                _log.warning("transport error on %s (%s); retrying in %.1fs", path, exc, delay)
+                self._sleep(delay)
+                transient_attempts += 1
+                continue
+
+            status = response.status_code
+
+            if status == 429:
+                delay = _retry_after_seconds(response) or _backoff_seconds(transient_attempts)
+                _log.warning("429 from %s; backing off %.1fs before retry", path, delay)
+                self._sleep(delay)
+                # 429 retries do not increment transient_attempts — rate-limited
+                # is a wait condition, not a fault. We could be 429'd for hours.
+                continue
+
+            if 500 <= status < 600:
+                if transient_attempts >= MAX_5XX_RETRIES:
+                    raise ApiError(
+                        f"{status} {response.reason_phrase} from {path} "
+                        f"(gave up after {MAX_5XX_RETRIES} attempts)",
+                        status_code=status,
+                    )
+                delay = _backoff_seconds(transient_attempts)
+                _log.warning(
+                    "%s from %s; retrying in %.1fs (attempt %d/%d)",
+                    status,
+                    path,
+                    delay,
+                    transient_attempts + 1,
+                    MAX_5XX_RETRIES,
+                )
+                self._sleep(delay)
+                transient_attempts += 1
+                continue
+
+            if not response.is_success:
+                # Non-retryable client error (4xx other than 429): surface immediately.
+                raise ApiError(
+                    f"{status} {response.reason_phrase} from {path}",
+                    status_code=status,
+                )
+
+            data: Any = response.json()
+            if not isinstance(data, dict):
+                raise ApiError(f"expected JSON object from {path}, got {type(data).__name__}")
+            return data
+
+
+# -- retry helpers ----------------------------------------------------------
+
+
+def _backoff_seconds(attempt: int) -> float:
+    """Exponential backoff capped at :data:`MAX_BACKOFF`. ``attempt`` is 0-based."""
+    return min(_BACKOFF_BASE**attempt, MAX_BACKOFF)
+
+
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    """Parse the ``Retry-After`` header, if any, as seconds.
+
+    Supports the integer-seconds form. Returns ``None`` for the HTTP-date
+    form or when the header is missing/unparseable; callers fall back to
+    exponential backoff in that case. The result is clamped to
+    :data:`MAX_BACKOFF` so a misbehaving server can't park us forever.
+    """
+    raw = response.headers.get("retry-after")
+    if not raw:
+        return None
+    try:
+        seconds = float(raw.strip())
+    except ValueError:
+        return None
+    return min(max(seconds, 0.0), MAX_BACKOFF)
 
 
 # -- payload -> model -------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,8 @@ def _json_response(payload: Any, status: int = 200) -> httpx.Response:
 
 
 def _make_client(handler: Callable[[httpx.Request], httpx.Response]) -> Client:
-    return Client(api_key="test-key", transport=_mock_transport(handler))
+    """Default test client: never actually sleeps during retries."""
+    return Client(api_key="test-key", transport=_mock_transport(handler), sleep=lambda _s: None)
 
 
 # -- construction -------------------------------------------------------------
@@ -201,3 +202,177 @@ class TestErrors:
             pytest.raises(ApiError, match="expected JSON object"),
         ):
             client.list_issues()
+
+
+# -- retry / rate-limit -------------------------------------------------------
+
+
+def _sequenced_handler(
+    responses: list[httpx.Response],
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Return a handler that yields the given responses one per call."""
+    iterator = iter(responses)
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        try:
+            return next(iterator)
+        except StopIteration as exc:
+            raise AssertionError("handler ran out of canned responses") from exc
+
+    return handler
+
+
+def _sequenced_exceptions(
+    items: list[BaseException | httpx.Response],
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Like _sequenced_handler but each element may be a Response or an exception."""
+    iterator = iter(items)
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        item = next(iterator)
+        if isinstance(item, httpx.Response):
+            return item
+        raise item
+
+    return handler
+
+
+def _client_with_sleep_recorder(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> tuple[Client, list[float]]:
+    """Client whose sleep() records its arguments instead of waiting."""
+    sleeps: list[float] = []
+    client = Client(
+        api_key="test-key",
+        transport=_mock_transport(handler),
+        sleep=sleeps.append,
+    )
+    return client, sleeps
+
+
+class TestRetry5xx:
+    def test_recovers_after_transient_5xx(self) -> None:
+        # Two 503s, then success.
+        handler = _sequenced_handler(
+            [
+                httpx.Response(503),
+                httpx.Response(503),
+                _json_response({"dailyCongressionalRecord": [], "pagination": {"count": 0}}),
+            ]
+        )
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client:
+            issues, _ = client.list_issues()
+        assert issues == []
+        # Slept between the two retries (1s, 2s).
+        assert sleeps == [1.0, 2.0]
+
+    def test_gives_up_after_max_attempts(self) -> None:
+        # Always 500. Should retry MAX_5XX_RETRIES (5) times, then raise.
+        handler = _sequenced_handler([httpx.Response(500) for _ in range(6)])
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client, pytest.raises(ApiError, match="gave up after 5 attempts") as exc:
+            client.list_issues()
+        assert exc.value.status_code == 500
+        # Five sleeps before the final attempt fails out.
+        assert len(sleeps) == 5
+        # Backoff schedule: 1, 2, 4, 8, 16
+        assert sleeps == [1.0, 2.0, 4.0, 8.0, 16.0]
+
+    def test_4xx_other_than_429_is_not_retried(self) -> None:
+        # A 404 must NOT trigger retries — it's a permanent error.
+        handler = _sequenced_handler([httpx.Response(404)])
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client, pytest.raises(ApiError) as exc:
+            client.list_issues()
+        assert exc.value.status_code == 404
+        assert sleeps == []  # Never slept.
+
+
+class TestRetryTransport:
+    def test_recovers_after_transient_connect_error(self) -> None:
+        handler = _sequenced_exceptions(
+            [
+                httpx.ConnectError("first"),
+                _json_response({"dailyCongressionalRecord": [], "pagination": {"count": 0}}),
+            ]
+        )
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client:
+            client.list_issues()
+        assert sleeps == [1.0]
+
+    def test_gives_up_after_max_transport_errors(self) -> None:
+        handler = _sequenced_exceptions([httpx.ConnectError("x") for _ in range(6)])
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client, pytest.raises(ApiError, match="gave up after 5 attempts") as exc:
+            client.list_issues()
+        assert exc.value.status_code is None
+        assert len(sleeps) == 5
+
+
+class TestRetry429:
+    def test_respects_retry_after_header(self) -> None:
+        handler = _sequenced_handler(
+            [
+                httpx.Response(429, headers={"Retry-After": "3"}),
+                _json_response({"dailyCongressionalRecord": [], "pagination": {"count": 0}}),
+            ]
+        )
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client:
+            client.list_issues()
+        # Slept the 3 seconds the server requested, exactly once.
+        assert sleeps == [3.0]
+
+    def test_falls_back_to_backoff_without_retry_after(self) -> None:
+        handler = _sequenced_handler(
+            [
+                httpx.Response(429),  # no header
+                _json_response({"dailyCongressionalRecord": [], "pagination": {"count": 0}}),
+            ]
+        )
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client:
+            client.list_issues()
+        assert sleeps == [1.0]  # _backoff_seconds(0) = 1
+
+    def test_retries_indefinitely(self) -> None:
+        """Many 429s in a row should NOT count against the 5xx budget."""
+        # 10 consecutive 429s — would exceed MAX_5XX_RETRIES — then succeed.
+        responses = [httpx.Response(429) for _ in range(10)]
+        responses.append(
+            _json_response({"dailyCongressionalRecord": [], "pagination": {"count": 0}})
+        )
+        handler = _sequenced_handler(responses)
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client:
+            client.list_issues()
+        # Slept once per 429, all with the same delay (no escalation).
+        assert len(sleeps) == 10
+
+    def test_retry_after_capped_to_max_backoff(self) -> None:
+        # A pathological server says "wait 24 hours" — clamp to MAX_BACKOFF.
+        handler = _sequenced_handler(
+            [
+                httpx.Response(429, headers={"Retry-After": "86400"}),
+                _json_response({"dailyCongressionalRecord": [], "pagination": {"count": 0}}),
+            ]
+        )
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client:
+            client.list_issues()
+        assert sleeps == [60.0]  # MAX_BACKOFF
+
+    def test_malformed_retry_after_falls_back_to_backoff(self) -> None:
+        handler = _sequenced_handler(
+            [
+                httpx.Response(429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}),
+                _json_response({"dailyCongressionalRecord": [], "pagination": {"count": 0}}),
+            ]
+        )
+        client, sleeps = _client_with_sleep_recorder(handler)
+        with client:
+            client.list_issues()
+        # HTTP-date form not supported; falls back to exponential.
+        assert sleeps == [1.0]


### PR DESCRIPTION
## Summary
The API client now retries transient failures so multi-hour backfills survive flaky networks and rate-limit windows:

- **429**: retried *indefinitely*, respecting `Retry-After` (capped to `MAX_BACKOFF=60s`), falling back to exponential backoff. Does not count against the transient budget — being rate-limited is a wait condition.
- **5xx + transport errors**: retried up to 5 times, exponential backoff (1, 2, 4, 8, 16s), then `ApiError`.
- **4xx other than 429**: not retried (404 stays a 404).
- Sleep is injectable on `Client(sleep=...)` so tests run in milliseconds. Default is `time.sleep`.
- Retries log to `concord.api` at WARNING level for visibility on long pulls.

10 new tests using a sequenced `MockTransport` handler and a sleep recorder cover every branch.

Closes #23.

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 93/93 green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)