### PR TITLE
Ergonomics: data/ defaults, `concord run`, progress, search bug fix

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything in this directory except the placeholder.
+# The CLI defaults to ./data/proceedings.{jsonl,db}; the directory needs
+# to exist in git so a fresh clone can populate it.
+*
+!.gitignore
+!.gitkeep

--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -2,19 +2,30 @@
 
 Subcommands:
 
-- ``concord pull`` — Stage 0. Scrape api.congress.gov + congress.gov into
+- ``concord pull``  — Stage 0. Scrape api.congress.gov + congress.gov into
   the canonical JSONL store.
-- ``concord load`` — Stage 1. Mirror the JSONL into a ``proceedings`` table
+- ``concord load``  — Stage 1. Mirror the JSONL into a ``proceedings`` table
   in SQLite. Idempotent on ``granule_id``.
-- ``concord index`` — Stage 2. Chunk + embed every proceeding into FTS5
-  and ``sqlite-vec`` indexes. Idempotent per chunk and per embedding.
+- ``concord index`` — Stage 2. Chunk + embed every proceeding into FTS5 and
+  ``sqlite-vec`` indexes. Idempotent per chunk and per embedding.
+- ``concord run``   — Run all three stages back-to-back.
 - ``concord serve`` — Web layer. Run the FastAPI search demo via uvicorn.
+
+Default paths:
+
+- ``--storage`` (pull, run): ``./data/proceedings.jsonl``
+- ``--db``      (load, index, run, serve): ``./data/proceedings.db``
+- ``--to``      (pull, run): today's date (UTC)
+
+Progress is on by default for long-running commands (``--no-progress``
+to disable). Output goes to stderr so success summaries on stdout stay
+scriptable.
 """
 
 import json
 import logging
 import os
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Annotated
 
@@ -25,9 +36,10 @@ from pydantic import ValidationError
 from .api import ENV_API_KEY, ApiError, Client
 from .chunking import Chunker
 from .embedding import Embedder
-from .indexing import index
+from .indexing import IndexResult, index
+from .indexing import ProgressEvent as IndexProgressEvent
 from .models import Proceeding
-from .pipeline import ProgressEvent, pull
+from .pipeline import ProgressEvent, PullResult, pull
 from .storage import JsonlStorage, MongoStorage, SqliteStorage
 from .storage.base import Storage
 from .text import fetch_text
@@ -41,13 +53,20 @@ ENV_OPENAI_API_KEY = "OPENAI_API_KEY"
 #: responses and triggers transport errors that abort multi-day pulls.
 TEXT_FETCH_TIMEOUT = 60.0
 
+#: How often (in lines processed) the load command emits a progress line.
+LOAD_PROGRESS_EVERY = 100
+
+#: Default canonical store paths.
+DEFAULT_JSONL = Path("./data/proceedings.jsonl")
+DEFAULT_DB = Path("./data/proceedings.db")
+
 app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
     # Plain Python tracebacks; Rich's pretty formatter is verbose and harder
     # to read for unfamiliar code paths.
     pretty_exceptions_enable=False,
-    help="Pull Congressional Record articles from api.congress.gov.",
+    help="Concord — collect, index, and search the Congressional Record.",
 )
 
 
@@ -61,6 +80,11 @@ def _root() -> None:
     """
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
 def _parse_date(value: str) -> date:
     try:
         return date.fromisoformat(value)
@@ -68,91 +92,42 @@ def _parse_date(value: str) -> date:
         raise typer.BadParameter(f"expected YYYY-MM-DD, got {value!r}") from exc
 
 
