### PR TITLE
Implement Stage 1 — Load (concord load → SQLite proceedings table)

### DIFF
--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -1,21 +1,31 @@
 """Command-line interface for Concord.
 
-One command today — ``concord pull`` — that wires the API client, text
-fetcher, and JSONL storage together for a given inclusive date range.
+Subcommands:
+
+- ``concord pull`` — Stage 0. Scrape api.congress.gov + congress.gov into
+  the canonical JSONL store.
+- ``concord load`` — Stage 1. Mirror the JSONL into a ``proceedings`` table
+  in SQLite. Idempotent on ``granule_id``.
 """
 
+import json
+import logging
 from datetime import date
 from pathlib import Path
 from typing import Annotated
 
 import httpx
 import typer
+from pydantic import ValidationError
 
 from .api import ENV_API_KEY, ApiError, Client
+from .models import Proceeding
 from .pipeline import ProgressEvent, pull
-from .storage import JsonlStorage, MongoStorage
+from .storage import JsonlStorage, MongoStorage, SqliteStorage
 from .storage.base import Storage
 from .text import fetch_text
+
+_log = logging.getLogger("concord.cli")
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -154,6 +164,78 @@ def pull_command(
     )
 
 
+@app.command("load")
+def load_command(
+    jsonl_path: Annotated[
+        Path,
+        typer.Option(
+            "--jsonl",
+            help="Input JSONL file produced by `concord pull` (one Proceeding per line).",
+            show_default=False,
+        ),
+    ],
+    db_path: Annotated[
+        Path,
+        typer.Option(
+            "--db",
+            help="Output SQLite database. Created if missing.",
+        ),
+    ] = Path("./proceedings.db"),
+    limit: Annotated[
+        int | None,
+        typer.Option(
+            "--limit",
+            help="Maximum number of new proceedings to write.",
+        ),
+    ] = None,
+) -> None:
+    """Mirror a JSONL file into the SQLite ``proceedings`` table.
+
+    Reads the JSONL line by line, validates each entry as a Proceeding, and
+    writes it to SQLite via SqliteStorage. Re-running over the same JSONL is
+    a no-op — dedup is enforced by ``granule_id``.
+
+    Schema changes are not handled by migrations; if the schema ever changes,
+    delete the SQLite file and re-run ``concord load``.
+    """
+    if not jsonl_path.exists():
+        typer.echo(f"error: input file not found: {jsonl_path}", err=True)
+        raise typer.Exit(code=2)
+
+    storage = SqliteStorage(db_path)
+    written = 0
+    skipped = 0
+    malformed = 0
+
+    try:
+        with jsonl_path.open("r", encoding="utf-8") as fh:
+            for line_no, raw in enumerate(fh, 1):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    proceeding = Proceeding.model_validate_json(line)
+                except (ValidationError, json.JSONDecodeError) as exc:
+                    malformed += 1
+                    _log.warning("skipping malformed line %d: %s", line_no, exc)
+                    continue
+                if storage.has(proceeding.granule_id):
+                    skipped += 1
+                    continue
+                storage.write(proceeding)
+                written += 1
+                if limit is not None and written >= limit:
+                    break
+    finally:
+        storage.close()
+
+    summary = f"Loaded {written} new proceedings into {db_path} (skipped {skipped} already present"
+    if malformed:
+        summary += f", {malformed} malformed lines skipped"
+    summary += ")"
+    typer.echo(summary)
+
+
 def main() -> None:  # pragma: no cover - entry point shim
     app()
 
@@ -163,4 +245,4 @@ if __name__ == "__main__":  # pragma: no cover
 
 
 # re-export for any callers who want to introspect the env-var name
-__all__ = ["ENV_API_KEY", "app", "main", "pull_command"]
+__all__ = ["ENV_API_KEY", "app", "load_command", "main", "pull_command"]

--- a/src/concord/storage/__init__.py
+++ b/src/concord/storage/__init__.py
@@ -2,8 +2,11 @@
 
 The :class:`Storage` Protocol is the contract every backend implements.
 
