### PR TITLE
Tolerate per-article fetch failures; bump HTTP timeout; plain tracebacks

### DIFF
--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -36,9 +36,17 @@ _log = logging.getLogger("concord.cli")
 
 ENV_OPENAI_API_KEY = "OPENAI_API_KEY"
 
+#: Per-request timeout (seconds) for fetching article text from congress.gov.
+#: The default httpx timeout (5s) is too aggressive for occasional slow
+#: responses and triggers transport errors that abort multi-day pulls.
+TEXT_FETCH_TIMEOUT = 60.0
+
 app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
+    # Plain Python tracebacks; Rich's pretty formatter is verbose and harder
+    # to read for unfamiliar code paths.
+    pretty_exceptions_enable=False,
     help="Pull Congressional Record articles from api.congress.gov.",
 )
 
@@ -142,14 +150,18 @@ def pull_command(
     else:
         storage = JsonlStorage(storage_path)
         storage_label = str(storage_path)
-    http_client = httpx.Client()
+    http_client = httpx.Client(timeout=TEXT_FETCH_TIMEOUT)
 
     def _print_progress(event: ProgressEvent) -> None:
         typer.echo(
             f"{event.issue.issue_date}  "
             f"vol {event.issue.volume} iss {event.issue.issue_number:>4}  "
-            f"+{event.issue_written:>4} written, {event.issue_skipped:>4} skipped  "
-            f"(total: {event.total_written} / {event.total_skipped})",
+            f"+{event.issue_written:>4} written, "
+            f"{event.issue_skipped:>4} skipped, "
+            f"{event.issue_failed:>3} failed  "
+            f"(total: {event.total_written} / "
+            f"{event.total_skipped} / "
+            f"{event.total_failed})",
             err=True,
         )
 
@@ -167,10 +179,14 @@ def pull_command(
     finally:
         http_client.close()
 
-    typer.echo(
+    summary = (
         f"Wrote {result.written} new proceedings to {storage_label} "
-        f"(skipped {result.skipped} already present)"
+        f"(skipped {result.skipped} already present"
     )
+    if result.failed:
+        summary += f", {result.failed} failed to fetch — will retry on next run"
+    summary += ")"
+    typer.echo(summary)
 
 
 @app.command("load")

--- a/src/concord/pipeline.py
+++ b/src/concord/pipeline.py
@@ -23,6 +23,7 @@ Design notes
   backend in #20 was designed to provide.
 """
 
+import logging
 from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import NamedTuple
@@ -30,6 +31,9 @@ from typing import NamedTuple
 from .api import Client
 from .models import Issue, Proceeding
 from .storage.base import Storage
+from .text import TextFetchError
+
+_log = logging.getLogger("concord.pipeline")
 
 #: Per-page size when paginating ``list_issues``. The API caps at 250;
 #: using the max minimizes round trips on long-range pulls.
@@ -39,29 +43,30 @@ LIST_PAGE_SIZE = 250
 class PullResult(NamedTuple):
     """Outcome of a single :func:`pull` invocation.
 
-    ``written`` is the count of new :class:`Proceeding` records persisted to
-    storage during this call. ``skipped`` is the count of articles that were
-    already present in storage (matched by ``granule_id``) and whose text
-    fetch was therefore avoided.
+    ``written``  — new :class:`Proceeding` records persisted this call.
+    ``skipped``  — articles already in storage (matched by ``granule_id``);
+                   their text fetch was avoided.
+    ``failed``   — articles whose text fetch raised :class:`TextFetchError`
+                   and were skipped so the rest of the run could continue.
+                   These will be re-attempted on the next ``pull`` since
+                   they were never written to storage.
     """
 
     written: int
     skipped: int
+    failed: int = 0
 
 
 class ProgressEvent(NamedTuple):
-    """A single progress notification emitted after each in-range issue.
-
-    Emitted *after* every article in the issue has been processed (either
-    written or skipped). Multi-hour backfills use this to print a heartbeat
-    line so the operator can see the run is making progress.
-    """
+    """A single progress notification emitted after each in-range issue."""
 
     issue: Issue
     issue_written: int
     issue_skipped: int
+    issue_failed: int
     total_written: int
     total_skipped: int
+    total_failed: int
 
 
 def pull(
@@ -121,10 +126,11 @@ def pull(
         ``(written, skipped)`` counts for this call.
     """
     if end < start:
-        return PullResult(written=0, skipped=0)
+        return PullResult(written=0, skipped=0, failed=0)
 
     written = 0
     skipped = 0
+    failed = 0
     offset = 0
     while True:
         issues, next_offset = client.list_issues(limit=LIST_PAGE_SIZE, offset=offset)
@@ -134,13 +140,29 @@ def pull(
 
             issue_written = 0
             issue_skipped = 0
+            issue_failed = 0
             hit_limit = False
             for article in client.list_articles(issue.volume, issue.issue_number):
                 if storage.has(article.granule_id):
                     skipped += 1
                     issue_skipped += 1
                     continue
-                text = fetch(str(article.text_url))
+                try:
+                    text = fetch(str(article.text_url))
+                except TextFetchError as exc:
+                    # Single article failed to fetch (timeout, 5xx, etc.).
+                    # Log + skip + continue — the run as a whole should not
+                    # die because one article is temporarily unreachable.
+                    # The next `concord pull` over the same range will
+                    # retry this granule since it was never written.
+                    _log.warning(
+                        "skipping %s after fetch failure: %s",
+                        article.granule_id,
+                        exc,
+                    )
+                    failed += 1
+                    issue_failed += 1
+                    continue
                 proceeding = Proceeding.build(
                     issue=issue,
                     article=article,
@@ -160,13 +182,15 @@ def pull(
                         issue=issue,
                         issue_written=issue_written,
                         issue_skipped=issue_skipped,
+                        issue_failed=issue_failed,
                         total_written=written,
                         total_skipped=skipped,
+                        total_failed=failed,
                     )
                 )
 
             if hit_limit:
-                return PullResult(written=written, skipped=skipped)
+                return PullResult(written=written, skipped=skipped, failed=failed)
         if next_offset is None:
-            return PullResult(written=written, skipped=skipped)
+            return PullResult(written=written, skipped=skipped, failed=failed)
         offset = next_offset

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -200,6 +200,63 @@ class TestDedup:
         assert articles[1].text_url not in [httpx.URL(u) for u in fetch_calls]
 
 
+class TestFetchFailures:
+    def test_single_fetch_failure_does_not_abort_run(self) -> None:
+        from concord.text import TextFetchError
+
+        issue = _issue("2026-05-22", issue_number=88)
+        articles = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(3)]
+        client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})
+        storage = _InMemoryStorage()
+
+        def flaky_fetch(url: str) -> str:
+            if articles[1].granule_id in url:
+                raise TextFetchError("simulated timeout", status_code=None)
+            return "body"
+
+        result = pull(
+            date(2026, 5, 22),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=flaky_fetch,
+            storage=storage,
+            now=_now,
+        )
+        assert result.written == 2  # the two that succeeded
+        assert result.skipped == 0
+        assert result.failed == 1  # the one that timed out
+        # Storage didn't accept the failed article — re-running can retry it.
+        assert all(p.granule_id != articles[1].granule_id for p in storage.writes)
+
+    def test_failed_count_in_progress_event(self) -> None:
+        from concord.text import TextFetchError
+
+        issue = _issue("2026-05-22", issue_number=88)
+        articles = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(3)]
+        client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})
+        storage = _InMemoryStorage()
+
+        def flaky_fetch(url: str) -> str:
+            if articles[0].granule_id in url:
+                raise TextFetchError("simulated", status_code=None)
+            return "body"
+
+        events: list[Any] = []
+        pull(
+            date(2026, 5, 22),
+            date(2026, 5, 22),
+            client=client,  # type: ignore[arg-type]
+            fetch=flaky_fetch,
+            storage=storage,
+            progress=events.append,
+            now=_now,
+        )
+        assert len(events) == 1
+        assert events[0].issue_failed == 1
+        assert events[0].issue_written == 2
+        assert events[0].total_failed == 1
+
+
 class TestLimit:
     def test_limit_caps_writes(self) -> None:
         issue = _issue("2026-05-22", issue_number=88)


### PR DESCRIPTION
## Summary
A real one-week pull died on a single article timeout. Three connected fixes:

1. **`pipeline.pull` catches `TextFetchError` per article and continues.** Previously one transient timeout aborted the entire multi-day run. Failed articles are logged + counted + skipped; they're never written to storage, so the next `concord pull` retries them via the existing idempotency contract.
2. **`PullResult` and `ProgressEvent` gain a `failed` counter** (default 0, backward-compatible). CLI summary and per-issue progress lines surface the count.
3. **CLI bumps `httpx.Client(timeout=60.0)`** — the default 5-second timeout is too aggressive for congress.gov and was the proximate cause of the original bug.
4. **CLI sets `pretty_exceptions_enable=False`** on the Typer app — plain Python tracebacks instead of Rich's wide formatted ones (per the reporter's preference).

2 new tests cover the fetch-failure path. 228/228 total green.

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 228/228 green
- [x] Manually verified the new progress format and summary on a synthetic run
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)