-@app.command("pull")
-def pull_command(
-    from_: Annotated[
-        str,
-        typer.Option(
-            "--from",
-            help="Start date YYYY-MM-DD (inclusive).",
-            show_default=False,
-        ),
-    ],
-    to: Annotated[
-        str,
-        typer.Option(
-            "--to",
-            help="End date YYYY-MM-DD (inclusive).",
-            show_default=False,
-        ),
-    ],
-    storage_path: Annotated[
-        Path,
-        typer.Option(
-            "--storage",
-            help="JSONL output file. Created if missing.",
-        ),
-    ] = Path("./proceedings.jsonl"),
-    limit: Annotated[
-        int | None,
-        typer.Option(
-            "--limit",
-            help="Maximum number of new proceedings to write.",
-        ),
-    ] = None,
-    show_progress: Annotated[
-        bool,
-        typer.Option(
-            "--progress/--no-progress",
-            help="Print a line per issue as the pull proceeds. Useful for backfills.",
-        ),
-    ] = False,
-    mongo_uri: Annotated[
-        str | None,
-        typer.Option(
-            "--mongo-uri",
-            help="MongoDB connection URI. When set, --storage is ignored.",
-        ),
-    ] = None,
-    mongo_db: Annotated[
-        str,
-        typer.Option("--mongo-db", help="MongoDB database name (with --mongo-uri)."),
-    ] = "concord",
-    mongo_collection: Annotated[
-        str,
-        typer.Option("--mongo-collection", help="MongoDB collection name (with --mongo-uri)."),
-    ] = "proceedings",
-) -> None:
-    """Pull every article in every issue between --from and --to (inclusive).
+def _today() -> str:
+    return datetime.now(UTC).date().isoformat()
 
-    Re-running the same command after a crash, network drop, or Ctrl+C is
-    safe: already-stored articles are detected by their granule ID and
-    skipped without re-fetching.
-    """
-    start = _parse_date(from_)
-    end = _parse_date(to)
 