-- :class:`JsonlStorage` — the default, a single append-only ``.jsonl`` file
-  with no infrastructure requirements.
+- :class:`JsonlStorage` — the scraper's default write target. The canonical
+  raw store per ADR-0002.
+- :class:`SqliteStorage` — the recommended derived store per ADR-0003. Holds
+  the ``proceedings`` table (Stage 1) and, after Stage 2 lands, the chunks /
+  FTS5 / vector indexes.
 - :class:`MongoStorage` — optional, behind the ``[mongo]`` extra. Imported
   lazily so the package works without :mod:`pymongo` installed.
 """
@@ -11,5 +14,6 @@ The :class:`Storage` Protocol is the contract every backend implements.
 from .base import Storage
 from .jsonl import JsonlStorage
 from .mongo import MongoStorage
+from .sqlite import SqliteStorage
 
-__all__ = ["JsonlStorage", "MongoStorage", "Storage"]
+__all__ = ["JsonlStorage", "MongoStorage", "SqliteStorage", "Storage"]

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -1,0 +1,159 @@
+"""SQLite storage — the recommended derived store.
+
+One file on disk, one ``proceedings`` table that mirrors the
+:class:`Proceeding` model 1:1. Dedup is enforced by SQL: ``granule_id`` is
+the primary key, and writes use ``INSERT OR IGNORE`` so re-running over an
+unchanged JSONL is a no-op.
+
+WAL mode is enabled on construction so the web layer can read concurrently
+while the pipeline writes. The class isn't thread-safe — the underlying
+``sqlite3.Connection`` is created with ``check_same_thread=True``, which is
+the right default for a one-process loader.
+
+Stage 2 (chunks + FTS5 + ``sqlite-vec``) extends this schema in
+:doc:`docs/plans/stage-2-index`; Stage 1 only creates the ``proceedings``
+table and its secondary indexes.
+"""
+
+import sqlite3
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+from ..models import Proceeding
+
+# Columns in the exact order they appear in the INSERT statement. Keeping
+# this list in one place makes it easy to add a column later: extend here,
+# extend _row_from_proceeding, extend the DDL.
+_COLUMNS: tuple[str, ...] = (
+    "granule_id",
+    "issue_date",
+    "congress",
+    "session",
+    "volume",
+    "issue_number",
+    "update_date",
+    "section",
+    "title",
+    "start_page",
+    "end_page",
+    "text_url",
+    "pdf_url",
+    "text",
+    "fetched_at",
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS proceedings (
+    granule_id   TEXT PRIMARY KEY,
+    issue_date   TEXT NOT NULL,
+    congress     INTEGER NOT NULL,
+    session      INTEGER NOT NULL,
+    volume       INTEGER NOT NULL,
+    issue_number INTEGER NOT NULL,
+    update_date  TEXT NOT NULL,
+    section      TEXT NOT NULL,
+    title        TEXT NOT NULL,
+    start_page   TEXT NOT NULL,
+    end_page     TEXT NOT NULL,
+    text_url     TEXT NOT NULL,
+    pdf_url      TEXT NOT NULL,
+    text         TEXT NOT NULL,
+    fetched_at   TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_proceedings_issue_date
+    ON proceedings (issue_date);
+
+CREATE INDEX IF NOT EXISTS idx_proceedings_congress
+    ON proceedings (congress);
+"""
+
+_INSERT_SQL = (
+    "INSERT OR IGNORE INTO proceedings (" + ", ".join(_COLUMNS) + ") "
+    "VALUES (" + ", ".join("?" for _ in _COLUMNS) + ")"
+)
+
+
+class SqliteStorage:
+    """SQLite-backed :class:`Storage` implementation.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path for the ``.db`` file. Parent directories are
+        created on first use.
+
+    The class opens one long-lived :class:`sqlite3.Connection` on
+    construction. WAL mode is enabled so other readers (eventually the web
+    layer) can run concurrently with writes. Not thread-safe; instantiate
+    one per writer.
+    """
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self._path)
+        self._conn.row_factory = sqlite3.Row
+        # WAL gives us concurrent reads alongside our single writer.
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        # Foreign keys aren't used yet but Stage 2's chunks table will need
+        # them on; enabling here is cheap and saves a footgun later.
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    # -- Storage Protocol -------------------------------------------------
+
+    def has(self, granule_id: str) -> bool:
+        cursor = self._conn.execute(
+            "SELECT 1 FROM proceedings WHERE granule_id = ? LIMIT 1",
+            (granule_id,),
+        )
+        return cursor.fetchone() is not None
+
+    def write(self, proceeding: Proceeding) -> None:
+        self._conn.execute(_INSERT_SQL, _row_from_proceeding(proceeding))
+        self._conn.commit()
+
+    # -- introspection ----------------------------------------------------
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def __len__(self) -> int:
+        """Total number of distinct Proceedings stored."""
+        cursor = self._conn.execute("SELECT COUNT(*) FROM proceedings")
+        (count,) = cursor.fetchone()
+        return int(count)
+
+    # -- lifecycle --------------------------------------------------------
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> "SqliteStorage":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+# -- serialization ---------------------------------------------------------
+
+
+def _row_from_proceeding(proceeding: Proceeding) -> tuple[Any, ...]:
+    """Project a :class:`Proceeding` into the column tuple expected by SQL.
+
+    Uses ``model_dump(mode="json")`` so dates, datetimes, and HttpUrl
+    values come out as ISO/string forms that SQLite stores in TEXT columns
+    without surprise. Order must match :data:`_COLUMNS`.
+    """
+    dumped: dict[str, Any] = proceeding.model_dump(mode="json")
+    return tuple(dumped[col] for col in _COLUMNS)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -366,3 +366,173 @@ class TestMongoBackend:
         )
         assert result.exit_code == 2
         assert "pymongo not installed" in _strip(result.output)
