### PR TITLE
Drop unneeded `from __future__ import annotations`

### DIFF
--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -4,8 +4,6 @@ One command today — ``concord pull`` — that wires the API client, text
 fetcher, and JSONL storage together for a given inclusive date range.
 """
 
-from __future__ import annotations
-
 from datetime import date
 from pathlib import Path
 from typing import Annotated

--- a/src/concord/pipeline.py
+++ b/src/concord/pipeline.py
@@ -23,8 +23,6 @@ Design notes
   backend in #20 was designed to provide.
 """
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import NamedTuple

--- a/src/concord/storage/base.py
+++ b/src/concord/storage/base.py
@@ -7,8 +7,6 @@ over articles without ever checking — though it's still expected to call
 ``has`` first to skip the text-fetch HTTP for already-stored articles.
 """
 
-from __future__ import annotations
-
 from typing import Protocol
 
 from ..models import Proceeding

--- a/src/concord/storage/jsonl.py
+++ b/src/concord/storage/jsonl.py
@@ -10,8 +10,6 @@ load — losing one record from a long backfill is better than losing the
 ability to resume the whole thing.
 """
 
-from __future__ import annotations
-
 import json
 from pathlib import Path
 

--- a/src/concord/text.py
+++ b/src/concord/text.py
@@ -10,8 +10,6 @@ No bs4, no lxml — the format is stable enough that one stdlib parser does the
 job and removes a dependency the rest of the project doesn't need.
 """
 
-from __future__ import annotations
-
 from html.parser import HTMLParser
 
 import httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,6 @@ suite never touches the network. The ``load_fixture`` helper returns the raw
 text of a fixture file; ``load_json_fixture`` parses it as JSON.
 """
 
-from __future__ import annotations
-
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,8 +5,6 @@ JSON responses are real captures from the live API, stored under
 ``tests/fixtures/api/``.
 """
 
-from __future__ import annotations
-
 import json
 from collections.abc import Callable
 from pathlib import Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,6 @@ itself is covered by tests/test_pipeline.py — here we stub it out and verify
 the CLI does the right thing around it.
 """
 
-from __future__ import annotations
-
 import re
 from datetime import date
 from pathlib import Path

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,8 +5,6 @@ These cover the coercions the models perform on raw API payloads
 logic that ties Article URLs together.
 """
 
-from __future__ import annotations
-
 from datetime import UTC, date, datetime
 
 import pytest

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,8 +6,6 @@ JsonlStorage together via httpx.MockTransport, using the JSON and HTML
 fixtures captured for #18 and #19.
 """
 
-from __future__ import annotations
-
 import json
 from collections.abc import Callable
 from datetime import UTC, date, datetime

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,7 +1,5 @@
 """Smoke tests proving the project skeleton is wired up correctly."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import concord

--- a/tests/test_storage_jsonl.py
+++ b/tests/test_storage_jsonl.py
@@ -1,7 +1,5 @@
 """Tests for the JSONL storage backend."""
 
-from __future__ import annotations
-
 from datetime import UTC, datetime
 from pathlib import Path
 

--- a/tests/test_storage_mongo.py
+++ b/tests/test_storage_mongo.py
@@ -4,8 +4,6 @@ Uses ``mongomock`` (a pymongo-compatible in-memory fake) so the suite runs
 without a real Mongo server.
 """
 
-from __future__ import annotations
-
 from datetime import UTC, datetime
 
 import mongomock

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,7 +1,5 @@
 """Tests for the article text fetcher."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
The future import was added to every new module by reflex without auditing whether it actually did anything. In Python 3.12+ (our minimum) it's only required when a class method's signature references the enclosing class by name — at `def`-time the class isn't bound yet, so without it the annotation would need to be a string literal.

Audit found three files that genuinely need it:

| File | Reason |
| ---- | ------ |
| `src/concord/api.py` | `Client.__enter__(self) -> Client` |
| `src/concord/models.py` | `Article._check_granule_id_matches_urls -> Article`, `Proceeding.build(...) -> Proceeding` |
| `src/concord/storage/mongo.py` | `MongoStorage.from_uri(...) -> MongoStorage` |

The other 14 modules + tests just used `X | Y` and `list[int]` (handled natively since 3.10/3.9) and had no self-references. Removing the import there cuts 28 lines of noise and means runtime annotation introspection (`typing.get_type_hints`, `inspect.signature`) returns real types rather than strings.

No behavior change. All 110 tests pass.

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 110/110 green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)