+def _require_openai_key() -> None:
+    if not os.environ.get(ENV_OPENAI_API_KEY):
+        typer.echo(
+            f"error: {ENV_OPENAI_API_KEY} is not set; required for embedding calls",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+
+# ---------------------------------------------------------------------------
+# Stage workers — invoked by both `concord <stage>` and `concord run`.
+# ---------------------------------------------------------------------------
+
+
+def _run_pull(
+    *,
+    start: date,
+    end: date,
+    storage: Storage,
+    storage_label: str,
+    limit: int | None,
+    show_progress: bool,
+) -> PullResult:
     try:
-        api_client = Client()  # reads CONGRESS_API_KEY from env
+        api_client = Client()
     except ApiError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
 
-    storage: Storage
-    storage_label: str
-    if mongo_uri is not None:
-        try:
-            storage = MongoStorage.from_uri(mongo_uri, db=mongo_db, collection=mongo_collection)
-        except ImportError as exc:
-            typer.echo(f"error: {exc}", err=True)
-            raise typer.Exit(code=2) from exc
-        storage_label = f"mongodb://{mongo_db}.{mongo_collection}"
-    else:
-        storage = JsonlStorage(storage_path)
-        storage_label = str(storage_path)
     http_client = httpx.Client(timeout=TEXT_FETCH_TIMEOUT)
 
-    def _print_progress(event: ProgressEvent) -> None:
+    def _on_progress(event: ProgressEvent) -> None:
         typer.echo(
             f"{event.issue.issue_date}  "
             f"vol {event.issue.volume} iss {event.issue.issue_number:>4}  "
@@ -174,7 +149,7 @@ def pull_command(
                 fetch=lambda url: fetch_text(url, http_client),
                 storage=storage,
                 limit=limit,
-                progress=_print_progress if show_progress else None,
+                progress=_on_progress if show_progress else None,
             )
     finally:
         http_client.close()
@@ -187,42 +162,17 @@ def pull_command(
         summary += f", {result.failed} failed to fetch — will retry on next run"
     summary += ")"
     typer.echo(summary)
+    return result
 
 
-@app.command("load")
-def load_command(
-    jsonl_path: Annotated[
-        Path,
-        typer.Option(
-            "--jsonl",
-            help="Input JSONL file produced by `concord pull` (one Proceeding per line).",
-            show_default=False,
-        ),
-    ],
-    db_path: Annotated[
-        Path,
-        typer.Option(
-            "--db",
-            help="Output SQLite database. Created if missing.",
-        ),
-    ] = Path("./proceedings.db"),
-    limit: Annotated[
-        int | None,
-        typer.Option(
-            "--limit",
-            help="Maximum number of new proceedings to write.",
-        ),
-    ] = None,
-) -> None:
-    """Mirror a JSONL file into the SQLite ``proceedings`` table.
-
-    Reads the JSONL line by line, validates each entry as a Proceeding, and
-    writes it to SQLite via SqliteStorage. Re-running over the same JSONL is
-    a no-op — dedup is enforced by ``granule_id``.
-
-    Schema changes are not handled by migrations; if the schema ever changes,
-    delete the SQLite file and re-run ``concord load``.
-    """
+def _run_load(
+    *,
+    jsonl_path: Path,
+    db_path: Path,
+    limit: int | None,
+    show_progress: bool,
+) -> tuple[int, int, int]:
+    """Return ``(written, skipped, malformed)``."""
     if not jsonl_path.exists():
         typer.echo(f"error: input file not found: {jsonl_path}", err=True)
         raise typer.Exit(code=2)
@@ -231,6 +181,7 @@ def load_command(
     written = 0
     skipped = 0
     malformed = 0
+    seen = 0
 
     try:
         with jsonl_path.open("r", encoding="utf-8") as fh:
@@ -238,6 +189,7 @@ def load_command(
                 line = raw.strip()
                 if not line:
                     continue
+                seen += 1
                 try:
                     proceeding = Proceeding.model_validate_json(line)
                 except (ValidationError, json.JSONDecodeError) as exc:
@@ -246,9 +198,15 @@ def load_command(
                     continue
                 if storage.has(proceeding.granule_id):
                     skipped += 1
-                    continue
-                storage.write(proceeding)
-                written += 1
+                else:
+                    storage.write(proceeding)
+                    written += 1
+                if show_progress and seen % LOAD_PROGRESS_EVERY == 0:
+                    typer.echo(
+                        f"  loaded {seen:>6} records ({written} new, {skipped} skipped"
+                        + (f", {malformed} malformed)" if malformed else ")"),
+                        err=True,
+                    )
                 if limit is not None and written >= limit:
                     break
     finally:
@@ -259,53 +217,54 @@ def load_command(
         summary += f", {malformed} malformed lines skipped"
     summary += ")"
     typer.echo(summary)
+    return written, skipped, malformed
 
 
-@app.command("index")
-def index_command(
-    db_path: Annotated[
-        Path,
-        typer.Option(
-            "--db",
-            help="SQLite database written by `concord load`.",
-            show_default=False,
-        ),
-    ],
-    limit: Annotated[
-        int | None,
-        typer.Option(
-            "--limit",
-            help="Cap on new chunks written in the chunk pass (the embed pass still runs).",
-        ),
-    ] = None,
-) -> None:
-    """Chunk every proceeding and embed every chunk via OpenAI.
-
-    Two passes, both idempotent. Safe to interrupt and re-run — a crashed
-    run loses at most one proceeding's chunks + one embedding batch's worth
-    of OpenAI calls (~$0.002).
-    """
+def _run_index(
+    *,
+    db_path: Path,
+    limit: int | None,
+    show_progress: bool,
+) -> IndexResult:
     if not db_path.exists():
         typer.echo(f"error: database not found: {db_path}", err=True)
         raise typer.Exit(code=2)
-
-    if not os.environ.get(ENV_OPENAI_API_KEY):
-        typer.echo(
-            f"error: {ENV_OPENAI_API_KEY} is not set; required for embedding calls",
-            err=True,
-        )
-        raise typer.Exit(code=2)
+    _require_openai_key()
 
     # Lazy import so `concord --help` doesn't pay the openai SDK import cost.
     import openai
 
     storage = SqliteStorage(db_path)
+
+    def _on_progress(event: IndexProgressEvent) -> None:
+        if event.phase == "chunk":
+            typer.echo(
+                f"  [chunk] {event.processed:>6} proceedings chunked"
+                + (
+                    f"  (latest: {event.most_recent_granule_id})"
+                    if event.most_recent_granule_id
+                    else ""
+                ),
+                err=True,
+            )
+        else:  # "embed"
+            typer.echo(
+                f"  [embed] +{event.processed:>3} chunks embedded"
+                + (
+                    f"  (latest chunk id: {event.most_recent_chunk_id})"
+                    if event.most_recent_chunk_id is not None
+                    else ""
+                ),
+                err=True,
+            )
+
     try:
         result = index(
             storage,
             chunker=Chunker(),
             embedder=Embedder(openai.OpenAI()),
             limit=limit,
+            progress=_on_progress if show_progress else None,
         )
     finally:
         storage.close()
@@ -317,38 +276,267 @@ def index_command(
         f"embedded {result.embedded_chunks} new chunks "
         f"(skipped {result.skipped_embedded} already embedded)"
     )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+@app.command("pull")
+def pull_command(
+    from_: Annotated[
+        str,
+        typer.Option(
+            "--from",
+            help="Start date YYYY-MM-DD (inclusive).",
+            show_default=False,
+        ),
+    ],
+    to: Annotated[
+        str | None,
+        typer.Option(
+            "--to",
+            help="End date YYYY-MM-DD (inclusive). Defaults to today (UTC).",
+            show_default=False,
+        ),
+    ] = None,
+    storage_path: Annotated[
+        Path,
+        typer.Option("--storage", help="JSONL output file. Created if missing."),
+    ] = DEFAULT_JSONL,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", help="Maximum number of new proceedings to write."),
+    ] = None,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help="Print a line per issue to stderr as the pull proceeds.",
+        ),
+    ] = True,
+    mongo_uri: Annotated[
+        str | None,
+        typer.Option(
+            "--mongo-uri",
+            help="MongoDB connection URI. When set, --storage is ignored.",
+        ),
+    ] = None,
+    mongo_db: Annotated[
+        str,
+        typer.Option("--mongo-db", help="MongoDB database name (with --mongo-uri)."),
+    ] = "concord",
+    mongo_collection: Annotated[
+        str,
+        typer.Option(
+            "--mongo-collection",
+            help="MongoDB collection name (with --mongo-uri).",
+        ),
+    ] = "proceedings",
+) -> None:
+    """Pull every article in every issue between --from and --to (inclusive).
+
+    Re-running the same command after a crash, network drop, or Ctrl+C is
+    safe: already-stored articles are detected by their granule ID and
+    skipped without re-fetching.
+    """
+    start = _parse_date(from_)
+    end = _parse_date(to or _today())
+
+    storage: Storage
+    storage_label: str
+    if mongo_uri is not None:
+        try:
+            storage = MongoStorage.from_uri(mongo_uri, db=mongo_db, collection=mongo_collection)
+        except ImportError as exc:
+            typer.echo(f"error: {exc}", err=True)
+            raise typer.Exit(code=2) from exc
+        storage_label = f"mongodb://{mongo_db}.{mongo_collection}"
+    else:
+        storage = JsonlStorage(storage_path)
+        storage_label = str(storage_path)
+
+    _run_pull(
+        start=start,
+        end=end,
+        storage=storage,
+        storage_label=storage_label,
+        limit=limit,
+        show_progress=show_progress,
+    )
+
+
+@app.command("load")
+def load_command(
+    jsonl_path: Annotated[
+        Path,
+        typer.Option("--jsonl", help="Input JSONL file (from `concord pull`)."),
+    ] = DEFAULT_JSONL,
+    db_path: Annotated[
+        Path,
+        typer.Option("--db", help="Output SQLite database. Created if missing."),
+    ] = DEFAULT_DB,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", help="Maximum number of new proceedings to write."),
+    ] = None,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help=f"Print a stderr line every {LOAD_PROGRESS_EVERY} records.",
+        ),
+    ] = True,
+) -> None:
+    """Mirror a JSONL file into the SQLite ``proceedings`` table.
+
+    Reads the JSONL line by line, validates each entry as a Proceeding, and
+    writes it to SQLite via SqliteStorage. Re-running over the same JSONL is
+    a no-op — dedup is enforced by ``granule_id``.
+
+    Schema changes are not handled by migrations; if the schema ever changes,
+    delete the SQLite file and re-run ``concord load``.
+    """
+    _run_load(
+        jsonl_path=jsonl_path,
+        db_path=db_path,
+        limit=limit,
+        show_progress=show_progress,
+    )
+
+
+@app.command("index")
+def index_command(
+    db_path: Annotated[
+        Path,
+        typer.Option("--db", help="SQLite database written by `concord load`."),
+    ] = DEFAULT_DB,
+    limit: Annotated[
+        int | None,
+        typer.Option(
+            "--limit",
+            help="Cap on new chunks written in the chunk pass (the embed pass still runs).",
+        ),
+    ] = None,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help="Emit a stderr line per chunked proceeding and per embedding batch.",
+        ),
+    ] = True,
+) -> None:
+    """Chunk every proceeding and embed every chunk via OpenAI.
+
+    Two passes, both idempotent. Safe to interrupt and re-run — a crashed
+    run loses at most one proceeding's chunks + one embedding batch's worth
+    of OpenAI calls (~$0.002).
+    """
+    _run_index(db_path=db_path, limit=limit, show_progress=show_progress)
+
+
+@app.command("run")
+def run_command(
+    from_: Annotated[
+        str,
+        typer.Option("--from", help="Start date YYYY-MM-DD (inclusive)."),
+    ],
+    to: Annotated[
+        str | None,
+        typer.Option(
+            "--to",
+            help="End date YYYY-MM-DD (inclusive). Defaults to today (UTC).",
+            show_default=False,
+        ),
+    ] = None,
+    storage_path: Annotated[
+        Path,
+        typer.Option("--storage", help="JSONL canonical store. Created if missing."),
+    ] = DEFAULT_JSONL,
+    db_path: Annotated[
+        Path,
+        typer.Option("--db", help="SQLite derived store. Created if missing."),
+    ] = DEFAULT_DB,
+    limit: Annotated[
+        int | None,
+        typer.Option(
+            "--limit",
+            help="Cap on new proceedings to scrape (also limits the index chunk pass).",
+        ),
+    ] = None,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help="Print progress to stderr throughout all three stages.",
+        ),
+    ] = True,
+) -> None:
+    """Run all three stages: pull → load → index.
+
+    Equivalent to ``concord pull --from … --to …`` followed by ``concord
+    load`` and ``concord index``. Convenient for daily cron jobs and for
+    one-shot backfills against fresh ``data/`` directories.
+
+    ``OPENAI_API_KEY`` and ``CONGRESS_API_KEY`` must both be set; the
+    command fails fast if either is missing.
+    """
+    # Fail-fast key checks before any work happens.
+    if not os.environ.get(ENV_API_KEY):
+        typer.echo(f"error: {ENV_API_KEY} is not set; required for `concord pull`", err=True)
+        raise typer.Exit(code=2)
+    _require_openai_key()
+
+    start = _parse_date(from_)
+    end = _parse_date(to or _today())
+
+    typer.echo("→ Stage 0: pull", err=True)
+    _run_pull(
+        start=start,
+        end=end,
+        storage=JsonlStorage(storage_path),
+        storage_label=str(storage_path),
+        limit=limit,
+        show_progress=show_progress,
+    )
+
+    typer.echo("→ Stage 1: load", err=True)
+    _run_load(
+        jsonl_path=storage_path,
+        db_path=db_path,
+        limit=None,  # load reads from JSONL; limit only constrains the pull
+        show_progress=show_progress,
+    )
+
+    typer.echo("→ Stage 2: index", err=True)
+    _run_index(
+        db_path=db_path,
+        limit=limit,
+        show_progress=show_progress,
+    )
+
+    typer.echo("✓ Done.", err=True)
 
 
 @app.command("serve")
 def serve_command(
     db_path: Annotated[
         Path,
-        typer.Option(
-            "--db",
-            help="SQLite database produced by `concord load` + `concord index`.",
-            show_default=False,
-        ),
-    ],
+        typer.Option("--db", help="SQLite database (from `concord load` + `concord index`)."),
+    ] = DEFAULT_DB,
     host: Annotated[
         str,
-        typer.Option(
-            "--host",
-            help="Bind address. Use 127.0.0.1 behind a reverse proxy.",
-        ),
+        typer.Option("--host", help="Bind address. Use 127.0.0.1 behind a reverse proxy."),
     ] = "127.0.0.1",
     port: Annotated[
         int,
-        typer.Option(
-            "--port",
-            help="TCP port for the web server.",
-        ),
+        typer.Option("--port", help="TCP port for the web server."),
     ] = 8000,
     reload: Annotated[
         bool,
-        typer.Option(
-            "--reload/--no-reload",
-            help="Enable uvicorn auto-reload (dev only).",
-        ),
+        typer.Option("--reload/--no-reload", help="Enable uvicorn auto-reload (dev only)."),
     ] = False,
 ) -> None:
     """Run the public-facing search demo via uvicorn.
@@ -360,13 +548,7 @@ def serve_command(
     if not db_path.exists():
         typer.echo(f"error: database not found: {db_path}", err=True)
         raise typer.Exit(code=2)
-
-    if not os.environ.get(ENV_OPENAI_API_KEY):
-        typer.echo(
-            f"error: {ENV_OPENAI_API_KEY} is not set; required for embedding queries",
-            err=True,
-        )
-        raise typer.Exit(code=2)
+    _require_openai_key()
 
     # Lazy imports so `concord --help` doesn't pay the FastAPI/uvicorn cost.
     import uvicorn
@@ -385,8 +567,9 @@ if __name__ == "__main__":  # pragma: no cover
     main()
 
 
-# re-export for any callers who want to introspect the env-var name
 __all__ = [
+    "DEFAULT_DB",
+    "DEFAULT_JSONL",
     "ENV_API_KEY",
     "ENV_OPENAI_API_KEY",
     "app",
@@ -394,5 +577,6 @@ __all__ = [
     "load_command",
     "main",
     "pull_command",
+    "run_command",
     "serve_command",
 ]

--- a/src/concord/web/templates/_results.html
+++ b/src/concord/web/templates/_results.html
@@ -23,7 +23,7 @@
           class="text-stone-600 hover:text-stone-900 underline"
           href="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page - 1 }}"
           hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page - 1 }}"
-          hx-target="#results"
+          hx-target="main"
           hx-push-url="true"
         >&larr; Previous</a>
       {% else %}<span></span>{% endif %}
@@ -32,7 +32,7 @@
           class="text-stone-600 hover:text-stone-900 underline"
           href="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page + 1 }}"
           hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page + 1 }}"
-          hx-target="#results"
+          hx-target="main"
           hx-push-url="true"
         >Next &rarr;</a>
       {% else %}<span></span>{% endif %}

--- a/src/concord/web/templates/base.html
+++ b/src/concord/web/templates/base.html
@@ -19,7 +19,8 @@
       </div>
       <form
         hx-get="/search"
-        hx-target="#results"
+        hx-target="main"
+        hx-swap="innerHTML"
         hx-push-url="true"
         hx-trigger="submit, change from:select[name='section']"
         action="/search"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,7 +140,30 @@ class TestArgParsing:
         # With --progress, a callback is wired up.
         assert stub_pull[0]["progress"] is not None
 
-    def test_pull_no_progress_by_default(
+    def test_pull_progress_on_by_default(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        stub_pull: list[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        # Long-running pulls benefit from feedback; --no-progress opts out.
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "pull",
+                "--from",
+                "2026-05-22",
+                "--to",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert stub_pull[0]["progress"] is not None
+
+    def test_pull_no_progress_when_disabled(
         self,
         runner: CliRunner,
         with_api_key: None,
@@ -157,10 +180,10 @@ class TestArgParsing:
                 "2026-05-22",
                 "--storage",
                 str(tmp_path / "out.jsonl"),
+                "--no-progress",
             ],
         )
         assert result.exit_code == 0, result.output
-        # Without --progress, callback is None.
         assert stub_pull[0]["progress"] is None
 
     def test_pull_default_storage_path(
@@ -749,3 +772,143 @@ class TestServeCommand:
         assert captured["kwargs"]["host"] == "0.0.0.0"
         assert captured["kwargs"]["port"] == 8123
         assert captured["kwargs"]["reload"] is False
+
+
+# -- defaults & ergonomics --------------------------------------------------
+
+
+class TestDefaults:
+    def test_pull_to_defaults_to_today(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        stub_pull: list[dict[str, Any]],
+        tmp_path: Path,
+    ) -> None:
+        from datetime import UTC, datetime
+
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "pull",
+                "--from",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+                "--no-progress",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # When --to is omitted, end should be today (UTC).
+        assert stub_pull[0]["end"] == datetime.now(UTC).date()
+
+
+# -- `concord run` ----------------------------------------------------------
+
+
+class TestRunCommand:
+    def test_help_lists_all_flags(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli_module.app, ["run", "--help"])
+        assert result.exit_code == 0
+        plain = _strip(result.output)
+        for flag in ["--from", "--to", "--storage", "--db", "--limit"]:
+            assert flag in plain
+
+    def test_run_dispatches_all_three_stages(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """`concord run` should call _run_pull, _run_load, _run_index in order."""
+        from concord.indexing import IndexResult
+        from concord.pipeline import PullResult
+
+        monkeypatch.setenv(cli_module.ENV_OPENAI_API_KEY, "sk-test")
+        calls: list[str] = []
+
+        def fake_pull(**_kw: Any) -> PullResult:
+            calls.append("pull")
+            return PullResult(written=0, skipped=0, failed=0)
+
+        def fake_load(**_kw: Any) -> tuple[int, int, int]:
+            calls.append("load")
+            return (0, 0, 0)
+
+        def fake_index(**_kw: Any) -> IndexResult:
+            calls.append("index")
+            return IndexResult(
+                chunked_proceedings=0,
+                chunks_written=0,
+                embedded_chunks=0,
+                skipped_chunked=0,
+                skipped_embedded=0,
+            )
+
+        monkeypatch.setattr(cli_module, "_run_pull", fake_pull)
+        monkeypatch.setattr(cli_module, "_run_load", fake_load)
+        monkeypatch.setattr(cli_module, "_run_index", fake_index)
+
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "run",
+                "--from",
+                "2026-05-22",
+                "--to",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+                "--db",
+                str(tmp_path / "out.db"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert calls == ["pull", "load", "index"]
+        plain = _strip(result.output)
+        assert "Stage 0" in plain and "Stage 1" in plain and "Stage 2" in plain
+
+    def test_run_fails_fast_on_missing_congress_key(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.delenv(cli_module.ENV_API_KEY, raising=False)
+        monkeypatch.setenv(cli_module.ENV_OPENAI_API_KEY, "sk-test")
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "run",
+                "--from",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+            ],
+        )
+        assert result.exit_code == 2
+        plain = _strip(result.output) + _strip(result.stderr or "")
+        assert cli_module.ENV_API_KEY in plain
+
+    def test_run_fails_fast_on_missing_openai_key(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.delenv(cli_module.ENV_OPENAI_API_KEY, raising=False)
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "run",
+                "--from",
+                "2026-05-22",
+                "--storage",
+                str(tmp_path / "out.jsonl"),
+            ],
+        )
+        assert result.exit_code == 2
+        plain = _strip(result.output) + _strip(result.stderr or "")
+        assert cli_module.ENV_OPENAI_API_KEY in plain

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -174,6 +174,37 @@ class TestProceedingRoute:
         assert "Not found" in r.text
 
 
+# -- search form behavior on every page -------------------------------------
+
+
+class TestSearchFormTarget:
+    """Regression: the header search form must work from /proceedings/{id}.
+
+    Previously the form had hx-target="#results", which doesn't exist on
+    the proceeding detail page, so HTMX silently failed. The fix targets
+    `main`, which exists on every page via base.html.
+    """
+
+    def test_form_targets_main_on_index(self, client: TestClient) -> None:
+        r = client.get("/")
+        assert 'hx-target="main"' in r.text
+        assert 'hx-target="#results"' not in r.text
+
+    def test_form_targets_main_on_proceeding(self, client: TestClient) -> None:
+        r = client.get("/proceedings/CREC-2026-05-22-pt1-PgS001-1")
+        assert 'hx-target="main"' in r.text
+        assert 'hx-target="#results"' not in r.text
+
+    def test_form_targets_main_on_search(self, client: TestClient) -> None:
+        r = client.get("/search?q=banking")
+        assert 'hx-target="main"' in r.text
+
+    def test_form_targets_main_on_404(self, client: TestClient) -> None:
+        r = client.get("/proceedings/CREC-not-real")
+        assert r.status_code == 404
+        assert 'hx-target="main"' in r.text
+
+
 # -- rate limiting ------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
Five user-reported ergonomics issues, batched into one PR since they all touch CLI / web UX.

1. **`data/` directory committed as a placeholder** so a fresh clone has a home for `proceedings.{jsonl,db}` without needing `mkdir`. `data/.gitkeep` tracked; `data/.gitignore` ignores the rest.
2. **CLI default paths changed** to `./data/proceedings.jsonl` and `./data/proceedings.db`. `pull` / `run` `--to` now defaults to today's date (UTC).
3. **Fixed: searching from a `/proceedings/{id}` page silently did nothing.** The header form used `hx-target="#results"`, which only existed on index/search pages. Changed to `hx-target="main"` (exists on every page via base.html). Route regression tests verify this.
4. **New `concord run --from … [--to …]` subcommand** runs all three stages (pull → load → index). Fails fast on missing env vars. Per-stage stderr headers.
5. **Progress on by default** for `pull`, `load`, and `index`. `--no-progress` to disable. `load` emits a stderr line every 100 records; `index` emits one per chunked proceeding and per embedding batch.

Refactored per-stage logic into shared `_run_pull` / `_run_load` / `_run_index` helpers.

**236/236 tests passing** (8 new).

## Test plan
- [x] Local: `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — 236/236 green
- [x] `uv run concord --help` lists all 5 commands including `run`
- [x] `uv run concord run --help` shows expected flags + defaults
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)