+
+
+# -- `concord load` ----------------------------------------------------------
+
+
+_PROCEEDING_LINE_TEMPLATE = (
+    '{{"granule_id":"{gid}",'
+    '"issue_date":"2026-05-22","congress":119,"session":2,"volume":172,'
+    '"issue_number":88,"update_date":"2026-05-23T06:44:22Z",'
+    '"section":"Daily Digest","title":"Sample {gid}",'
+    '"start_page":"D551","end_page":"D552",'
+    '"text_url":"https://www.congress.gov/119/crec/2026/05/22/172/88/modified/{gid}.htm",'
+    '"pdf_url":"https://www.congress.gov/119/crec/2026/05/22/172/88/{gid}.pdf",'
+    '"text":"body for {gid}",'
+    '"fetched_at":"2026-05-24T00:00:00Z"}}'
+)
+
+
+def _write_jsonl(path: Path, granule_ids: list[str]) -> None:
+    """Write a JSONL fixture with one valid Proceeding per granule_id."""
+    lines = [_PROCEEDING_LINE_TEMPLATE.format(gid=gid) for gid in granule_ids]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class TestLoadCommand:
+    def test_help_lists_all_flags(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli_module.app, ["load", "--help"])
+        assert result.exit_code == 0
+        plain = _strip(result.output)
+        for flag in ["--jsonl", "--db", "--limit"]:
+            assert flag in plain
+
+    def test_loads_jsonl_into_sqlite(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        jsonl = tmp_path / "in.jsonl"
+        db = tmp_path / "out.db"
+        _write_jsonl(jsonl, ["CREC-2026-05-22-pt1-PgD551-1", "CREC-2026-05-22-pt1-PgD551-2"])
+
+        result = runner.invoke(
+            cli_module.app,
+            ["load", "--jsonl", str(jsonl), "--db", str(db)],
+        )
+        assert result.exit_code == 0, result.output
+        plain = _strip(result.output)
+        assert "Loaded 2 new proceedings" in plain
+        assert str(db) in plain
+
+        # Verify the rows actually landed.
+        from concord.storage import SqliteStorage
+
+        with SqliteStorage(db) as storage:
+            assert len(storage) == 2
+
+    def test_idempotent_when_jsonl_unchanged(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        jsonl = tmp_path / "in.jsonl"
+        db = tmp_path / "out.db"
+        _write_jsonl(jsonl, ["CREC-2026-05-22-pt1-PgD551-1", "CREC-2026-05-22-pt1-PgD551-2"])
+
+        first = runner.invoke(cli_module.app, ["load", "--jsonl", str(jsonl), "--db", str(db)])
+        assert first.exit_code == 0
+        second = runner.invoke(cli_module.app, ["load", "--jsonl", str(jsonl), "--db", str(db)])
+        assert second.exit_code == 0, second.output
+        plain = _strip(second.output)
+        assert "Loaded 0 new proceedings" in plain
+        assert "skipped 2 already present" in plain
+
+    def test_limit_caps_writes(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        jsonl = tmp_path / "in.jsonl"
+        db = tmp_path / "out.db"
+        _write_jsonl(
+            jsonl,
+            [
+                "CREC-2026-05-22-pt1-PgD551-1",
+                "CREC-2026-05-22-pt1-PgD551-2",
+                "CREC-2026-05-22-pt1-PgD551-3",
+                "CREC-2026-05-22-pt1-PgD551-4",
+                "CREC-2026-05-22-pt1-PgD551-5",
+            ],
+        )
+        result = runner.invoke(
+            cli_module.app,
+            ["load", "--jsonl", str(jsonl), "--db", str(db), "--limit", "2"],
+        )
+        assert result.exit_code == 0, result.output
+        plain = _strip(result.output)
+        assert "Loaded 2 new proceedings" in plain
+
+        from concord.storage import SqliteStorage
+
+        with SqliteStorage(db) as storage:
+            assert len(storage) == 2
+
+    def test_malformed_line_skipped(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        jsonl = tmp_path / "in.jsonl"
+        db = tmp_path / "out.db"
+        good_1 = _PROCEEDING_LINE_TEMPLATE.format(gid="CREC-2026-05-22-pt1-PgD551-1")
+        good_2 = _PROCEEDING_LINE_TEMPLATE.format(gid="CREC-2026-05-22-pt1-PgD551-2")
+        # Insert one truncated-JSON line and one missing-field line between
+        # two valid lines.
+        broken_json = '{"granule_id": "CREC-truncated", "text": "no closing'
+        missing_fields = '{"granule_id": "CREC-missing-fields-only"}'
+        jsonl.write_text(
+            "\n".join([good_1, broken_json, missing_fields, good_2]) + "\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            cli_module.app,
+            ["load", "--jsonl", str(jsonl), "--db", str(db)],
+        )
+        assert result.exit_code == 0, result.output
+        plain = _strip(result.output)
+        # Two valid lines made it through.
+        assert "Loaded 2 new proceedings" in plain
+        # Two bad lines were called out.
+        assert "2 malformed lines skipped" in plain
+
+    def test_blank_lines_are_skipped(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        jsonl = tmp_path / "in.jsonl"
+        db = tmp_path / "out.db"
+        good = _PROCEEDING_LINE_TEMPLATE.format(gid="CREC-2026-05-22-pt1-PgD551-1")
+        jsonl.write_text("\n\n" + good + "\n\n", encoding="utf-8")
+
+        result = runner.invoke(
+            cli_module.app,
+            ["load", "--jsonl", str(jsonl), "--db", str(db)],
+        )
+        assert result.exit_code == 0, result.output
+        # Blank lines aren't malformed — they're just skipped silently.
+        assert "malformed" not in _strip(result.output)
+        assert "Loaded 1 new proceedings" in _strip(result.output)
+
+    def test_missing_jsonl_file_exits_cleanly(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "load",
+                "--jsonl",
+                str(tmp_path / "does-not-exist.jsonl"),
+                "--db",
+                str(tmp_path / "out.db"),
+            ],
+        )
+        assert result.exit_code == 2
+        plain = _strip(result.output) + _strip(result.stderr or "")
+        assert "not found" in plain
+        assert "Traceback" not in plain

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -1,0 +1,232 @@
+"""Tests for the SQLite storage backend."""
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from concord.models import Article, Issue, Proceeding
+from concord.storage import SqliteStorage, Storage
+
+DEFAULT_GRANULE = "CREC-2026-05-22-pt1-PgD551-6"
+
+
+def _sample_proceeding(*, granule_id: str = DEFAULT_GRANULE, text: str = "body") -> Proceeding:
+    """Build a Proceeding whose URLs are derived from the granule ID.
+
+    The Article model verifies that the granule_id matches the granule
+    embedded in both text_url and pdf_url, so the URLs are constructed
+    from the same granule ID.
+    """
+    text_url = f"https://www.congress.gov/119/crec/2026/05/22/172/88/modified/{granule_id}.htm"
+    pdf_url = f"https://www.congress.gov/119/crec/2026/05/22/172/88/{granule_id}.pdf"
+    issue = Issue(
+        issue_date="2026-05-22",
+        congress=119,
+        session=2,
+        volume=172,
+        issue_number=88,
+        update_date="2026-05-23T06:44:22Z",
+    )
+    article = Article(
+        section="Daily Digest",
+        title="Sample",
+        start_page="D551",
+        end_page="D552",
+        text_url=text_url,
+        pdf_url=pdf_url,
+        granule_id=granule_id,
+    )
+    return Proceeding.build(
+        issue=issue,
+        article=article,
+        text=text,
+        fetched_at=datetime(2026, 5, 24, tzinfo=UTC),
+    )
+
+
+# -- protocol conformance ------------------------------------------------------
+
+
+class TestProtocol:
+    def test_sqlite_storage_satisfies_storage_protocol(self, tmp_path: Path) -> None:
+        storage: Storage = SqliteStorage(tmp_path / "out.db")
+        assert hasattr(storage, "has")
+        assert hasattr(storage, "write")
+
+
+# -- schema --------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_proceedings_table_exists(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.db"
+        SqliteStorage(path).close()
+        conn = sqlite3.connect(path)
+        try:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='proceedings'"
+            )
+            assert cursor.fetchone() is not None
+        finally:
+            conn.close()
+
+    def test_indexes_exist(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.db"
+        SqliteStorage(path).close()
+        conn = sqlite3.connect(path)
+        try:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='proceedings'"
+            )
+            names = {row[0] for row in cursor.fetchall()}
+            assert "idx_proceedings_issue_date" in names
+            assert "idx_proceedings_congress" in names
+        finally:
+            conn.close()
+
+    def test_wal_mode_enabled(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.db"
+        SqliteStorage(path).close()
+        conn = sqlite3.connect(path)
+        try:
+            (mode,) = conn.execute("PRAGMA journal_mode").fetchone()
+            assert mode.lower() == "wal"
+        finally:
+            conn.close()
+
+    def test_columns_match_proceeding_fields(self, tmp_path: Path) -> None:
+        """Every Proceeding field has a corresponding column in the table."""
+        path = tmp_path / "out.db"
+        SqliteStorage(path).close()
+        conn = sqlite3.connect(path)
+        try:
+            cursor = conn.execute("PRAGMA table_info(proceedings)")
+            cols = {row[1] for row in cursor.fetchall()}
+        finally:
+            conn.close()
+        expected = set(Proceeding.model_fields.keys())
+        assert expected.issubset(cols), f"missing columns: {expected - cols}"
+
+
+# -- basic write / has ---------------------------------------------------------
+
+
+class TestWriteAndHas:
+    def test_has_returns_false_for_unseen(self, tmp_path: Path) -> None:
+        storage = SqliteStorage(tmp_path / "out.db")
+        assert storage.has("CREC-never-seen") is False
+
+    def test_has_returns_true_after_write(self, tmp_path: Path) -> None:
+        storage = SqliteStorage(tmp_path / "out.db")
+        p = _sample_proceeding()
+        storage.write(p)
+        assert storage.has(p.granule_id) is True
+
+    def test_multiple_writes_each_persist(self, tmp_path: Path) -> None:
+        storage = SqliteStorage(tmp_path / "out.db")
+        storage.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-1"))
+        storage.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-2"))
+        assert len(storage) == 2
+
+    def test_len_starts_at_zero(self, tmp_path: Path) -> None:
+        storage = SqliteStorage(tmp_path / "out.db")
+        assert len(storage) == 0
+
+
+# -- dedup --------------------------------------------------------------------
+
+
+class TestDedup:
+    def test_writing_same_granule_twice_is_noop(self, tmp_path: Path) -> None:
+        storage = SqliteStorage(tmp_path / "out.db")
+        p = _sample_proceeding()
+        storage.write(p)
+        storage.write(p)  # idempotent via INSERT OR IGNORE
+        assert len(storage) == 1
+
+    def test_dedup_persists_across_instances(self, tmp_path: Path) -> None:
+        """Re-opening the same file sees the previously-written rows.
+
+        This is the resume contract Stage 2 and the web layer depend on.
+        """
+        path = tmp_path / "out.db"
+        first = SqliteStorage(path)
+        first.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-1"))
+        first.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-2"))
+        first.close()
+
+        second = SqliteStorage(path)
+        try:
+            assert second.has("CREC-2026-05-22-pt1-PgD551-1")
+            assert second.has("CREC-2026-05-22-pt1-PgD551-2")
+            assert not second.has("CREC-2026-05-22-pt1-PgD551-3")
+            # Writing an already-stored granule from the second instance is a no-op.
+            second.write(_sample_proceeding(granule_id="CREC-2026-05-22-pt1-PgD551-1"))
+            assert len(second) == 2
+        finally:
+            second.close()
+
+
+# -- round-trip integrity ------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_written_row_can_be_parsed_back_as_proceeding(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.db"
+        original = _sample_proceeding(text="some content body")
+        with SqliteStorage(path) as storage:
+            storage.write(original)
+
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT * FROM proceedings WHERE granule_id = ?",
+                (original.granule_id,),
+            ).fetchone()
+            assert row is not None
+            roundtripped = Proceeding.model_validate(dict(row))
+        finally:
+            conn.close()
+        assert roundtripped == original
+
+
+# -- path handling -------------------------------------------------------------
+
+
+class TestPath:
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        storage = SqliteStorage(str(tmp_path / "out.db"))
+        storage.write(_sample_proceeding())
+        assert len(storage) == 1
+        storage.close()
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "c" / "out.db"
+        storage = SqliteStorage(nested)
+        storage.write(_sample_proceeding())
+        assert nested.exists()
+        storage.close()
+
+    def test_path_property_returns_path(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.db"
+        storage = SqliteStorage(path)
+        assert storage.path == path
+        storage.close()
+
+
+# -- lifecycle -----------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_context_manager_closes_connection(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.db"
+        with SqliteStorage(path) as storage:
+            storage.write(_sample_proceeding())
+        # Closed: operations on the underlying connection should fail.
+        try:
+            storage._conn.execute("SELECT 1")
+        except sqlite3.ProgrammingError:
+            pass
+        else:
+            raise AssertionError("expected closed connection to refuse queries")


### PR DESCRIPTION
## Summary
Executes [docs/plans/stage-1-load.md](../blob/master/docs/plans/stage-1-load.md).

- `src/concord/storage/sqlite.py` — new `SqliteStorage` backend (`Storage` Protocol). Single-file SQLite, `proceedings` table 1:1 with the `Proceeding` model + indexes on `issue_date` and `congress`. WAL mode + `foreign_keys=ON`. Dedup via `INSERT OR IGNORE` on the `granule_id` PK.
- `concord load --jsonl PATH [--db PATH] [--limit N]` — reads JSONL, validates each line via Pydantic, writes through `SqliteStorage`. Malformed lines logged + skipped. Missing input file → exit 2, no traceback.
- 23 new tests (16 SQLite storage, 7 CLI). 133/133 passing total.

Closes the work of [Stage 1 plan](https://github.com/johnmarcampbell/concord/blob/master/docs/plans/stage-1-load.md); unblocks Stage 2.

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 133/133 green
- [x] `uv run concord load --help` renders cleanly
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)