### PR TITLE
Add progress reporting and resume-safety test

### DIFF
--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -14,7 +14,7 @@ import httpx
 import typer
 
 from .api import ENV_API_KEY, ApiError, Client
-from .pipeline import pull
+from .pipeline import ProgressEvent, pull
 from .storage import JsonlStorage
 from .text import fetch_text
 
@@ -74,8 +74,20 @@ def pull_command(
             help="Maximum number of new proceedings to write.",
         ),
     ] = None,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help="Print a line per issue as the pull proceeds. Useful for backfills.",
+        ),
+    ] = False,
 ) -> None:
-    """Pull every article in every issue between --from and --to (inclusive)."""
+    """Pull every article in every issue between --from and --to (inclusive).
+
+    Re-running the same command after a crash, network drop, or Ctrl+C is
+    safe: already-stored articles are detected by their granule ID and
+    skipped without re-fetching.
+    """
     start = _parse_date(from_)
     end = _parse_date(to)
 
@@ -88,6 +100,15 @@ def pull_command(
     storage = JsonlStorage(storage_path)
     http_client = httpx.Client()
 
+    def _print_progress(event: ProgressEvent) -> None:
+        typer.echo(
+            f"{event.issue.issue_date}  "
+            f"vol {event.issue.volume} iss {event.issue.issue_number:>4}  "
+            f"+{event.issue_written:>4} written, {event.issue_skipped:>4} skipped  "
+            f"(total: {event.total_written} / {event.total_skipped})",
+            err=True,
+        )
+
     try:
         with api_client:
             result = pull(
@@ -97,6 +118,7 @@ def pull_command(
                 fetch=lambda url: fetch_text(url, http_client),
                 storage=storage,
                 limit=limit,
+                progress=_print_progress if show_progress else None,
             )
     finally:
         http_client.close()

--- a/src/concord/pipeline.py
+++ b/src/concord/pipeline.py
@@ -30,7 +30,7 @@ from datetime import UTC, date, datetime
 from typing import NamedTuple
 
 from .api import Client
-from .models import Proceeding
+from .models import Issue, Proceeding
 from .storage.base import Storage
 
 #: Per-page size when paginating ``list_issues``. The API caps at 250;
@@ -51,6 +51,21 @@ class PullResult(NamedTuple):
     skipped: int
 
 
+class ProgressEvent(NamedTuple):
+    """A single progress notification emitted after each in-range issue.
+
+    Emitted *after* every article in the issue has been processed (either
+    written or skipped). Multi-hour backfills use this to print a heartbeat
+    line so the operator can see the run is making progress.
+    """
+
+    issue: Issue
+    issue_written: int
+    issue_skipped: int
+    total_written: int
+    total_skipped: int
+
+
 def pull(
     start: date,
     end: date,
@@ -59,9 +74,20 @@ def pull(
     fetch: Callable[[str], str],
     storage: Storage,
     limit: int | None = None,
+    progress: Callable[[ProgressEvent], None] | None = None,
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
 ) -> PullResult:
     """Pull every in-range article and persist it as a :class:`Proceeding`.
+
+    Resume contract
+    ---------------
+
+    The pipeline is crash-safe by construction. Storage writes one Proceeding
+    at a time and the dedup index is rebuilt from disk on the next run, so
+    killing the process at any point loses at most the in-flight article;
+    the next invocation picks up only what's missing. Callers don't need a
+    special "resume" mode — re-running the same ``pull(start, end, ...)`` is
+    the resume.
 
     Parameters
     ----------
@@ -82,6 +108,11 @@ def pull(
     limit:
         Cap on total writes. ``None`` (the default) means unlimited. Useful
         for smoke tests and dry runs.
+    progress:
+        Optional callback invoked once per in-range issue *after* its
+        articles have been processed (written or skipped). Use this to print
+        a heartbeat line on long backfills. The pipeline itself prints
+        nothing — formatting is the caller's choice.
     now:
         Injection point for ``datetime.now(UTC)`` used to stamp
         ``fetched_at``. Lets tests assert exact timestamps.
@@ -102,9 +133,14 @@ def pull(
         for issue in issues:
             if not (start <= issue.issue_date <= end):
                 continue
+
+            issue_written = 0
+            issue_skipped = 0
+            hit_limit = False
             for article in client.list_articles(issue.volume, issue.issue_number):
                 if storage.has(article.granule_id):
                     skipped += 1
+                    issue_skipped += 1
                     continue
                 text = fetch(str(article.text_url))
                 proceeding = Proceeding.build(
@@ -115,8 +151,24 @@ def pull(
                 )
                 storage.write(proceeding)
                 written += 1
+                issue_written += 1
                 if limit is not None and written >= limit:
-                    return PullResult(written=written, skipped=skipped)
+                    hit_limit = True
+                    break
+
+            if progress is not None:
+                progress(
+                    ProgressEvent(
+                        issue=issue,
+                        issue_written=issue_written,
+                        issue_skipped=issue_skipped,
+                        total_written=written,
+                        total_skipped=skipped,
+                    )
+                )
+
+            if hit_limit:
+                return PullResult(written=written, skipped=skipped)
         if next_offset is None:
             return PullResult(written=written, skipped=skipped)
         offset = next_offset

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,53 @@ class TestArgParsing:
         assert result.exit_code == 0, result.output
         assert stub_pull[0]["limit"] == 5
 
+    def test_pull_progress_flag_passes_callback(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        stub_pull: list[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "pull",
+                "--from",
+                "2026-05-22",
+                "--to",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+                "--progress",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # With --progress, a callback is wired up.
+        assert stub_pull[0]["progress"] is not None
+
+    def test_pull_no_progress_by_default(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        stub_pull: list[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "pull",
+                "--from",
+                "2026-05-22",
+                "--to",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Without --progress, callback is None.
+        assert stub_pull[0]["progress"] is None
+
     def test_pull_default_storage_path(
         self,
         runner: CliRunner,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,6 +12,7 @@ import json
 from collections.abc import Callable
 from datetime import UTC, date, datetime
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -365,3 +366,168 @@ class TestIntegration:
         assert second.skipped == 20  # ...and all of them counted as skipped.
         # File has exactly 20 lines, not 40.
         assert len(storage.path.read_text().strip().splitlines()) == 20
+
+
+# ---------------------------------------------------------------------------
+# Resume / crash recovery
+# ---------------------------------------------------------------------------
+
+
+class TestResume:
+    def test_crash_mid_pull_is_recoverable(
+        self,
+        fixtures_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Simulate the operator's worst-case: kill -9 partway through.
+
+        Setup: integration components but the fetch callable raises on the
+        N-th article. Run pull, catch the exception, count what was written,
+        then run pull again with a working fetch and verify no duplicates
+        and no missing records.
+        """
+        # Build two clients (one will be re-created for the resume) sharing
+        # the same JSONL path.
+        out = tmp_path / "out.jsonl"
+
+        # ---- attempt 1: fetch dies after 7 articles
+        api_transport_1 = httpx.MockTransport(_api_mock_handler(fixtures_dir))
+        text_transport_1 = httpx.MockTransport(_text_mock_handler())
+        text_http_1 = httpx.Client(transport=text_transport_1)
+        client_1 = Client(api_key="test", transport=api_transport_1, sleep=lambda _: None)
+        storage_1 = JsonlStorage(out)
+
+        call_count = {"n": 0}
+
+        def crashing_fetch(url: str) -> str:
+            call_count["n"] += 1
+            if call_count["n"] > 7:
+                raise RuntimeError("simulated crash")
+            return fetch_text(url, text_http_1)
+
+        with client_1, pytest.raises(RuntimeError, match="simulated crash"):
+            pull(
+                date(2026, 5, 22),
+                date(2026, 5, 22),
+                client=client_1,
+                fetch=crashing_fetch,
+                storage=storage_1,
+                now=_now,
+            )
+        text_http_1.close()
+
+        # 7 articles made it onto disk before the crash.
+        written_during_crash = len(out.read_text().strip().splitlines())
+        assert written_during_crash == 7
+
+        # ---- attempt 2: fresh components, working fetch
+        api_transport_2 = httpx.MockTransport(_api_mock_handler(fixtures_dir))
+        text_transport_2 = httpx.MockTransport(_text_mock_handler())
+        text_http_2 = httpx.Client(transport=text_transport_2)
+        client_2 = Client(api_key="test", transport=api_transport_2, sleep=lambda _: None)
+        # Re-opening the same JSONL path rebuilds the seen-set from disk.
+        storage_2 = JsonlStorage(out)
+
+        with client_2:
+            result = pull(
+                date(2026, 5, 22),
+                date(2026, 5, 22),
+                client=client_2,
+                fetch=lambda url: fetch_text(url, text_http_2),
+                storage=storage_2,
+                now=_now,
+            )
+        text_http_2.close()
+
+        # Resume wrote only the remaining articles, skipped the 7 already there.
+        assert result.written == 13  # 20 total - 7 already done
+        assert result.skipped == 7
+
+        # Final state: exactly 20 distinct records, no duplicates.
+        lines = out.read_text().strip().splitlines()
+        assert len(lines) == 20
+        granule_ids = {Proceeding.model_validate_json(line).granule_id for line in lines}
+        assert len(granule_ids) == 20  # all unique
+
+
+# ---------------------------------------------------------------------------
+# Progress reporting
+# ---------------------------------------------------------------------------
+
+
+class TestProgress:
+    def test_callback_invoked_once_per_in_range_issue(self) -> None:
+        # Two in-range issues, one out-of-range.
+        in_1 = _issue("2026-05-22", issue_number=88)
+        in_2 = _issue("2026-05-21", issue_number=87)
+        out_of_range = _issue("2026-05-01", issue_number=80)
+        articles_88 = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(3)]
+        articles_87 = [_article(f"CREC-2026-05-21-pt1-PgS{n:04d}") for n in range(2)]
+        client = _StubClient(
+            pages=[[in_1, in_2, out_of_range]],
+            articles_by_issue={(172, 88): articles_88, (172, 87): articles_87},
+        )
+        storage = _InMemoryStorage()
+
+        events: list[Any] = []
+        pull(
+            date(2026, 5, 21),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=_stub_fetch,
+            storage=storage,
+            progress=events.append,
+            now=_now,
+        )
+        # Two callbacks: one per in-range issue. Out-of-range was skipped
+        # without invoking progress.
+        assert len(events) == 2
+        # First call: issue 88 with 3 writes.
+        assert events[0].issue.issue_number == 88
+        assert events[0].issue_written == 3
+        assert events[0].issue_skipped == 0
+        assert events[0].total_written == 3
+        # Second call: issue 87 with 2 more writes; totals accumulate.
+        assert events[1].issue.issue_number == 87
+        assert events[1].issue_written == 2
+        assert events[1].total_written == 5
+
+    def test_callback_reports_skipped(self) -> None:
+        issue = _issue("2026-05-22", issue_number=88)
+        articles = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(3)]
+        client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})
+        storage = _InMemoryStorage()
+        # Pre-seed one as already stored.
+        storage._seen.add(articles[1].granule_id)
+
+        events: list[Any] = []
+        pull(
+            date(2026, 5, 22),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=_stub_fetch,
+            storage=storage,
+            progress=events.append,
+            now=_now,
+        )
+        assert len(events) == 1
+        assert events[0].issue_written == 2
+        assert events[0].issue_skipped == 1
+
+    def test_progress_optional(self) -> None:
+        """No progress kwarg → no events, no errors."""
+        issue = _issue("2026-05-22", issue_number=88)
+        client = _StubClient(
+            pages=[[issue]],
+            articles_by_issue={(172, 88): [_article("CREC-2026-05-22-pt1-PgS0001")]},
+        )
+        storage = _InMemoryStorage()
+        result = pull(
+            date(2026, 5, 22),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=_stub_fetch,
+            storage=storage,
+            now=_now,
+        )
+        assert result.written == 1


### PR DESCRIPTION
## Summary
Crash-safety was already there structurally (storage's per-record writes from #20 + the orchestrator's `has` check from #21). This issue adds the missing affordances:

- `ProgressEvent` + optional `progress=` callback on `pull()`, emitted once per in-range issue with per-issue and cumulative counts.
- CLI `--progress` / `--no-progress` flag (default off). Heartbeat line to **stderr** so the final success summary on stdout stays scriptable.
- Integration test simulating a kill mid-pull: real components, fetch that raises after 7 articles, then a fresh run on the same JSONL file. Asserts exactly 20 distinct granule IDs on disk — no missing, no duplicates.
- 3 progress callback tests + 2 CLI tests.

Closes #24.

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 99/99 green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)