### PR TITLE
Phase 1 — Members ingest + multi-entity pipeline refactor

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,12 +5,23 @@ Implementation lives elsewhere; this file is a dictionary, not a spec.
 
 ## Source domain (Congressional Record)
 
+The vocabulary in this section covers the Congressional Record sub-domain — the original scope of the project. The broader Congress sub-domain (Members, Bills, Votes, …) is defined under "Entities" below.
+
+
 - **Congressional Record** — the official record of the proceedings and debates of the U.S. Congress, published daily that Congress is in session. Data source.
 - **Issue** — one day's edition of the Congressional Record. Identified by `(volume, issue_number)`. Carries metadata: `issue_date`, `congress`, `session`.
 - **Section** — a top-level grouping within an issue: `Senate Section`, `House Section`, `Extensions of Remarks Section`, `Daily Digest`.
 - **Article** — one discrete item within a section. Has `title`, `start_page`, `end_page`, a Formatted Text URL and a PDF URL on congress.gov.
 - **Granule ID** — the stable identifier for an article, e.g. `CREC-2026-05-22-pt1-PgD551-6`. Embedded in both the text and PDF URLs. Used as the primary key across the entire pipeline; dedup is keyed on it.
 - **Proceeding** — the canonical output record of the scrape pipeline. One article's metadata + plain text + fetch timestamp. The unit of analysis throughout the project.
+
+## Entities (broader Congress sub-domain)
+
+- **Member** — a person who has served in the U.S. Congress. The canonical actor entity. Identified by Bioguide ID. "Former" vs "current" is a query filter, not a separate term.
+- **Bioguide ID** — the stable primary key for a Member, assigned by the Biographical Directory of the United States Congress. Example: `O000172`. Never reused, never rewritten.
+- **Term** — one continuous service period for a Member in one chamber. A Member has 1..N terms. Keyed by `(bioguide_id, congress, chamber)`. Carries party, state, district (House only), and start/end dates.
+- **Chamber** — `house` or `senate`. A property of the Term, not the Member: Members can move between chambers across terms.
+- **Party** — recorded per-Term, not per-Member. Members can change parties between terms; per-Term storage preserves historical state.
 
 ## Pipeline stages
 

--- a/docs/adr/0006-snapshot-on-fetch-for-mutable-entities.md
+++ b/docs/adr/0006-snapshot-on-fetch-for-mutable-entities.md
@@ -1,0 +1,64 @@
+# 0006 — Snapshot-on-fetch for mutable entities
+
+**Status**: Accepted, 2026-05-25.
+
+## Context
+
+[ADR 0002](./0002-jsonl-as-canonical-raw-store.md) makes JSONL the canonical raw store and treats Proceedings as immutable: a `granule_id` keys a single line, and the file is append-only because the underlying article never changes after publication.
+
+The roadmap in [docs/plans/members-bills-votes-roadmap.md](../plans/members-bills-votes-roadmap.md) extends ingest to Members, Bills, Votes, Committees, and Amendments. These don't share the immutability property:
+
+- **Bills** gain cosponsors, accumulate actions, change status, get amended.
+- **Members** extend term history mid-Congress; rare metadata edits happen.
+- **Votes** are mostly immutable once a roll is closed, but errata corrections do appear.
+- **Committee memberships** are time-bounded and change with each Congress and with mid-session reassignments.
+
+The append-only contract from ADR 0002 doesn't trivially survive that. Two shapes considered:
+
+1. **Mutate in place.** One line per entity key in JSONL; the scraper rewrites the line when the upstream object changes. SQLite is loaded from the latest state.
+2. **Snapshot-on-fetch.** Every fetch appends a new line tagged with `fetched_at`. Multiple lines per entity key are expected. SQLite is loaded by projecting "latest snapshot per key".
+
+## Decision
+
+Snapshot-on-fetch. Every Stage 0 fetch of a mutable entity appends a new JSONL line, never edits an existing one. Each line carries `fetched_at` (ISO-8601, UTC). The Stage 1 loader projects the latest snapshot per natural key into SQLite.
+
+Concretely, the JSONL row shape for these entities is:
+
+```json
+{"fetched_at": "2026-05-25T14:02:11Z", "key": {...}, "payload": {...}}
+```
+
+where `key` is the natural key (e.g. `{"bioguide_id": "S000033"}` for a Member, `{"congress": 119, "bill_type": "hr", "bill_number": 1234}` for a Bill) and `payload` is the raw API response body, stored verbatim.
+
+Proceedings stay under their original ADR 0002 contract — one line per `granule_id`, no `fetched_at` envelope. The snapshot envelope applies only to the new mutable-entity files.
+
+## Consequences
+
+**Trade-offs accepted:**
+
+- **Storage grows with churn.** A Bill that accumulates 200 cosponsors over a year writes 200 snapshot lines if we fetch daily, each containing the full payload. At v1 scope (3 congresses, federal only) the upper bound is comfortably under a few GB per entity type. Revisit when v2 backfill to 1995 is on the table.
+- **The loader is no longer a stream-and-insert.** Stage 1 now has to either group-by-key-keep-latest as it reads, or load all snapshots and project at the end. Both are cheap at our scale; neither requires anything beyond standard SQL.
+- **JSONL files for mutable entities are not human-greppable for "current state"** — a `grep` on `bill_number=1234` returns every snapshot. Mitigated by: SQLite is the right tool for current-state queries; JSONL is the recovery substrate, not the day-to-day surface.
+
+**Things this buys:**
+
+- **ADR 0002's append-only contract survives unchanged.** No special-case "this file mutates, that one doesn't" rule. Every JSONL file in the project is append-only; the only variation is whether multiple lines share a key.
+- **Mutation history is recoverable for free.** "When did Senator X become a cosponsor of HR 1234?" is a JSONL replay — no separate history table, no audit log to maintain. The canonical store *is* the history.
+- **Re-derivation stays mechanical.** Stage 1 can be re-run at any earlier cutoff (`WHERE fetched_at < T`) to reconstruct SQLite state as of an arbitrary past moment. Useful for debugging "the surface showed the wrong sponsor list yesterday" without rerunning the scrape.
+- **Failed or partial fetches are non-corrupting.** A botched run writes incomplete snapshots; the next clean run supersedes them. No reconciliation logic.
+
+**What stays open:**
+
+- **Compaction policy.** When storage starts to bite (post-v1), we'll want a periodic compaction that keeps the first snapshot, the latest snapshot, and any snapshots where the payload changed — discarding intermediate no-op fetches. This is a non-breaking change: compacted files load identically.
+- **Hashing payloads for change detection.** A `payload_hash` field on each snapshot would let the loader skip lines that don't differ from the previous snapshot for the same key, and would make compaction trivial. Cheap to add now or later.
+- **Fetch cadence is unspecified by this ADR** — it belongs in each entity's phase plan. The contract here is only that *every* fetch produces a snapshot, regardless of cadence.
+
+## Rejected: mutate in place
+
+Rewriting a JSONL line when the upstream object changes would let SQLite be loaded with a simple line-by-line read, no projection step. It was rejected for three reasons:
+
+1. **It breaks the append-only invariant.** JSONL files become subject to torn writes, partial rewrites, and editor-style corruption modes that append-only files are immune to.
+2. **It throws away mutation history.** The previous state is gone the moment the scraper sees a new version. Recovering "what the cosponsor list looked like last Tuesday" requires a separate audit mechanism that didn't need to exist.
+3. **It special-cases Proceedings vs mutable entities.** Two contracts for "what a JSONL file is" instead of one. Snapshot-on-fetch keeps every JSONL file under the same append-only rule.
+
+The storage cost of duplicated snapshots is real but bounded and addressable via compaction. The contract simplicity is permanent.

--- a/docs/adr/0007-parallel-pipelines-per-entity.md
+++ b/docs/adr/0007-parallel-pipelines-per-entity.md
@@ -1,0 +1,53 @@
+# 0007 — Parallel Stage 0 + Stage 1 per entity type
+
+**Status**: Accepted, 2026-05-25.
+
+## Context
+
+Concord's current pipeline is one-source, one-entity: api.congress.gov's `/congressional-record` endpoint → Proceedings. The roadmap in [docs/plans/members-bills-votes-roadmap.md](../plans/members-bills-votes-roadmap.md) extends this to five additional sources (`/member`, `/bill`, `/committee`, `/amendment`, `/house-vote` + `/senate-vote`) producing five new peer entity types.
+
+[members-bills-votes-scope.md](../plans/members-bills-votes-scope.md) names two ways to slot this in:
+
+1. **Generalize the existing stages.** Stage 0 becomes "scrape any congress.gov endpoint to JSONL"; Stage 1 becomes "load JSONL → typed tables". One pipeline, parameterized by entity type.
+2. **Parallel pipelines, shared DB.** Each entity type gets its own Stage 0 + its own Stage 1. Stage 2 (Index) and Stage 3 (Enrich) operate across the unified SQLite.
+
+The question is where to draw the line between "shared infrastructure" and "per-entity code".
+
+## Decision
+
+Stage 0 and Stage 1 are parallel per entity type. Stage 2 (Index) and Stage 3 (Enrich) are shared and operate across the unified SQLite.
+
+In practice:
+
+- Each entity gets its own scraper module (`scraper/members.py`, `scraper/bills.py`, …) and its own JSONL file (`data/members.jsonl`, `data/bills.jsonl`, …).
+- Each entity gets its own loader module (`pipeline/load_members.py`, …) writing to its own SQLite tables.
+- The CLI gains per-entity verbs: `concord scrape members`, `concord scrape bills`, `concord load members`, etc. The existing `concord scrape` (for Proceedings) becomes `concord scrape proceedings`.
+- Stage 2 stays one module operating across the chunks table (see [ADR 0008](./0008-chunks-generalize-beyond-proceedings.md) for how chunks span entity types). Stage 3 stays one module producing the cross-entity `mentions` table.
+- Shared concerns — HTTP client, rate-limit handling, retry policy, `fetched_at` envelope from [ADR 0006](./0006-snapshot-on-fetch-for-mutable-entities.md) — live in a thin `scraper/_common.py` that each per-entity scraper imports. Not a framework; a utility module.
+
+## Consequences
+
+**Trade-offs accepted:**
+
+- **Six scrapers instead of one.** Some structural duplication across modules (pagination loop, error handling, JSONL writer). Bounded by the shared utility module; what stays per-entity is the part that's actually different.
+- **CLI surface grows.** Five new verb-noun pairs at v1. Mitigated by consistent shape (`concord <stage> <entity>`); discoverability via `--help` listings.
+- **No single "scrape everything" command out of the box.** Adding one is trivial (a shell loop or a meta-command), but the per-entity commands are the canonical interface.
+
+**Things this buys:**
+
+- **Per-source quirks stay visible.** Each congress.gov endpoint has its own response shape, pagination idiom, rate-limit behavior, and mutability profile. The `/bill` response has nested cosponsor objects with their own ID conventions; `/house-vote` is thin and needs augmentation from clerk.house.gov bulk XML; `/member` has a quirky term-history substructure. A generalized Stage 0 would either lose this detail behind a lowest-common-denominator schema or accumulate per-source branches inside a single function — the second is worse than just having separate modules.
+- **Blast radius per change is small.** Modifying the Bills loader to handle a new field can't break Members ingest. A single shared loader would couple them.
+- **Each entity ships independently.** The roadmap phases entity ingest one at a time. Parallel modules mean Phase 1 (Members) doesn't touch the code Phase 2 (Bills) will write.
+- **Stage 2 / Stage 3 stay shared, which is where sharing actually pays.** Chunking, embedding, FTS5 indexing, and entity extraction all benefit from one implementation. The decision here is specifically about Stages 0 and 1, where the inputs differ per source.
+
+**What stays open:**
+
+- **The shared utility module will accrete.** That's fine as long as it stays a utility, not a framework — the test is whether a per-entity scraper still reads top-to-bottom as "fetch, paginate, write" without indirection through base classes.
+- **If a seventh and eighth source land in v2 (FEC, LDA), the per-entity pattern may start to feel heavy.** The threshold for revisiting is "two new sources have nearly identical Stage 0 logic and only the URL differs." We're nowhere near that at v1.
+- **Cross-entity ingest orchestration** (e.g. "scrape everything for Congress 119 since last Tuesday") is unspecified by this ADR. It belongs at the CLI or shell-script level, not inside the per-entity scrapers.
+
+## Rejected: generalized Stage 0 + Stage 1
+
+A single `concord scrape --entity bills` would be aesthetically cleaner and produce less code by line count. It was rejected because the apparent symmetry between the congress.gov endpoints is shallow: they share an auth scheme and a base URL and almost nothing else. A generalized scraper would either expose a config object large enough to encode every per-source quirk (at which point the "generalization" is a serialization of what the per-entity module already says directly), or it would suppress those quirks behind a uniform schema and lose detail.
+
+The roadmap also expects sources beyond congress.gov in v2 — clerk.house.gov XML in Phase 3 for full roll-call detail, FEC and LDA in v2. A "generalize over congress.gov endpoints" abstraction would be the wrong shape for those anyway. Better to start with one module per source and let any real sharing surface from below.

--- a/docs/adr/0008-chunks-generalize-beyond-proceedings.md
+++ b/docs/adr/0008-chunks-generalize-beyond-proceedings.md
@@ -1,0 +1,60 @@
+# 0008 — Chunks generalize beyond Proceedings
+
+**Status**: Accepted, 2026-05-25.
+
+## Context
+
+[ADR 0005](./0005-chunks-as-unit-of-retrieval.md) defines a Chunk as a span of a Proceeding's text sized for one embedding, and makes chunks the unit of retrieval for both FTS5 and `sqlite-vec`. The schema today assumes every chunk has a `granule_id` foreign key to a Proceeding.
+
+Phase 5 of the roadmap ([docs/plans/members-bills-votes-roadmap.md](../plans/members-bills-votes-roadmap.md)) indexes Bill text for RAG. Bill text is a different source — keyed by `(congress, bill_type, bill_number)`, not `granule_id` — but it wants the same treatment: chunked, embedded, indexed in FTS5, retrievable via the same hybrid-search ranking. The question is whether to extend the existing chunks tables to span source types, or to stand up a parallel set of tables per source.
+
+Two shapes considered:
+
+1. **Per-source tables.** `proceeding_chunks`, `proceeding_chunks_fts`, `vec_proceeding_chunks`; `bill_chunks`, `bill_chunks_fts`, `vec_bill_chunks`. Search queries `UNION` across them and merges results.
+2. **One chunks table with a source discriminator.** `chunks` gains `source_type` + `source_id` columns; `chunks_fts` and `vec_chunks` stay single tables. Search queries one set of indexes and filters on `source_type` at the surface.
+
+## Decision
+
+One chunks table, discriminated by `source_type` + `source_id`. Concretely:
+
+```sql
+chunks(
+  chunk_id INTEGER PRIMARY KEY,
+  source_type TEXT NOT NULL,    -- 'proceeding' | 'bill' | future entity types
+  source_id TEXT NOT NULL,      -- granule_id, or '<congress>-<type>-<number>', etc.
+  ord INTEGER NOT NULL,         -- chunk position within the source
+  text TEXT NOT NULL,
+  UNIQUE (source_type, source_id, ord)
+)
+```
+
+`chunks_fts` and `vec_chunks` continue to key on `chunk_id`. RRF and grouping logic from ADR 0005 are unchanged; the surface layer decides whether to roll a result up to a Proceeding page or a Bill page based on `source_type`.
+
+The migration from the current schema is a column add + backfill (`source_type = 'proceeding'`, `source_id = granule_id`) and a rename of the `granule_id` FK column. Stage 2 is regenerable per ADR 0002, so the migration is a re-derive, not a careful in-place ALTER.
+
+## Consequences
+
+**Trade-offs accepted:**
+
+- **`source_id` is a string instead of a typed FK.** SQLite can't have a foreign key that points to different tables depending on a discriminator column. We accept loss of referential integrity at the schema level; the loader enforces it. In practice the trade is invisible — there's no `ON DELETE CASCADE` workflow we'd otherwise rely on, since chunks are rebuilt from source on Stage 2 re-runs.
+- **Every chunks query has to handle `source_type` somewhere.** Either in the WHERE clause (when filtering) or in the result handler (when grouping for display). Bounded: there are three query paths total (keyword, semantic, hybrid).
+- **A single FTS5 table grows larger than per-source ones combined would individually.** Operationally identical — SQLite FTS5 handles tens of millions of entries fine, and we're nowhere near that.
+
+**Things this buys:**
+
+- **Hybrid search across sources is mechanical.** A query for "infrastructure spending" returns both Proceeding chunks and Bill chunks in one ranked list, scored on the same axis, via the same RRF logic from ADR 0005. No UNION ALL across parallel tables, no cross-table rank reconciliation.
+- **The unit-of-retrieval principle from ADR 0005 holds.** Chunks remain the unit; only the source the chunk came from varies. ADR 0005's argument for "score weighting is meaningful because both signals score the same span" carries over without modification.
+- **New entity types with indexable text are additive.** If a v2 phase indexes committee report text or amendment text, it's a new `source_type` value — no new tables, no new index path. The cost of adding a source is a loader change and a surface-page route.
+- **The surface layer dispatches cleanly.** A search result hands back `(source_type, source_id, chunk_text, score)`. The web layer routes to `/proceedings/{id}` or `/bills/{id}` based on `source_type`. Snippet rendering is identical.
+
+**What stays open:**
+
+- **Embedding model per source type.** [ADR 0004](./0004-openai-embeddings.md) uses one OpenAI embedding model across all chunks. If a future source benefits from a different model (e.g. a code-aware model for statutory text), `vec_chunks` would need to split by model or carry a `model_id` column. Not a v1 concern.
+- **Per-source chunk size tuning.** Bill text has different structural conventions than Congressional Record articles (sections, subsections, enumerated paragraphs). The 512-token / 100-overlap default from ADR 0005 may not be optimal for bill text. Tunable per source if we ever care; v1 uses the default.
+- **Speaker attribution from ADR 0005's "What stays open" section** is now even more clearly Proceeding-specific. When that work lands in Stage 3, it touches `source_type = 'proceeding'` chunks only. The generalized table makes this distinction explicit instead of implicit.
+
+## Rejected: per-source chunk tables
+
+Standing up `bill_chunks`, `vec_bill_chunks`, `bill_chunks_fts` in parallel to the Proceeding tables would keep schemas perfectly typed and let each source have its own FK to its parent. It was rejected because it breaks the central property ADR 0005 establishes — that hybrid search operates on one ranked list of chunks. With parallel tables, every cross-source search becomes a UNION ALL that has to reconcile rankings from two independently-scored indexes, and the RRF math gets fuzzy. The unit of retrieval would silently become "chunks within a source type", not "chunks", and the ADR 0005 argument would have to be re-derived per source.
+
+The typing benefit is real but small — `source_id` as a string costs nothing operationally and only matters at schema review time. The hybrid-search clarity benefit is permanent and load-bearing for the Phase 5 surface.

--- a/docs/plans/members-bills-votes-roadmap.md
+++ b/docs/plans/members-bills-votes-roadmap.md
@@ -1,0 +1,133 @@
+# Members, Bills, Votes — roadmap
+
+**Status:** roadmap, not yet broken into implementation plans. Follow-up to [members-bills-votes-scope.md](./members-bills-votes-scope.md). Each phase below should get its own `docs/plans/<slug>.md` before code lands.
+
+**Date:** 2026-05-25.
+
+## Scope locked from the scoping conversation
+
+- **Audience / surface:** public demo, extending the existing FastAPI+HTMX site. Same ethos as the current `/search`.
+- **Entities in v1:** Member, Bill, Vote, Committee, Amendment. Bill *text* indexed for RAG.
+- **History:** last ~3 congresses (117th–119th, roughly 2021→present).
+- **Repo:** stays in Concord. The domain broadens; [CONTEXT.md](../../CONTEXT.md) gets updated, not replaced.
+
+Explicitly **out of v1:** FEC / lobbying money trails, state legislatures, network-graph visualizations, conversational layer over bills, alerts/subscriptions, graph DB.
+
+## Architectural decisions to ratify before Phase 1
+
+These need new ADRs. They're prerequisites; no ingest work should start until they land.
+
+### ADR 0006 — Mutability model for non-Proceeding entities
+
+**Problem.** [ADR 0002](../adr/0002-jsonl-as-canonical-raw-store.md) makes JSONL append-only and Proceedings immutable. Bills mutate: they gain cosponsors, get amended, change status. Member term histories extend.
+
+**Proposed answer.** Keep JSONL append-only. On every fetch of a mutable entity, append a *snapshot* line with a `fetched_at` timestamp. The Stage 1 loader projects "latest snapshot per key" into SQLite. The canonical-store contract survives; mutation history is recoverable by replaying JSONL with earlier cutoffs.
+
+Tradeoff: storage grows with churn (every cosponsor addition rewrites a Bill snapshot). At 3 congresses this is fine. Revisit if we backfill to 1995.
+
+### ADR 0007 — Pipeline shape for multi-source ingest
+
+**Problem.** [members-bills-votes-scope.md](./members-bills-votes-scope.md) names two options: parallel pipelines per entity, or one generalized pipeline.
+
+**Proposed answer.** Parallel Stage 0 + Stage 1 per entity type. Each source produces its own JSONL file (`members.jsonl`, `bills.jsonl`, `votes.jsonl`, …) and its own loader. Stage 2 (Index) and Stage 3 (Enrich) operate across the unified SQLite. CLI gains `concord scrape <entity>` / `concord load <entity>`.
+
+Rationale: each congress.gov endpoint has its own response shape, rate-limit behavior, and mutability profile. A "generalized Stage 0" abstracts over differences that should stay visible. Three similar loaders beats one premature framework.
+
+### ADR 0008 — Chunks generalize beyond Proceedings
+
+**Problem.** [ADR 0005](../adr/0005-chunks-as-unit-of-retrieval.md) defines Chunks as spans of a Proceeding's text. Bill text RAG means chunks come from Bills too.
+
+**Proposed answer.** A chunk gets a `source_type` + `source_id`. The `chunks`, `chunks_fts`, and `vec_chunks` tables stay single-tabled, with `source_type` as a discriminator. Search ranking is the same; surface layer decides whether to roll up to a Proceeding or a Bill.
+
+## Phasing
+
+Each phase ships a visible public page. Order is driven by (a) prerequisite-first and (b) what unlocks the next phase's UX.
+
+### Phase 1 — Members
+
+Smallest entity, most stable, fastest visible win.
+
+- Stage 0: scrape `/member` for the 3 congresses in scope → `data/members.jsonl`
+- Stage 1: `members` table (Bioguide ID PK), `member_terms` child table
+- Stage 2: name-alias FTS5 index for "did you mean" search (no embeddings)
+- Web: `/members` index + `/members/{bioguide_id}` profile page (party, state, term history)
+- CONTEXT.md update: define Member, Bioguide ID, Term
+
+**Done means:** a journalist can pull up any current member's profile by name from the public site.
+
+### Phase 2 — Bills (metadata)
+
+- Stage 0: scrape `/bill` → `data/bills.jsonl` (snapshot-on-fetch per ADR 0006)
+- Stage 1: `bills`, `bill_sponsors`, `bill_cosponsors`, `bill_actions` tables
+- Web: `/bills/{congress}/{type}/{number}` page — sponsor + cosponsor list (links to Member pages), action history, status
+- Cross-link from Member page: "Sponsored", "Cosponsored" sections
+
+**Done means:** a bill page reads like a profile, with every name a working link.
+
+### Phase 3 — Votes
+
+- Stage 0: scrape `/house-vote` + `/senate-vote`. Augment from clerk.house.gov / senate.gov bulk XML for full per-member positions (the API is thin here).
+- Stage 1: `votes`, `vote_positions` (member × vote → yea/nay/present/not-voting) tables
+- Web: `/votes/{chamber}/{congress}/{session}/{roll}` page; Member page gains "Recent votes" + party-line alignment stat; Bill page gains "Vote history".
+
+**Done means:** the Member↔Bill loop closes through Votes. Party-line break stats are computable.
+
+### Phase 4 — Committees + Amendments
+
+- Stage 0: scrape `/committee`, `/amendment` → respective JSONL
+- Stage 1: `committees`, `committee_memberships` (time-bounded), `amendments` tables
+- Web: Bill page gains "Committee path" timeline; Member page gains committee assignments; Committee page lists membership + referred bills.
+
+**Done means:** the legislative path of a bill is visible end-to-end on the bill page.
+
+### Phase 5 — Bill text RAG
+
+This is where Stage 2 generalizes (ADR 0008).
+
+- Stage 0: fetch bill text from congress.gov for bills in scope → JSONL or per-bill files
+- Stage 2: generalize chunks table with `source_type`; chunk bill text; embed via existing OpenAI pipeline ([ADR 0004](../adr/0004-openai-embeddings.md))
+- Web: existing `/search` becomes hybrid across Proceedings + Bills, with source-type filters. Bill page gains "Search within this bill".
+
+**Done means:** a single search box returns Congressional Record passages *and* bill-text passages, with the same RRF ranking.
+
+### Phase 6 — Mentions (Stage 3 Enrich)
+
+This is the bridge to the existing Proceedings infra. It was always going to be Stage 3 per [CONTEXT.md](../../CONTEXT.md); the entity tables are the prerequisite that made it tractable.
+
+- Stage 3: NER + dictionary-match over Proceeding text → `mentions` table (proceeding_id × entity_type × entity_id)
+- Web: Member page gains "Mentioned in proceedings"; Bill page gains "Discussed in"; Proceeding page gains a sidebar of detected entities.
+
+**Done means:** Concord's original Proceeding corpus is now navigable *through* the entity graph.
+
+### Phase 7 — Universal search + entity pages polish
+
+- One search box, faceted across all entity types
+- "Most cosponsored with" / "Most votes against party" style derived rankings (computed as SQLite materialized views, not at request time)
+- Editorial-neutrality review of any ranking surface (per the risk in the scoping doc)
+
+**Done means:** the surface is good enough to be the public demo. Anything beyond this is v2.
+
+## What v2 looks like (not committed)
+
+Captured so we don't quietly drift into them mid-v1:
+
+- FEC + LDA money trails (the EpsteinExposed "Flights" analog)
+- Dossier templates ("members who broke with party >5x on healthcare last quarter")
+- Subscriptions / alerts
+- Bill lifecycle viz (only after committee data is rich enough)
+- Multi-hop graph queries → Apache AGE / Neo4j evaluation
+- State legislatures
+- Backfill to 1995
+
+## Risks carried forward from scoping
+
+Tracked here so each phase's plan can re-check them:
+
+- **Staleness.** Each ingest source needs a daily refresh cadence wired up before its surface goes public. Phase plans must specify cadence + failure visibility.
+- **Editorial neutrality.** Phase 7's ranking surfaces are the highest-risk; Phase 3's party-line stat is the first place this bites. Define the stat with a named methodology, not a vibe.
+- **Mutability mismatch.** ADR 0006 handles the storage side. UI side: surface `fetched_at` on every Bill/Vote page so staleness is legible.
+- **Viz-vs-utility.** No network graphs in v1. If the urge appears mid-phase, push it to v2.
+
+## How to pick this up
+
+Next session should start by drafting the three ADRs (0006, 0007, 0008). Those are blocking for Phase 1. After they land, Phase 1 gets its own `docs/plans/phase-1-members.md` via the `implementation-plan` skill.

--- a/docs/plans/members-bills-votes-scope.md
+++ b/docs/plans/members-bills-votes-scope.md
@@ -1,0 +1,101 @@
+# Members, Bills, Votes — scoping brainstorm
+
+**Status:** scoping conversation, not a plan yet. Captures a wrap session on extending Concord beyond Proceedings. Needs grilling against [CONTEXT.md](../../CONTEXT.md) and the existing ADRs before any of this becomes committed work.
+
+**Date:** 2026-05-25.
+
+## The ask
+
+Surface, alongside Proceedings:
+
+- **Members** of Congress
+- **Bills**
+- **Votes**
+- A knowledge graph connecting them — "Member X cosponsored Bill Y", "Vote Z determined the outcome of Bill Y", etc.
+
+## Inspiration
+
+[epsteinexposed.com](https://epsteinexposed.com) and its pipeline at [stonesalltheway1/Epstein-Pipeline](https://github.com/stonesalltheway1/Epstein-Pipeline). What's worth borrowing:
+
+- Entity profile pages with aggressive cross-linking (every name/document/flight is a link)
+- "Most connected persons" ranking patterns
+- Dual storage: Postgres+pgvector for semantic/tabular, Neo4j for the multi-hop graph traversal stuff
+- Universal search across all entity types
+
+What to *not* borrow: leading with the network graph viz. They photograph well, mostly underperform a good filtered list.
+
+## Entity model (proposed)
+
+Three peers to Proceeding, plus two I'd argue belong in v1:
+
+- **Member** — canonical key is Bioguide ID
+- **Bill** — keyed by `(congress, bill_type, bill_number)`
+- **Vote** — keyed by `(chamber, congress, session, roll_number)`
+- **Committee** — the *path* of a bill (referred-to → markup → reported-out) is most of the legislative story
+- **Amendment** — often the real news is the amendment, not the underlying bill
+
+Edges:
+
+- Member `sponsored` Bill, `cosponsored` Bill, `voted-position` Vote
+- Bill `referred-to` Committee, `amended-by` Amendment, `subject-of` Vote
+- Member `sits-on` Committee (time-bounded, chair/ranking-member role)
+- Vote `determines-outcome-on` Bill/Amendment
+
+Bridge to existing Concord state:
+
+- Mention edges from Proceeding → Member / Bill — this is the current Stage 3 "Enrich" stage from [CONTEXT.md](../../CONTEXT.md), extracted from proceeding text
+
+## How this slots into the existing pipeline
+
+The current pipeline is *one source* (api.congress.gov /congressional-record) → *one entity* (Proceeding). The proposal expands to *multiple sources* (/member, /bill, /committee, /amendment, /house-vote, /senate-vote) → *multiple peer entities*. That's a real architectural shift, not just an extension of Stage 3.
+
+Two ways to slot it in:
+
+1. **Parallel pipelines, shared DB.** Each entity type gets its own Stage 0 + Stage 1. Stage 2 (Index) and Stage 3 (Enrich) operate across the unified DB.
+2. **Generalize the existing stages.** Stage 0 becomes "scrape any congress.gov endpoint to JSONL"; Stage 1 becomes "load JSONL → typed tables".
+
+Tension to resolve: Proceedings are immutable once published (granule_id is a stable PK, JSONL is append-only per [ADR 0002](../adr/0002-jsonl-as-canonical-raw-store.md)). Bills *mutate* — they get amended, change status, accumulate cosponsors. The append-only contract doesn't trivially carry over. Option 1 lets Bills/Votes have a different storage contract without retrofitting Proceedings.
+
+## What api.congress.gov gives you, and what it doesn't
+
+**Have:** `/member`, `/bill`, `/committee`, `/amendment`, `/house-vote`, `/senate-vote`. Bills carry sponsor/cosponsor lists. Members carry full term history.
+
+**Thin or missing:**
+
+- Full **roll-call detail** is cleaner from clerk.house.gov / senate.gov bulk XML than from the API
+- No **campaign finance** — FEC API + OpenSecrets fill that gap (the EpsteinExposed "Flights" equivalent — a public-data money trail tied to people)
+- No **lobbying disclosures** — LDA filings via House + Senate clerk
+- No first-class **news coverage** — but if this is ever Post-adjacent, that's the unique-to-Post advantage
+
+## Surfacing patterns, in increasing ambition
+
+1. **Entity pages with hard cross-linking.** Member page = profile + sponsored/cosponsored + recent votes + committees + party-line alignment. Bill page = sponsors + cosponsor list + vote history + committee path. Underrated; ships fast.
+2. **Bill lifecycle timeline.** Intro → committee → markup → floor → other chamber → conference → signature. Highly visual.
+3. **Pre-computed dossiers.** "Members who broke with party >5x last quarter on healthcare." This is the kind of thing journalists actually want.
+4. **Network visualizations.** Cosponsorship + committee co-membership. Earn them with a *specific* multi-hop question.
+5. **Conversational layer.** RAG over bill text + the Congressional Record (Concord already has the latter indexed per [ADR 0005](../adr/0005-chunks-as-unit-of-retrieval.md)). TableRAG fits roll-call tables almost perfectly.
+6. **Alerts/subscriptions.** "Tell me when Senator X votes against party."
+
+## Storage
+
+SQLite + FKs + materialized views gets you 90% of "knowledge graph" before you need a graph DB. Don't migrate off SQLite ([ADR 0003](../adr/0003-sqlite-as-derived-store.md)) prematurely. The threshold is when >2-hop traversals become load-bearing — "members who cosponsored together >N times across bills of topic X" type queries. At that point: Apache AGE on Postgres, or a separate Neo4j store.
+
+## Risks / tradeoffs to flag explicitly
+
+- **Staleness.** Congress moves daily. Ingest has to be solid before the surface goes public, or trust evaporates on the first stale vote count.
+- **Editorial neutrality.** EpsteinExposed has a baked-in political valence; that's appropriate for its topic. A congressional product has to be politically neutral by construction. Affects ranking algorithms, "most connected" lists, dossier templates.
+- **Mutability mismatch.** Proceedings are immutable; Bills mutate. The storage contract for the latter has to handle versioning / state transitions.
+- **Viz-vs-utility.** Network graphs photograph well, mostly underperform a good filtered list. Resist leading with them.
+
+## Open questions (the conversation to continue)
+
+1. **Audience and surface.** Internal tool? Public site? A feature inside an existing product?
+2. **Historical depth.** Current Congress only, or back to 1995 (the CREC floor)?
+3. **Bill *text* in v1, or metadata only?** Bill text + RAG is interesting given Concord's existing vector infra; also expensive.
+4. **Money trails (FEC, lobbying)** in or out of scope?
+5. **Federal only, or state legislatures too?**
+6. **Does this stay in the Concord repo, or fork into a new project?** "Concord" implies records of proceedings; expanding scope may warrant a different framing where Concord becomes one of several ingest paths.
+
+## How to pick this up
+
+Start a fresh session in `~/code/concord` and open this file. The wrap session left off at the open questions — that's the natural place to resume.

--- a/docs/plans/phase-1-members.md
+++ b/docs/plans/phase-1-members.md
@@ -1,0 +1,333 @@
+# Phase 1 — Members ingest
+
+> Ingest U.S. Congress Member records from api.congress.gov into Concord, surface them on the public web app as browseable profiles, and federate Members into the existing `/search` route alongside Proceedings.
+
+## Source
+
+- Roadmap: [docs/plans/members-bills-votes-roadmap.md](./members-bills-votes-roadmap.md) (Phase 1 section)
+- Scoping conversation: [docs/plans/members-bills-votes-scope.md](./members-bills-votes-scope.md)
+
+## Context
+
+Concord today ingests one entity type — **Proceedings** (articles from the Congressional Record) — and surfaces them via `/search` and `/proceedings/{granule_id}` on a FastAPI+HTMX site ([CONTEXT.md](../../CONTEXT.md), [ADR 0001](../adr/0001-python-end-to-end-for-the-web-layer.md)). Phase 1 is the first step in expanding to the broader Congress domain: **Member** records (people who have served in Congress) become Concord's first peer entity to Proceedings.
+
+Members are chosen first because they are (a) the smallest entity in the planned set, (b) almost entirely stable (Bioguide IDs are immutable; term history changes rarely), and (c) the prerequisite for every later phase — Bills cite sponsors, Votes cite per-member positions, Stage 3 Enrichment mentions members in Proceeding text. Shipping Members early de-risks the architectural shift to multi-entity ingest before the harder mutable entities (Bills, Votes) arrive.
+
+Domain terms (Member, Bioguide ID, Term, Chamber, Party) are defined in the "Entities" section of [CONTEXT.md](../../CONTEXT.md), added as part of this plan's grilling pass.
+
+## Goals
+
+1. The scraper can fetch all Members for the last three congresses (117th, 118th, 119th) from `api.congress.gov/v3/member` and persist them to `data/members.jsonl` using the snapshot-on-fetch envelope from [ADR 0006](../adr/0006-snapshot-on-fetch-for-mutable-entities.md).
+2. The loader projects the latest snapshot per Bioguide ID into a `members` table and per `(bioguide_id, congress, chamber)` into a `member_terms` table in `data/proceedings.db`.
+3. The indexer populates a `members_fts` FTS5 virtual table over Member names so the search box can resolve names.
+4. The web app serves `/members` (browseable list with filters) and `/members/{bioguide_id}` (profile page).
+5. The existing `/search` route is federated: it queries both the existing chunks pipeline (Proceedings) and `members_fts` (Members) and renders results in two grouped sections with inline checkbox filters.
+6. The CLI is renamed for entity-explicit verbs per [ADR 0007](../adr/0007-parallel-pipelines-per-entity.md): `concord pull` → `concord scrape proceedings`, `load` → `load proceedings`, `index` → `index proceedings`, `run` → `run proceedings`. New commands: `concord scrape members`, `load members`, `index members`, `run members`.
+7. The code layout matches ADR 0007 literally: `src/concord/scraper/{proceedings,members}.py` and `src/concord/pipeline/{load,index}_{proceedings,members}.py` subpackages.
+8. All existing tests continue to pass after the CLI rename and subpackage refactor.
+
+## Non-goals
+
+1. **Bill text RAG, Votes, Committees, Amendments** — those are Phases 2–5. The `/members/{bioguide_id}` profile page renders placeholder sections for them, but the data isn't ingested.
+2. **Mentions of Members in Proceeding text.** That's Phase 6 (Stage 3 Enrich). The profile page has a placeholder section for it.
+3. **Backfill to 1995.** Phase 1 ingests the last three congresses only (roadmap scope decision).
+4. **Embeddings on Member names.** Name search uses FTS5 only ([Q3 grilling outcome](#approach)); semantic similarity over names isn't useful.
+5. **Curated nickname/initialism aliases** (no "AOC" → Ocasio-Cortez mapping at v1). The API's name fields only. Curated aliases are a tiny follow-up after real traffic surfaces the demand.
+6. **Per-state or per-district detail pages** (`/states/VT`, `/districts/CA-12`). `/members?state=VT` covers the use case via the index page's filter.
+7. **Auto-release / cron scheduling for daily refresh.** The plan lands the commands; wiring them into a scheduler is a separate task.
+8. **A `members_raw` SQLite table** holding raw API payloads. The JSONL is the recovery substrate per [ADR 0006](../adr/0006-snapshot-on-fetch-for-mutable-entities.md); duplicating snapshots into SQL adds maintenance without unlocking anything `jq` can't do.
+
+## Relevant prior decisions
+
+- [ADR 0001 — Python end-to-end for the web layer](../adr/0001-python-end-to-end-for-the-web-layer.md) — defines the FastAPI+Jinja2+HTMX surface that `/members` and `/members/{bioguide_id}` extend.
+- [ADR 0002 — JSONL as canonical raw store](../adr/0002-jsonl-as-canonical-raw-store.md) — Members go to `data/members.jsonl`.
+- [ADR 0003 — SQLite as derived store](../adr/0003-sqlite-as-derived-store.md) — Members tables live in the existing `proceedings.db`.
+- [ADR 0005 — Chunks as the unit of retrieval](../adr/0005-chunks-as-unit-of-retrieval.md) — does **not** apply to Members; member name search uses its own FTS5 table, not chunks.
+- [ADR 0006 — Snapshot-on-fetch for mutable entities](../adr/0006-snapshot-on-fetch-for-mutable-entities.md) (new, created with this plan's parent roadmap) — defines the JSONL envelope shape for Members.
+- [ADR 0007 — Parallel Stage 0 + Stage 1 per entity type](../adr/0007-parallel-pipelines-per-entity.md) (new) — defines the per-entity subpackage layout and CLI verb shape.
+- [ADR 0008 — Chunks generalize beyond Proceedings](../adr/0008-chunks-generalize-beyond-proceedings.md) (new) — **not exercised by Phase 1** (Members aren't chunked); referenced for completeness because Phase 5 will require the chunks-table migration this ADR specifies.
+
+## Relevant files and code
+
+Files to **read** for context:
+
+- [CONTEXT.md](../../CONTEXT.md) — domain glossary, including the new "Entities" section.
+- [src/concord/cli.py](../../src/concord/cli.py) — current typer CLI with `pull`/`load`/`index`/`run`/`serve` commands at lines 287, 371, 410, 440, 523.
+- [src/concord/api.py](../../src/concord/api.py) — congress.gov HTTP client. The pagination + auth + retry patterns to mirror for the new `/member` calls.
+- [src/concord/models.py](../../src/concord/models.py) — pydantic patterns to follow for the new `Member` and `Term` models.
+- [src/concord/pipeline.py](../../src/concord/pipeline.py) — Stage 1 loader to be moved into `src/concord/pipeline/load_proceedings.py`.
+- [src/concord/indexing.py](../../src/concord/indexing.py) — Stage 2 indexer to be moved into `src/concord/pipeline/index_proceedings.py`.
+- [src/concord/storage/sqlite.py](../../src/concord/storage/sqlite.py) — existing schema, lines 60–134. New `members`/`member_terms`/`members_fts` schema goes alongside.
+- [src/concord/web/app.py](../../src/concord/web/app.py) — FastAPI app; existing routes at lines 125, 131, 189, 207. New `/members*` routes added here.
+- [src/concord/web/search.py](../../src/concord/web/search.py) — existing search query layer; will be extended for federated Member+Proceeding search.
+- [tests/conftest.py](../../tests/conftest.py) — fixture helpers (`load_fixture`, `load_json_fixture`).
+- [tests/test_storage_sqlite.py](../../tests/test_storage_sqlite.py) and [tests/test_pipeline.py](../../tests/test_pipeline.py) — test patterns to mirror.
+
+Files to **create**:
+
+- `src/concord/scraper/__init__.py`
+- `src/concord/scraper/proceedings.py` (extracted from `cli.py` + `api.py`)
+- `src/concord/scraper/members.py`
+- `src/concord/pipeline/__init__.py`
+- `src/concord/pipeline/load_proceedings.py` (moved from `pipeline.py`)
+- `src/concord/pipeline/load_members.py`
+- `src/concord/pipeline/index_proceedings.py` (moved from `indexing.py`)
+- `src/concord/pipeline/index_members.py`
+- `src/concord/web/templates/members/list.html`
+- `src/concord/web/templates/members/profile.html`
+- `tests/_snapshots.py` — shared helper for the ADR 0006 envelope shape.
+- `tests/fixtures/api/members/current_house.json`
+- `tests/fixtures/api/members/current_senate.json`
+- `tests/fixtures/api/members/historical.json`
+- `tests/test_models_members.py`
+- `tests/test_storage_members_sqlite.py`
+- `tests/test_scraper_members.py`
+- `tests/test_pipeline_members.py`
+- `tests/test_web_members.py`
+
+Files to **delete** (after moves):
+
+- `src/concord/pipeline.py` (contents moved to `src/concord/pipeline/load_proceedings.py` and any orchestration into `src/concord/pipeline/__init__.py`)
+- `src/concord/indexing.py` (moved to `src/concord/pipeline/index_proceedings.py`)
+
+## Approach
+
+### Domain model
+
+`Member` is per-person (fields stable across a career); `Term` is per-service-period. Splitting them avoids lying about historical state: a Member who was a Republican in one Congress and an Independent in the next has two Term rows with different `party` values. The same applies to Chamber — a Representative who later becomes a Senator has two Terms in different chambers, not a contradictory single Member record. (See [CONTEXT.md](../../CONTEXT.md) "Entities" section.)
+
+`is_current` is computed, not stored: `end_date IS NULL OR end_date >= date('now')`. No nightly maintenance job to flip a boolean.
+
+### Storage shape
+
+`data/members.jsonl` follows [ADR 0006](../adr/0006-snapshot-on-fetch-for-mutable-entities.md):
+
+```json
+{"fetched_at": "2026-05-25T14:02:11Z", "key": {"bioguide_id": "O000172"}, "payload": {...raw API body...}}
+```
+
+SQLite schema (new, added to `src/concord/storage/sqlite.py`):
+
+```sql
+CREATE TABLE IF NOT EXISTS members (
+  bioguide_id  TEXT PRIMARY KEY,
+  first_name   TEXT NOT NULL,
+  middle_name  TEXT,
+  last_name    TEXT NOT NULL,
+  suffix       TEXT,
+  birth_year   INTEGER,
+  death_year   INTEGER,
+  display_name TEXT NOT NULL,   -- API's directOrderName
+  photo_url    TEXT,             -- API's depiction.imageUrl
+  biography    TEXT,             -- free-text biography
+  fetched_at   TEXT NOT NULL     -- ISO-8601 UTC, latest snapshot's timestamp
+);
+
+CREATE TABLE IF NOT EXISTS member_terms (
+  bioguide_id TEXT NOT NULL REFERENCES members(bioguide_id),
+  congress    INTEGER NOT NULL,
+  chamber     TEXT NOT NULL CHECK (chamber IN ('house', 'senate')),
+  party       TEXT,
+  state       TEXT NOT NULL,
+  district    INTEGER,           -- NULL for senators
+  start_date  TEXT,
+  end_date    TEXT,              -- NULL = currently serving
+  PRIMARY KEY (bioguide_id, congress, chamber)
+);
+
+CREATE INDEX IF NOT EXISTS idx_member_terms_congress ON member_terms(congress);
+CREATE INDEX IF NOT EXISTS idx_member_terms_state ON member_terms(state);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS members_fts USING fts5(
+  bioguide_id UNINDEXED,
+  direct_order_name,
+  inverted_order_name,
+  last_name,
+  tokenize = 'porter'
+);
+```
+
+Name search uses FTS5 only — no embeddings. Embeddings over short proper nouns don't add over BM25 + porter stemming.
+
+### Federated search
+
+The existing `/search` route runs RRF over `chunks_fts` + `chunks_vec` for Proceedings. Phase 1 extends it to also query `members_fts` independently. Results render in two stacked sections: **Members (N)** with profile cards (photo, display name, current role), then **Proceedings (N)** with the existing snippet list. Score normalization across the two indexes is **not** attempted — each section uses its own ranking, which is honest about the data shapes and defers the harder unified-ranking problem to Phase 7.
+
+Filters above the results: `☑ Members  ☑ Proceedings` checkboxes. Unchecking suppresses that section and skips its query. Inline (above the results), not in a sidebar.
+
+`/members` itself has no search box — users searching by name use the global `/search`. The `/members` index is browse-only: paginated currently-serving list with **Chamber** (House/Senate/both) and **Party** (D/R/I/other) filter checkboxes, sorted `(state ASC, last_name ASC)`. Default page size: 50.
+
+### Disambiguation
+
+When `members_fts` returns multiple hits for an ambiguous query (`"Sanders"` matches several Members), results are ordered `(is_current DESC, last_active_congress DESC)` so the recognizable contemporary Sanders surfaces first. `last_active_congress` is computed as `MAX(congress) FROM member_terms WHERE bioguide_id = ?`.
+
+### CLI rename
+
+The rename pattern from [ADR 0007](../adr/0007-parallel-pipelines-per-entity.md) is `<stage> <entity>`. Applies to stage commands only:
+
+| Old | New |
+|---|---|
+| `concord pull` | `concord scrape proceedings` |
+| `concord load` | `concord load proceedings` |
+| `concord index` | `concord index proceedings` |
+| `concord run` | `concord run proceedings` |
+| `concord serve` | unchanged (not stage-scoped) |
+
+Plus new commands: `concord scrape members`, `concord load members`, `concord index members`, `concord run members`.
+
+Bare verbs are deleted, not aliased — the muscle-memory cost is bounded and one-time.
+
+### Subpackage refactor
+
+Per the Q7 grilling decision (Option A): honor [ADR 0007](../adr/0007-parallel-pipelines-per-entity.md) literally. `src/concord/scraper/` and `src/concord/pipeline/` become subpackages. Existing Proceedings logic moves into them. This is real but bounded work — the alternative (flat modules with prefix naming) would leave the codebase shape out of step with the ADR from day one.
+
+### Snapshot envelope helper
+
+`tests/_snapshots.py` exports a small helper used by every entity test module from Phase 1 onward:
+
+```python
+def wrap_snapshot(payload: dict, *, fetched_at: datetime, key: dict) -> dict:
+    return {"fetched_at": fetched_at.isoformat(), "key": key, "payload": payload}
+```
+
+Lands now (Phase 1 needs it) and is reused unchanged by Phase 2's Bills tests, Phase 3's Votes tests, etc.
+
+## Step-by-step plan
+
+The plan is grouped into five sections — **Refactor**, **Models & storage**, **Ingest**, **Web surface**, **Verification**. Steps within each section are ordered; sections are loosely orderable but the refactor must land before the new entity work to avoid moving moving-targets.
+
+### Section 1 — Subpackage refactor (do this first)
+
+1. **Create `src/concord/scraper/` subpackage.** Add empty `src/concord/scraper/__init__.py`. Create `src/concord/scraper/proceedings.py` and move the scrape-orchestration helper `_run_pull` from `src/concord/cli.py:113` into it as a public `scrape(...)` function. The pure HTTP client code stays in `src/concord/api.py` (it's a transport, not a scraper). Verify: `python -c "from concord.scraper.proceedings import scrape"` succeeds.
+
+2. **Create `src/concord/pipeline/` subpackage.** Add `src/concord/pipeline/__init__.py`. Move `src/concord/pipeline.py` → `src/concord/pipeline/load_proceedings.py`. Move `src/concord/indexing.py` → `src/concord/pipeline/index_proceedings.py`. Delete the old flat files. Update every import site (tests, cli) to the new paths. Verify: `pytest tests/test_pipeline.py tests/test_indexing.py` passes unchanged.
+
+3. **Rename existing CLI commands.** In `src/concord/cli.py`: rename `@app.command("pull")` → `@app.command("scrape proceedings")` (using typer subcommand groups; see typer docs for the `add_typer` pattern). Same for `load` → `load proceedings`, `index` → `index proceedings`, `run` → `run proceedings`. `serve` is unchanged. Update help strings and docstrings throughout `cli.py` to reflect new names. Verify: `concord scrape proceedings --help` works; bare `concord pull` errors with typer's "no such command".
+
+4. **Update existing tests for the CLI rename.** Edit `tests/test_cli.py` to invoke `scrape proceedings`, `load proceedings`, etc. Verify: `pytest tests/test_cli.py` passes.
+
+### Section 2 — Models & storage
+
+5. **Add `Member` and `Term` pydantic models.** Extend `src/concord/models.py` with `Member`, `Term`, and `MemberSnapshot` (envelope wrapper per ADR 0006). Match the schema in [Approach > Storage shape](#approach), with API-field aliases (`directOrderName` → `display_name`, `depiction.imageUrl` → `photo_url`, etc.) mirroring the `Issue`/`Article` aliasing pattern at `src/concord/models.py:42-72`. Keep these in the same file for now — if `models.py` later exceeds ~400 lines, promote to a `src/concord/models/` subpackage in a separate refactor. Verify: `pytest tests/test_models_members.py` (created next step) passes.
+
+6. **Write unit tests for the models.** Create `tests/test_models_members.py`. Cover: parsing a real API payload (use `current_house.json` fixture from step 13), the snapshot envelope wrapping, and serialization round-trip. Mirror the structure of `tests/test_models.py`.
+
+7. **Add `members`, `member_terms`, `members_fts` schema.** Edit `src/concord/storage/sqlite.py` to append the three table definitions from [Approach > Storage shape](#approach) to the existing `_SCHEMA` constant (currently around line 60). The existing init function will apply them on next open. Verify: open a fresh DB, run `.schema members*` in `sqlite3`, see all three tables.
+
+8. **Write storage tests for the new tables.** Create `tests/test_storage_members_sqlite.py` mirroring `tests/test_storage_sqlite.py`. Cover: insert + read-back of a Member with multiple Terms, conflict-on-duplicate-key behavior (snapshot-on-fetch means re-loading the same member must replace, not duplicate — UPSERT on Bioguide ID).
+
+### Section 3 — Ingest
+
+9. **Build the `/member` API client method.** Extend `src/concord/api.py`'s `Client` class with a `list_members(congress: int) -> Iterator[dict]` method that paginates `GET /v3/member/congress/{congress}` using the same auth + retry + rate-limit logic as the existing `list_issues` method. Return raw dicts; parsing into `Member` happens at the next layer. Verify: `tests/test_api.py` gains a test using a captured `/member` fixture and `httpx.MockTransport`.
+
+10. **Build the Members scraper.** Create `src/concord/scraper/members.py` with a `scrape(client, congresses: list[int], storage_path: Path, *, fetched_at: datetime) -> int` function. For each congress, page through `client.list_members(congress)`, wrap each member dict in a snapshot envelope (`{fetched_at, key, payload}`), and append to `data/members.jsonl`. Return the number of snapshots written. Note: a member who served in multiple congresses will get one snapshot per congress that lists them — Stage 1 deduplicates by Bioguide ID.
+
+11. **Build the Members loader.** Create `src/concord/pipeline/load_members.py` with a `load(jsonl_path: Path, db_path: Path) -> LoadStats` function. Read snapshots, group by `bioguide_id`, keep latest by `fetched_at`. For each kept snapshot: UPSERT a row into `members`, then DELETE-then-INSERT `member_terms` rows for that bioguide_id (avoids stale terms if the API ever drops one). Verify with `tests/test_pipeline_members.py` (next step).
+
+12. **Build the Members FTS5 indexer.** Create `src/concord/pipeline/index_members.py` with `index(db_path: Path) -> IndexStats`. Truncate `members_fts`, repopulate by selecting `(bioguide_id, display_name AS direct_order_name, ..., last_name)` from `members`. Idempotent — re-running gives the same final state.
+
+13. **Capture API fixtures.** Run a real `/member` call (with `CONGRESS_API_KEY` set) for three members and save the raw JSON to `tests/fixtures/api/members/`:
+    - `current_house.json` — a currently-serving Representative with at least 2 Terms.
+    - `current_senate.json` — a currently-serving Senator.
+    - `historical.json` — a former member with `end_date` populated and ideally a party change between terms.
+
+14. **Write scraper + loader integration tests.** Create `tests/test_scraper_members.py` (uses `httpx.MockTransport` with the captured fixtures to drive `scrape()` end-to-end) and `tests/test_pipeline_members.py` (loads the resulting JSONL into an in-memory SQLite and asserts the table contents).
+
+15. **Add `tests/_snapshots.py` helper.** Export `wrap_snapshot(payload, *, fetched_at, key)` as in [Approach](#approach). Update the tests written in steps 6, 8, 14 to use it instead of inlining envelope dicts.
+
+### Section 4 — CLI commands for Members
+
+16. **Add `concord scrape members` command.** In `src/concord/cli.py`, register a new typer command at `scrape members` that takes `--congresses` (default: `117,118,119`), `--storage` (default: `data/members.jsonl`), and calls `concord.scraper.members.scrape(...)`. Mirror the option shape of `scrape proceedings`. Verify: `concord scrape members --help` shows the help text; smoke test in `tests/test_cli.py`.
+
+17. **Add `concord load members` command.** Wires to `concord.pipeline.load_members.load(...)`. Same `--storage` / `--db` option pattern as `load proceedings`.
+
+18. **Add `concord index members` command.** Wires to `concord.pipeline.index_members.index(...)`.
+
+19. **Add `concord run members` command.** Mirrors `concord run proceedings` (step in step 3): chains `scrape members` → `load members` → `index members`. Useful for the cron path later.
+
+### Section 5 — Web surface
+
+20. **Add `/members` route.** In `src/concord/web/app.py`, add a `GET /members` handler that:
+    - Reads query params `chamber` (default both), `party` (default all), `page` (default 1).
+    - Queries `members` JOINed against `member_terms` for current terms only (`end_date IS NULL OR end_date >= date('now')`).
+    - Applies chamber + party filters.
+    - Orders by `(state ASC, last_name ASC)`, paginates 50/page.
+    - Renders `src/concord/web/templates/members/list.html`.
+
+21. **Add `/members/{bioguide_id}` route.** Handler queries one Member + all its Terms, renders `src/concord/web/templates/members/profile.html`. Sections: header (photo, name, current-role line, `fetched_at` tag), Biography (collapsed if >300 chars — pure HTMX, no JS framework), Term history table, future-phase placeholder sections labeled "Sponsored bills (Phase 2)", "Recent votes (Phase 3)", "Mentioned in proceedings (Phase 6)". Placeholders render as muted empty-state boxes — no dead links.
+
+22. **Add Member-aware search to `src/concord/web/search.py`.** Add a `search_members(db, q: str, limit: int = 10) -> list[MemberHit]` function: runs `SELECT ... FROM members_fts WHERE members_fts MATCH ? ORDER BY bm25(members_fts)`, joins to `members` for display fields, joins to `member_terms` for `MAX(congress) AS last_active_congress`, applies the disambiguation sort `(is_current DESC, last_active_congress DESC)`. Returns hits as a structured type.
+
+23. **Federate `/search`.** Update the `GET /search` handler in `src/concord/web/app.py` to:
+    - Read new query params `members` and `proceedings` (both default `on`).
+    - Run `search_members` and the existing proceedings search in parallel (or sequentially — performance isn't load-bearing at v1 scale).
+    - Render results in two grouped sections in the template.
+    - Render inline filter checkboxes above the results.
+
+24. **Update the global nav.** Add a `/members` link to whatever shared nav fragment the existing templates use (likely in a `base.html` or similar). Verify by clicking through from `/` to `/members` and back.
+
+### Section 6 — Verification
+
+25. **End-to-end smoke test.** Create or extend `tests/test_smoke.py` (existing file) with a scenario that: writes 3 snapshots to a temp JSONL, runs `load_members.load()` + `index_members.index()`, opens the web app via `httpx.ASGITransport`, hits `/members`, `/members/{id}`, and `/search?q=<member name>`, asserts a 200 and presence of expected text on each.
+
+26. **Update ADR 0007 with a clarifying note (optional).** Decided during the Q7 grilling that the literal subpackage paths in the ADR are authoritative. If during execution the subpackage refactor (Section 1) reveals any deviation, append a one-paragraph note to [ADR 0007](../adr/0007-parallel-pipelines-per-entity.md) describing the reality. If the refactor lands cleanly with no deviation, this step is a no-op.
+
+27. **Run the full test suite + a manual smoke against live data.** `pytest` clean. Then with real keys set: `concord run proceedings --from <recent-date>` (regression check for the rename), then `concord run members --congresses 119`, then `concord serve` and click through `/members` + `/search?q=<known senator surname>`.
+
+## Demo seed data
+
+This project does not have a `backend/demo/seed.sql` (the template's example) — it's a Python project that derives its demo state from `data/proceedings.jsonl` and `data/proceedings.db`. The Phase 1 equivalent: after step 27 lands, the user runs `concord run members --congresses 119` once locally to populate `data/members.jsonl` and the new SQLite tables. No checked-in seed file to update.
+
+If a future phase introduces a `data/demo/*.jsonl` fixture pattern for fresh-clone demo state, this plan's outputs should be included in it. Out of scope for Phase 1.
+
+## Testing strategy
+
+**Unit tests:**
+
+- `tests/test_models_members.py` — parsing real API payloads into `Member`/`Term`, snapshot-envelope round-trip.
+- `tests/test_storage_members_sqlite.py` — UPSERT behavior for Members, DELETE-then-INSERT for Terms, FTS5 population.
+- `tests/test_scraper_members.py` — `httpx.MockTransport` driving the scraper end-to-end against fixtures.
+- `tests/test_pipeline_members.py` — JSONL → SQLite projection, including latest-snapshot-wins semantics.
+- `tests/test_web_members.py` — `/members` (with each filter combo), `/members/{id}` (existing + 404), `/search?q=…` with the new federated layout.
+
+**Integration test:**
+
+- Extend `tests/test_smoke.py` per step 25.
+
+**Manual checks (frontend has no component tests per [ADR 0001](../adr/0001-python-end-to-end-for-the-web-layer.md)):**
+
+- `/members` renders, pagination works, both filter checkboxes work in combination.
+- `/members/{bioguide_id}` for a known House member, a known Senator, and a known historical member. Photo loads, biography collapse works, term history table is in chronological order.
+- `/search?q=Sanders` shows both a Members section (multiple Sanders) and a Proceedings section.
+- `/search?q=Sanders&members=on&proceedings=` shows only Members.
+- `/search?q=infrastructure spending&members=&proceedings=on` shows only Proceedings (regression check for the existing flow).
+
+**Regression risk:**
+
+- All of `tests/test_pipeline.py`, `tests/test_indexing.py`, `tests/test_cli.py`, `tests/test_web_routes.py`, `tests/test_web_search.py` must continue to pass after the Section 1 refactor. These tests reference old module paths (`concord.pipeline`, `concord.indexing`) and old CLI command names (`pull`, `load`, `index`, `run`); updating imports and command invocations is part of Section 1.
+
+## Acceptance criteria
+
+- [ ] `concord scrape members --congresses 119 --storage /tmp/members.jsonl` writes a non-empty JSONL with the ADR 0006 envelope shape.
+- [ ] `concord load members --storage /tmp/members.jsonl --db /tmp/test.db` populates `members` and `member_terms` tables with the right row counts.
+- [ ] `concord index members --db /tmp/test.db` populates `members_fts` with one row per Member.
+- [ ] `concord run members --congresses 119` does all three in one shot.
+- [ ] `concord scrape proceedings --from 2026-05-20` works (regression check for the rename).
+- [ ] `concord pull` (the old bare verb) errors with typer's "no such command".
+- [ ] `pytest` passes (full suite, ~all existing tests + new ones from this plan).
+- [ ] `GET /members` returns 200, renders a list, filters change the result set.
+- [ ] `GET /members/{bioguide_id}` returns 200 for a real Bioguide ID and 404 for an unknown one.
+- [ ] `GET /search?q=Sanders` shows two sections (Members + Proceedings); unchecking either suppresses it.
+- [ ] [CONTEXT.md](../../CONTEXT.md) has an "Entities" section with Member, Bioguide ID, Term, Chamber, Party defined (this plan's grilling already added it — confirm it didn't get reverted).
+- [ ] `tests/_snapshots.py` exists and is used by Members tests.
+- [ ] `src/concord/scraper/` and `src/concord/pipeline/` subpackages exist; `src/concord/pipeline.py` and `src/concord/indexing.py` flat files no longer exist.
+
+## Open questions
+
+None — all design decisions resolved during the grilling pass. The seven topics covered: (1) Member vocabulary, (2) schema split and field set, (3) name-alias scope, (4) CLI rename strategy and verb alignment, (5) web surface + federated `/search`, (6) test patterns + helper + fixture count, (7) subpackage vs flat module layout.
+
+## Out-of-band work
+
+- **Cron / scheduler wiring for daily refresh of `data/members.jsonl`.** Not in this plan. The roadmap's risk section calls out staleness; whoever wires Phase 2 (Bills) should consider building a shared scheduling layer that both Proceedings and Members use, rather than per-entity cron scripts.
+- **Curated alias CSV (nicknames, initialisms).** Deferred per Q3. If after a few weeks of real traffic the search logs show repeated misses for things like "AOC" or "Bernie", a small `data/member_aliases.csv` checked into the repo + a tweak to `index_members.py` to append those rows to `members_fts` is a ~1-hour follow-up.
+- **Phase 2 (Bills) implementation plan.** Should reuse the patterns established here: `src/concord/scraper/bills.py`, `src/concord/pipeline/{load,index}_bills.py`, `tests/_snapshots.py` envelope helper, `concord {scrape,load,index,run} bills` commands.

--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from types import TracebackType
 from typing import Any
 
@@ -43,6 +43,9 @@ ENV_API_KEY = "CONGRESS_API_KEY"
 #: at 250 results per page; using the max minimizes round trips on issues
 #: with hundreds of proceedings (the Senate routinely produces 100+).
 ARTICLES_PAGE_SIZE = 250
+
+#: Per-page size when walking ``/member/congress/{congress}``.
+MEMBERS_PAGE_SIZE = 250
 
 #: Cap on a single backoff delay, in seconds. Applied to both the exponential
 #: schedule and Retry-After values so a server-suggested 1-hour wait can't
@@ -174,6 +177,29 @@ class Client:
                 break
             offset += ARTICLES_PAGE_SIZE
         return out
+
+    def list_members(self, congress: int) -> Iterator[dict[str, Any]]:
+        """Yield every Member of one Congress as a raw API payload dict.
+
+        Walks ``GET /v3/member/congress/{congress}`` until ``pagination.next``
+        is absent. Returns raw dicts; structured parsing into
+        :class:`concord.models.Member` happens at the next layer per
+        ADR 0007.
+        """
+        offset = 0
+        path = f"/member/congress/{congress}"
+        while True:
+            payload = self._get(path, params={"limit": MEMBERS_PAGE_SIZE, "offset": offset})
+            page_count = 0
+            for raw in payload.get("members", []):
+                yield raw
+                page_count += 1
+            if "next" not in payload.get("pagination", {}):
+                return
+            if page_count == 0:
+                # Defensive: server advertises "next" but returned nothing.
+                return
+            offset += MEMBERS_PAGE_SIZE
 
     # -- internals -----------------------------------------------------------
 

--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -47,7 +47,6 @@ from .embedding import Embedder
 from .models import Proceeding
 from .pipeline.index_proceedings import IndexResult, index
 from .pipeline.index_proceedings import ProgressEvent as IndexProgressEvent
-from .pipeline.load_proceedings import ProgressEvent, PullResult, pull
 from .scraper.proceedings import scrape as scrape_proceedings_runner
 from .storage import JsonlStorage, MongoStorage, SqliteStorage
 from .storage.base import Storage
@@ -200,9 +199,7 @@ def _parse_congresses(raw: str) -> list[int]:
         try:
             out.append(int(token))
         except ValueError as exc:
-            raise typer.BadParameter(
-                f"expected comma-separated integers, got {raw!r}"
-            ) from exc
+            raise typer.BadParameter(f"expected comma-separated integers, got {raw!r}") from exc
     if not out:
         raise typer.BadParameter(f"no congresses parsed from {raw!r}")
     return out

--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -1,21 +1,29 @@
 """Command-line interface for Concord.
 
-Subcommands:
+Subcommands follow the pattern ``concord <stage> <entity>``:
 
-- ``concord pull``  — Stage 0. Scrape api.congress.gov + congress.gov into
-  the canonical JSONL store.
-- ``concord load``  — Stage 1. Mirror the JSONL into a ``proceedings`` table
-  in SQLite. Idempotent on ``granule_id``.
-- ``concord index`` — Stage 2. Chunk + embed every proceeding into FTS5 and
-  ``sqlite-vec`` indexes. Idempotent per chunk and per embedding.
-- ``concord run``   — Run all three stages back-to-back.
-- ``concord serve`` — Web layer. Run the FastAPI search demo via uvicorn.
+- ``concord scrape proceedings`` — Stage 0. Scrape api.congress.gov +
+  congress.gov into the canonical JSONL store.
+- ``concord load proceedings``   — Stage 1. Mirror the JSONL into a
+  ``proceedings`` table in SQLite. Idempotent on ``granule_id``.
+- ``concord index proceedings``  — Stage 2. Chunk + embed every
+  proceeding into FTS5 and ``sqlite-vec`` indexes. Idempotent per chunk
+  and per embedding.
+- ``concord run proceedings``    — Run all three stages back-to-back.
+
+The same shape applies to Members:
+
+- ``concord scrape members`` / ``concord load members`` /
+  ``concord index members`` / ``concord run members``.
+
+``concord serve`` is unchanged — it isn't stage-scoped.
 
 Default paths:
 
-- ``--storage`` (pull, run): ``./data/proceedings.jsonl``
+- ``--storage`` (scrape, run): ``./data/proceedings.jsonl`` /
+  ``./data/members.jsonl``
 - ``--db``      (load, index, run, serve): ``./data/proceedings.db``
-- ``--to``      (pull, run): today's date (UTC)
+- ``--to``      (scrape proceedings, run proceedings): today's date (UTC)
 
 Progress is on by default for long-running commands (``--no-progress``
 to disable). Output goes to stderr so success summaries on stdout stay
@@ -29,36 +37,35 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Annotated
 
-import httpx
 import typer
 from pydantic import ValidationError
 
-from .api import ENV_API_KEY, ApiError, Client
+from .api import ENV_API_KEY, Client
 from .chunking import Chunker
 from .embedding import Embedder
-from .indexing import IndexResult, index
-from .indexing import ProgressEvent as IndexProgressEvent
 from .models import Proceeding
-from .pipeline import ProgressEvent, PullResult, pull
+from .pipeline.index_proceedings import IndexResult, index
+from .pipeline.index_proceedings import ProgressEvent as IndexProgressEvent
+from .pipeline.load_proceedings import ProgressEvent, PullResult, pull
+from .scraper.proceedings import scrape as scrape_proceedings_runner
 from .storage import JsonlStorage, MongoStorage, SqliteStorage
 from .storage.base import Storage
-from .text import fetch_text
 
 _log = logging.getLogger("concord.cli")
 
 ENV_OPENAI_API_KEY = "OPENAI_API_KEY"
-
-#: Per-request timeout (seconds) for fetching article text from congress.gov.
-#: The default httpx timeout (5s) is too aggressive for occasional slow
-#: responses and triggers transport errors that abort multi-day pulls.
-TEXT_FETCH_TIMEOUT = 60.0
 
 #: How often (in lines processed) the load command emits a progress line.
 LOAD_PROGRESS_EVERY = 100
 
 #: Default canonical store paths.
 DEFAULT_JSONL = Path("./data/proceedings.jsonl")
+DEFAULT_MEMBERS_JSONL = Path("./data/members.jsonl")
 DEFAULT_DB = Path("./data/proceedings.db")
+
+#: Congresses scraped by ``concord scrape members`` when ``--congresses``
+#: is not passed. Matches the Phase 1 roadmap scope.
+DEFAULT_MEMBER_CONGRESSES = (117, 118, 119)
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -69,14 +76,43 @@ app = typer.Typer(
     help="Concord — collect, index, and search the Congressional Record.",
 )
 
+scrape_app = typer.Typer(
+    no_args_is_help=True,
+    add_completion=False,
+    pretty_exceptions_enable=False,
+    help="Stage 0 — scrape an entity type into its canonical JSONL store.",
+)
+load_app = typer.Typer(
+    no_args_is_help=True,
+    add_completion=False,
+    pretty_exceptions_enable=False,
+    help="Stage 1 — mirror a JSONL store into SQLite tables.",
+)
+index_app = typer.Typer(
+    no_args_is_help=True,
+    add_completion=False,
+    pretty_exceptions_enable=False,
+    help="Stage 2 — populate derived indexes (chunks/FTS5/vectors).",
+)
+run_app = typer.Typer(
+    no_args_is_help=True,
+    add_completion=False,
+    pretty_exceptions_enable=False,
+    help="Run all stages back-to-back for one entity type.",
+)
+
+app.add_typer(scrape_app, name="scrape")
+app.add_typer(load_app, name="load")
+app.add_typer(index_app, name="index")
+app.add_typer(run_app, name="run")
+
 
 @app.callback()
 def _root() -> None:
     """Concord — Congressional Record collection pipeline.
 
     The empty callback exists so Typer treats this as a multi-command app
-    (with ``pull`` as a real subcommand) rather than collapsing the lone
-    command into the root.
+    rather than collapsing the lone command into the root.
     """
 
 
@@ -105,64 +141,32 @@ def _require_openai_key() -> None:
         raise typer.Exit(code=2)
 
 
+def _parse_congresses(raw: str) -> list[int]:
+    """Parse ``--congresses 117,118,119`` into ``[117, 118, 119]``."""
+    out: list[int] = []
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        try:
+            out.append(int(token))
+        except ValueError as exc:
+            raise typer.BadParameter(
+                f"expected comma-separated integers, got {raw!r}"
+            ) from exc
+    if not out:
+        raise typer.BadParameter(f"no congresses parsed from {raw!r}")
+    return out
+
+
 # ---------------------------------------------------------------------------
-# Stage workers — invoked by both `concord <stage>` and `concord run`.
+# Stage workers — invoked by both `concord <stage> <entity>` and
+# `concord run <entity>`. The proceedings scrape orchestration lives in
+# ``concord.scraper.proceedings.scrape`` (used as ``_run_pull`` here).
 # ---------------------------------------------------------------------------
 
 
-def _run_pull(
-    *,
-    start: date,
-    end: date,
-    storage: Storage,
-    storage_label: str,
-    limit: int | None,
-    show_progress: bool,
-) -> PullResult:
-    try:
-        api_client = Client()
-    except ApiError as exc:
-        typer.echo(f"error: {exc}", err=True)
-        raise typer.Exit(code=2) from exc
-
-    http_client = httpx.Client(timeout=TEXT_FETCH_TIMEOUT)
-
-    def _on_progress(event: ProgressEvent) -> None:
-        typer.echo(
-            f"{event.issue.issue_date}  "
-            f"vol {event.issue.volume} iss {event.issue.issue_number:>4}  "
-            f"+{event.issue_written:>4} written, "
-            f"{event.issue_skipped:>4} skipped, "
-            f"{event.issue_failed:>3} failed  "
-            f"(total: {event.total_written} / "
-            f"{event.total_skipped} / "
-            f"{event.total_failed})",
-            err=True,
-        )
-
-    try:
-        with api_client:
-            result = pull(
-                start,
-                end,
-                client=api_client,
-                fetch=lambda url: fetch_text(url, http_client),
-                storage=storage,
-                limit=limit,
-                progress=_on_progress if show_progress else None,
-            )
-    finally:
-        http_client.close()
-
-    summary = (
-        f"Wrote {result.written} new proceedings to {storage_label} "
-        f"(skipped {result.skipped} already present"
-    )
-    if result.failed:
-        summary += f", {result.failed} failed to fetch — will retry on next run"
-    summary += ")"
-    typer.echo(summary)
-    return result
+_run_pull = scrape_proceedings_runner
 
 
 def _run_load(
@@ -280,12 +284,95 @@ def _run_index(
 
 
 # ---------------------------------------------------------------------------
-# Subcommands
+# Members stage workers
 # ---------------------------------------------------------------------------
 
 
-@app.command("pull")
-def pull_command(
+def _run_scrape_members(
+    *,
+    congresses: list[int],
+    storage_path: Path,
+    show_progress: bool,
+) -> int:
+    from .api import ApiError
+    from .scraper import members as members_scraper
+
+    try:
+        api_client = Client()
+    except ApiError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    def _on_progress(event: members_scraper.ScrapeProgressEvent) -> None:
+        typer.echo(
+            f"congress {event.congress:>3}  "
+            f"+{event.written_in_congress:>4} written  "
+            f"(total: {event.total_written})",
+            err=True,
+        )
+
+    try:
+        with api_client:
+            written = members_scraper.scrape(
+                client=api_client,
+                congresses=congresses,
+                storage_path=storage_path,
+                fetched_at=datetime.now(UTC),
+                progress=_on_progress if show_progress else None,
+            )
+    finally:
+        # Client() owns its httpx.Client; the `with` above closed it.
+        pass
+
+    typer.echo(
+        f"Wrote {written} member snapshot(s) to {storage_path} "
+        f"across {len(congresses)} congress(es)."
+    )
+    return written
+
+
+def _run_load_members(
+    *,
+    storage_path: Path,
+    db_path: Path,
+) -> tuple[int, int]:
+    """Return ``(members_written, terms_written)``."""
+    if not storage_path.exists():
+        typer.echo(f"error: input file not found: {storage_path}", err=True)
+        raise typer.Exit(code=2)
+
+    from .pipeline.load_members import load as load_members
+
+    result = load_members(jsonl_path=storage_path, db_path=db_path)
+    typer.echo(
+        f"Loaded {result.members_written} member(s) and "
+        f"{result.terms_written} term(s) into {db_path}."
+    )
+    return result.members_written, result.terms_written
+
+
+def _run_index_members(
+    *,
+    db_path: Path,
+) -> int:
+    if not db_path.exists():
+        typer.echo(f"error: database not found: {db_path}", err=True)
+        raise typer.Exit(code=2)
+
+    from .pipeline.index_members import index as index_members
+
+    result = index_members(db_path=db_path)
+    typer.echo(f"Indexed {result.indexed_members} member(s) into members_fts.")
+    return result.indexed_members
+
+
+# ---------------------------------------------------------------------------
+# Subcommands — Proceedings
+# ---------------------------------------------------------------------------
+
+
+@scrape_app.command("proceedings")
+def scrape_proceedings_command(
     from_: Annotated[
         str,
         typer.Option(
@@ -314,7 +401,7 @@ def pull_command(
         bool,
         typer.Option(
             "--progress/--no-progress",
-            help="Print a line per issue to stderr as the pull proceeds.",
+            help="Print a line per issue to stderr as the scrape proceeds.",
         ),
     ] = True,
     mongo_uri: Annotated[
@@ -336,7 +423,7 @@ def pull_command(
         ),
     ] = "proceedings",
 ) -> None:
-    """Pull every article in every issue between --from and --to (inclusive).
+    """Scrape every article in every issue between --from and --to (inclusive).
 
     Re-running the same command after a crash, network drop, or Ctrl+C is
     safe: already-stored articles are detected by their granule ID and
@@ -368,11 +455,11 @@ def pull_command(
     )
 
 
-@app.command("load")
-def load_command(
+@load_app.command("proceedings")
+def load_proceedings_command(
     jsonl_path: Annotated[
         Path,
-        typer.Option("--jsonl", help="Input JSONL file (from `concord pull`)."),
+        typer.Option("--jsonl", help="Input JSONL file (from `concord scrape proceedings`)."),
     ] = DEFAULT_JSONL,
     db_path: Annotated[
         Path,
@@ -397,7 +484,7 @@ def load_command(
     a no-op — dedup is enforced by ``granule_id``.
 
     Schema changes are not handled by migrations; if the schema ever changes,
-    delete the SQLite file and re-run ``concord load``.
+    delete the SQLite file and re-run ``concord load proceedings``.
     """
     _run_load(
         jsonl_path=jsonl_path,
@@ -407,11 +494,11 @@ def load_command(
     )
 
 
-@app.command("index")
-def index_command(
+@index_app.command("proceedings")
+def index_proceedings_command(
     db_path: Annotated[
         Path,
-        typer.Option("--db", help="SQLite database written by `concord load`."),
+        typer.Option("--db", help="SQLite database written by `concord load proceedings`."),
     ] = DEFAULT_DB,
     limit: Annotated[
         int | None,
@@ -437,8 +524,8 @@ def index_command(
     _run_index(db_path=db_path, limit=limit, show_progress=show_progress)
 
 
-@app.command("run")
-def run_command(
+@run_app.command("proceedings")
+def run_proceedings_command(
     from_: Annotated[
         str,
         typer.Option("--from", help="Start date YYYY-MM-DD (inclusive)."),
@@ -474,25 +561,26 @@ def run_command(
         ),
     ] = True,
 ) -> None:
-    """Run all three stages: pull → load → index.
+    """Run all three stages for Proceedings: scrape → load → index.
 
-    Equivalent to ``concord pull --from … --to …`` followed by ``concord
-    load`` and ``concord index``. Convenient for daily cron jobs and for
-    one-shot backfills against fresh ``data/`` directories.
+    Equivalent to ``concord scrape proceedings --from … --to …`` followed
+    by ``concord load proceedings`` and ``concord index proceedings``.
 
     ``OPENAI_API_KEY`` and ``CONGRESS_API_KEY`` must both be set; the
     command fails fast if either is missing.
     """
-    # Fail-fast key checks before any work happens.
     if not os.environ.get(ENV_API_KEY):
-        typer.echo(f"error: {ENV_API_KEY} is not set; required for `concord pull`", err=True)
+        typer.echo(
+            f"error: {ENV_API_KEY} is not set; required for `concord scrape proceedings`",
+            err=True,
+        )
         raise typer.Exit(code=2)
     _require_openai_key()
 
     start = _parse_date(from_)
     end = _parse_date(to or _today())
 
-    typer.echo("→ Stage 0: pull", err=True)
+    typer.echo("→ Stage 0: scrape", err=True)
     _run_pull(
         start=start,
         end=end,
@@ -506,7 +594,7 @@ def run_command(
     _run_load(
         jsonl_path=storage_path,
         db_path=db_path,
-        limit=None,  # load reads from JSONL; limit only constrains the pull
+        limit=None,  # load reads from JSONL; limit only constrains the scrape
         show_progress=show_progress,
     )
 
@@ -518,6 +606,142 @@ def run_command(
     )
 
     typer.echo("✓ Done.", err=True)
+
+
+# ---------------------------------------------------------------------------
+# Subcommands — Members
+# ---------------------------------------------------------------------------
+
+
+@scrape_app.command("members")
+def scrape_members_command(
+    congresses: Annotated[
+        str,
+        typer.Option(
+            "--congresses",
+            help="Comma-separated list of congress numbers to scrape.",
+        ),
+    ] = ",".join(str(c) for c in DEFAULT_MEMBER_CONGRESSES),
+    storage_path: Annotated[
+        Path,
+        typer.Option("--storage", help="JSONL output file. Created if missing."),
+    ] = DEFAULT_MEMBERS_JSONL,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help="Print a stderr line per congress as the scrape proceeds.",
+        ),
+    ] = True,
+) -> None:
+    """Snapshot every Member of the given Congresses into JSONL.
+
+    Each fetched Member appends one snapshot line per ADR 0006:
+    ``{"fetched_at": …, "key": {"bioguide_id": …}, "payload": {…}}``.
+    Re-running the command appends new snapshots; the Stage 1 loader
+    projects the latest snapshot per Bioguide ID into SQLite.
+    """
+    parsed = _parse_congresses(congresses)
+    _run_scrape_members(
+        congresses=parsed,
+        storage_path=storage_path,
+        show_progress=show_progress,
+    )
+
+
+@load_app.command("members")
+def load_members_command(
+    storage_path: Annotated[
+        Path,
+        typer.Option("--storage", help="Input JSONL file (from `concord scrape members`)."),
+    ] = DEFAULT_MEMBERS_JSONL,
+    db_path: Annotated[
+        Path,
+        typer.Option("--db", help="SQLite database. Created if missing."),
+    ] = DEFAULT_DB,
+) -> None:
+    """Project the latest Member snapshot per Bioguide ID into SQLite.
+
+    Populates the ``members`` and ``member_terms`` tables. Re-running is
+    safe: an UPSERT on ``bioguide_id`` and DELETE-then-INSERT on Terms
+    keeps the projection consistent with the JSONL's latest snapshot.
+    """
+    _run_load_members(storage_path=storage_path, db_path=db_path)
+
+
+@index_app.command("members")
+def index_members_command(
+    db_path: Annotated[
+        Path,
+        typer.Option("--db", help="SQLite database written by `concord load members`."),
+    ] = DEFAULT_DB,
+) -> None:
+    """Populate the ``members_fts`` FTS5 virtual table.
+
+    Truncates and repopulates ``members_fts`` from the current ``members``
+    table. Idempotent — running twice gives the same final state.
+    """
+    _run_index_members(db_path=db_path)
+
+
+@run_app.command("members")
+def run_members_command(
+    congresses: Annotated[
+        str,
+        typer.Option(
+            "--congresses",
+            help="Comma-separated list of congress numbers to scrape.",
+        ),
+    ] = ",".join(str(c) for c in DEFAULT_MEMBER_CONGRESSES),
+    storage_path: Annotated[
+        Path,
+        typer.Option("--storage", help="JSONL canonical store. Created if missing."),
+    ] = DEFAULT_MEMBERS_JSONL,
+    db_path: Annotated[
+        Path,
+        typer.Option("--db", help="SQLite derived store. Created if missing."),
+    ] = DEFAULT_DB,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help="Print progress to stderr throughout all three stages.",
+        ),
+    ] = True,
+) -> None:
+    """Run all three stages for Members: scrape → load → index.
+
+    ``CONGRESS_API_KEY`` must be set. Unlike ``run proceedings``, Stage 2
+    here is FTS5-only — no OpenAI calls and no ``OPENAI_API_KEY`` required.
+    """
+    if not os.environ.get(ENV_API_KEY):
+        typer.echo(
+            f"error: {ENV_API_KEY} is not set; required for `concord scrape members`",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    parsed = _parse_congresses(congresses)
+
+    typer.echo("→ Stage 0: scrape", err=True)
+    _run_scrape_members(
+        congresses=parsed,
+        storage_path=storage_path,
+        show_progress=show_progress,
+    )
+
+    typer.echo("→ Stage 1: load", err=True)
+    _run_load_members(storage_path=storage_path, db_path=db_path)
+
+    typer.echo("→ Stage 2: index", err=True)
+    _run_index_members(db_path=db_path)
+
+    typer.echo("✓ Done.", err=True)
+
+
+# ---------------------------------------------------------------------------
+# Subcommands — Web layer (not stage-scoped)
+# ---------------------------------------------------------------------------
 
 
 @app.command("serve")
@@ -570,13 +794,14 @@ if __name__ == "__main__":  # pragma: no cover
 __all__ = [
     "DEFAULT_DB",
     "DEFAULT_JSONL",
+    "DEFAULT_MEMBERS_JSONL",
     "ENV_API_KEY",
     "ENV_OPENAI_API_KEY",
     "app",
-    "index_command",
-    "load_command",
+    "index_proceedings_command",
+    "load_proceedings_command",
     "main",
-    "pull_command",
-    "run_command",
+    "run_proceedings_command",
+    "scrape_proceedings_command",
     "serve_command",
 ]

--- a/src/concord/models.py
+++ b/src/concord/models.py
@@ -1,13 +1,21 @@
 """Pydantic models for Concord.
 
 Every value that flows between the API client, text fetcher, and storage layer
-is one of these three types. API JSON is parsed *into* these models at the
+is one of these types. API JSON is parsed *into* these models at the
 network boundary; storage writes serialize *from* these models. Nothing in the
 pipeline handles untyped dicts.
+
+Proceedings (the original entity):
 
 - :class:`Issue` — one daily Congressional Record issue (metadata only).
 - :class:`Article` — one article within an issue, including its text URL.
 - :class:`Proceeding` — the final output record: an issue + article + text.
+
+Members (Phase 1):
+
+- :class:`Member` — a person who has served in Congress.
+- :class:`Term` — one continuous service period in one chamber.
+- :class:`MemberSnapshot` — ADR 0006 envelope wrapping a raw API payload.
 """
 
 from __future__ import annotations
@@ -158,3 +166,269 @@ class Proceeding(BaseModel):
             text=text,
             fetched_at=fetched_at,
         )
+
+
+# ---------------------------------------------------------------------------
+# Member entity (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+Chamber = Literal["house", "senate"]
+
+
+def _normalize_chamber(value: Any) -> Any:
+    """Map the API's verbose chamber names to the canonical ``house``/``senate``.
+
+    The API uses ``House of Representatives`` and ``Senate``; tests and SQL
+    use the lowercased one-word forms. Pass-through for already-normalized
+    values lets callers use either form on input.
+    """
+    if not isinstance(value, str):
+        return value
+    lower = value.strip().lower()
+    if lower in {"house", "house of representatives"}:
+        return "house"
+    if lower == "senate":
+        return "senate"
+    return value
+
+
+_STATE_NAME_TO_CODE = {
+    "alabama": "AL", "alaska": "AK", "arizona": "AZ", "arkansas": "AR",
+    "california": "CA", "colorado": "CO", "connecticut": "CT", "delaware": "DE",
+    "florida": "FL", "georgia": "GA", "hawaii": "HI", "idaho": "ID",
+    "illinois": "IL", "indiana": "IN", "iowa": "IA", "kansas": "KS",
+    "kentucky": "KY", "louisiana": "LA", "maine": "ME", "maryland": "MD",
+    "massachusetts": "MA", "michigan": "MI", "minnesota": "MN", "mississippi": "MS",
+    "missouri": "MO", "montana": "MT", "nebraska": "NE", "nevada": "NV",
+    "new hampshire": "NH", "new jersey": "NJ", "new mexico": "NM", "new york": "NY",
+    "north carolina": "NC", "north dakota": "ND", "ohio": "OH", "oklahoma": "OK",
+    "oregon": "OR", "pennsylvania": "PA", "rhode island": "RI",
+    "south carolina": "SC", "south dakota": "SD", "tennessee": "TN", "texas": "TX",
+    "utah": "UT", "vermont": "VT", "virginia": "VA", "washington": "WA",
+    "west virginia": "WV", "wisconsin": "WI", "wyoming": "WY",
+    "district of columbia": "DC", "puerto rico": "PR", "american samoa": "AS",
+    "guam": "GU", "northern mariana islands": "MP", "virgin islands": "VI",
+}
+
+
+def normalize_state(value: str | None) -> str | None:
+    """Map the API's full state name to a two-letter code; pass through codes."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    if len(stripped) == 2 and stripped.isupper():
+        return stripped
+    return _STATE_NAME_TO_CODE.get(stripped.lower(), stripped)
+
+
+class Term(BaseModel):
+    """One continuous service period for a :class:`Member` in one chamber.
+
+    Keyed by ``(bioguide_id, congress, chamber)``. Party, state, and district
+    are recorded per-Term so a Member who changed party between Congresses or
+    moved between House and Senate has multiple Terms reflecting reality.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    bioguide_id: str
+    congress: int
+    chamber: Chamber
+    party: str | None = None
+    state: str  # two-letter state code (e.g. "VT")
+    district: int | None = None  # NULL for senators
+    start_date: str | None = None  # ISO YYYY-MM-DD or YYYY (year-only fallback)
+    end_date: str | None = None  # None = currently serving
+
+    @field_validator("chamber", mode="before")
+    @classmethod
+    def _coerce_chamber(cls, value: Any) -> Any:
+        return _normalize_chamber(value)
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def _coerce_state(cls, value: Any) -> Any:
+        return normalize_state(value) if isinstance(value, str) else value
+
+
+class Member(BaseModel):
+    """A person who has served in Congress.
+
+    Identity fields only — anything that varies across a career (party,
+    chamber, state, district) lives on :class:`Term` instead.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    bioguide_id: str
+    first_name: str
+    middle_name: str | None = None
+    last_name: str
+    suffix: str | None = None
+    birth_year: int | None = None
+    death_year: int | None = None
+    display_name: str  # API's directOrderName
+    photo_url: str | None = None  # API's depiction.imageUrl
+    biography: str | None = None
+
+
+class MemberSnapshot(BaseModel):
+    """ADR 0006 envelope wrapping one raw ``/member`` API response.
+
+    Each Stage 0 fetch appends one of these to ``data/members.jsonl``. The
+    Stage 1 loader groups by ``key["bioguide_id"]`` and keeps the latest
+    ``fetched_at`` per key.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    fetched_at: datetime
+    key: dict[str, str]
+    payload: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Helpers for projecting raw API payloads into typed Member + Term records.
+# ---------------------------------------------------------------------------
+
+
+def _split_inverted_name(name: str) -> tuple[str, str]:
+    """Parse the API's ``"Last, First[ Middle][, Suffix]"`` into ``(first, last)``.
+
+    A best-effort fallback when the API's structured first/last fields are
+    absent (the list endpoint sometimes only returns the inverted form).
+    """
+    parts = [p.strip() for p in name.split(",", 1)]
+    if len(parts) == 1:
+        return parts[0], ""
+    last = parts[0]
+    first = parts[1].split()[0] if parts[1] else ""
+    return first, last
+
+
+def parse_member(payload: dict[str, Any]) -> tuple[Member, list[Term]]:
+    """Project a raw ``/member`` payload into a :class:`Member` + its :class:`Term`s.
+
+    Tolerates the union of fields returned by the list endpoint
+    (``/v3/member/congress/{congress}``) and the detail endpoint
+    (``/v3/member/{bioguideId}``). Missing optional fields become ``None``.
+    """
+    bioguide_id = str(payload["bioguideId"])
+
+    first_name = payload.get("firstName")
+    last_name = payload.get("lastName")
+    if not first_name or not last_name:
+        # Fall back to parsing the inverted "Last, First" name from the
+        # list endpoint when structured fields aren't present.
+        inverted = payload.get("invertedOrderName") or payload.get("name") or ""
+        derived_first, derived_last = _split_inverted_name(inverted)
+        first_name = first_name or derived_first
+        last_name = last_name or derived_last
+
+    display_name = (
+        payload.get("directOrderName")
+        or (
+            f"{first_name} {last_name}".strip()
+            if first_name or last_name
+            else payload.get("name", "")
+        )
+    )
+
+    depiction = payload.get("depiction") or {}
+    photo_url = depiction.get("imageUrl") if isinstance(depiction, dict) else None
+
+    member = Member(
+        bioguide_id=bioguide_id,
+        first_name=first_name or "",
+        middle_name=payload.get("middleName"),
+        last_name=last_name or "",
+        suffix=payload.get("suffixName"),
+        birth_year=_coerce_int(payload.get("birthYear")),
+        death_year=_coerce_int(payload.get("deathYear")),
+        display_name=display_name,
+        photo_url=photo_url,
+        biography=payload.get("biography"),
+    )
+
+    # Top-level fallback state/district/party for term rows that don't carry their own
+    # (the list endpoint flattens these onto the member rather than per-term).
+    top_state = payload.get("state")
+    top_district = payload.get("district")
+    top_party = payload.get("partyName")
+
+    terms_raw = payload.get("terms")
+    items: list[dict[str, Any]] = []
+    if isinstance(terms_raw, dict):
+        items = list(terms_raw.get("item") or [])
+    elif isinstance(terms_raw, list):
+        items = list(terms_raw)
+
+    terms: list[Term] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        congress = item.get("congress")
+        if congress is None:
+            continue
+        chamber_raw = item.get("chamber")
+        if chamber_raw is None:
+            continue
+        chamber = _normalize_chamber(chamber_raw)
+        if chamber not in {"house", "senate"}:
+            continue
+        state = item.get("stateCode") or item.get("stateName") or top_state
+        if not state:
+            continue
+        district = item.get("district")
+        if district is None and chamber == "house":
+            district = top_district
+        if isinstance(district, str):
+            try:
+                district = int(district)
+            except ValueError:
+                district = None
+        if chamber == "senate":
+            district = None
+        terms.append(
+            Term(
+                bioguide_id=bioguide_id,
+                congress=int(congress),
+                chamber=chamber,
+                party=item.get("partyName") or top_party,
+                state=state,  # validator normalizes to 2-letter
+                district=district,
+                start_date=_year_to_iso(item.get("startYear")),
+                end_date=_year_to_iso(item.get("endYear")),
+            )
+        )
+    return member, terms
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _year_to_iso(value: Any) -> str | None:
+    """Normalize a ``startYear``/``endYear`` integer to an ISO date string.
+
+    The API returns just a year; we project it to ``YYYY-01-01`` for start
+    dates and leave end dates ``None`` when the API omits them (current
+    service). Year-only inputs are preserved as-is so callers that pass an
+    already-ISO date round-trip cleanly.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, int):
+        return f"{value:04d}-01-01"
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.isdigit() and len(text) == 4:
+        return f"{int(text):04d}-01-01"
+    return text

--- a/src/concord/models.py
+++ b/src/concord/models.py
@@ -194,21 +194,62 @@ def _normalize_chamber(value: Any) -> Any:
 
 
 _STATE_NAME_TO_CODE = {
-    "alabama": "AL", "alaska": "AK", "arizona": "AZ", "arkansas": "AR",
-    "california": "CA", "colorado": "CO", "connecticut": "CT", "delaware": "DE",
-    "florida": "FL", "georgia": "GA", "hawaii": "HI", "idaho": "ID",
-    "illinois": "IL", "indiana": "IN", "iowa": "IA", "kansas": "KS",
-    "kentucky": "KY", "louisiana": "LA", "maine": "ME", "maryland": "MD",
-    "massachusetts": "MA", "michigan": "MI", "minnesota": "MN", "mississippi": "MS",
-    "missouri": "MO", "montana": "MT", "nebraska": "NE", "nevada": "NV",
-    "new hampshire": "NH", "new jersey": "NJ", "new mexico": "NM", "new york": "NY",
-    "north carolina": "NC", "north dakota": "ND", "ohio": "OH", "oklahoma": "OK",
-    "oregon": "OR", "pennsylvania": "PA", "rhode island": "RI",
-    "south carolina": "SC", "south dakota": "SD", "tennessee": "TN", "texas": "TX",
-    "utah": "UT", "vermont": "VT", "virginia": "VA", "washington": "WA",
-    "west virginia": "WV", "wisconsin": "WI", "wyoming": "WY",
-    "district of columbia": "DC", "puerto rico": "PR", "american samoa": "AS",
-    "guam": "GU", "northern mariana islands": "MP", "virgin islands": "VI",
+    "alabama": "AL",
+    "alaska": "AK",
+    "arizona": "AZ",
+    "arkansas": "AR",
+    "california": "CA",
+    "colorado": "CO",
+    "connecticut": "CT",
+    "delaware": "DE",
+    "florida": "FL",
+    "georgia": "GA",
+    "hawaii": "HI",
+    "idaho": "ID",
+    "illinois": "IL",
+    "indiana": "IN",
+    "iowa": "IA",
+    "kansas": "KS",
+    "kentucky": "KY",
+    "louisiana": "LA",
+    "maine": "ME",
+    "maryland": "MD",
+    "massachusetts": "MA",
+    "michigan": "MI",
+    "minnesota": "MN",
+    "mississippi": "MS",
+    "missouri": "MO",
+    "montana": "MT",
+    "nebraska": "NE",
+    "nevada": "NV",
+    "new hampshire": "NH",
+    "new jersey": "NJ",
+    "new mexico": "NM",
+    "new york": "NY",
+    "north carolina": "NC",
+    "north dakota": "ND",
+    "ohio": "OH",
+    "oklahoma": "OK",
+    "oregon": "OR",
+    "pennsylvania": "PA",
+    "rhode island": "RI",
+    "south carolina": "SC",
+    "south dakota": "SD",
+    "tennessee": "TN",
+    "texas": "TX",
+    "utah": "UT",
+    "vermont": "VT",
+    "virginia": "VA",
+    "washington": "WA",
+    "west virginia": "WV",
+    "wisconsin": "WI",
+    "wyoming": "WY",
+    "district of columbia": "DC",
+    "puerto rico": "PR",
+    "american samoa": "AS",
+    "guam": "GU",
+    "northern mariana islands": "MP",
+    "virgin islands": "VI",
 }
 
 
@@ -326,13 +367,8 @@ def parse_member(payload: dict[str, Any]) -> tuple[Member, list[Term]]:
         first_name = first_name or derived_first
         last_name = last_name or derived_last
 
-    display_name = (
-        payload.get("directOrderName")
-        or (
-            f"{first_name} {last_name}".strip()
-            if first_name or last_name
-            else payload.get("name", "")
-        )
+    display_name = payload.get("directOrderName") or (
+        f"{first_name} {last_name}".strip() if first_name or last_name else payload.get("name", "")
     )
 
     depiction = payload.get("depiction") or {}

--- a/src/concord/pipeline/__init__.py
+++ b/src/concord/pipeline/__init__.py
@@ -1,0 +1,9 @@
+"""Stage 1 (Load) and Stage 2 (Index) pipelines, per-entity.
+
+Each entity type gets its own loader and indexer module:
+
+- :mod:`concord.pipeline.load_proceedings` / :mod:`concord.pipeline.index_proceedings`
+- :mod:`concord.pipeline.load_members` / :mod:`concord.pipeline.index_members`
+
+See ADR 0007 for the per-entity layout rationale.
+"""

--- a/src/concord/pipeline/index_members.py
+++ b/src/concord/pipeline/index_members.py
@@ -1,0 +1,57 @@
+"""Stage 2 — Members indexer.
+
+Populates the ``members_fts`` FTS5 virtual table from the ``members``
+table. Truncate-then-repopulate keeps the index in lockstep with the
+current Member projection — no need for triggers, no risk of stale rows
+after a re-load.
+
+Member name search uses FTS5 only; per the Phase 1 plan there's no
+embedding pass for Member names (BM25 + porter stemming is the right
+tool for short proper-noun lookups).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+from ..storage.sqlite import SqliteStorage
+
+
+class IndexStats(NamedTuple):
+    """Outcome of one :func:`index` invocation."""
+
+    indexed_members: int
+
+
+def index(*, db_path: Path) -> IndexStats:
+    storage = SqliteStorage(db_path, load_vec=False)
+    try:
+        conn = storage.connection
+        # Truncate. FTS5 supports DELETE; this is preferred over the
+        # 'delete-all' command since it works without external content.
+        conn.execute("DELETE FROM members_fts")
+        cursor = conn.execute(
+            "SELECT bioguide_id, display_name, first_name, last_name FROM members"
+        )
+        rows = cursor.fetchall()
+        for row in rows:
+            inverted = f"{row['last_name']}, {row['first_name']}".strip(", ")
+            conn.execute(
+                "INSERT INTO members_fts "
+                "(bioguide_id, direct_order_name, inverted_order_name, last_name) "
+                "VALUES (?, ?, ?, ?)",
+                (
+                    row["bioguide_id"],
+                    row["display_name"],
+                    inverted,
+                    row["last_name"],
+                ),
+            )
+        conn.commit()
+        return IndexStats(indexed_members=len(rows))
+    finally:
+        storage.close()
+
+
+__all__ = ["IndexStats", "index"]

--- a/src/concord/pipeline/index_proceedings.py
+++ b/src/concord/pipeline/index_proceedings.py
@@ -18,10 +18,10 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import NamedTuple
 
-from .chunking import Chunk, Chunker
-from .embedding import Embedder
-from .models import Proceeding
-from .storage.sqlite import SqliteStorage
+from ..chunking import Chunk, Chunker
+from ..embedding import Embedder
+from ..models import Proceeding
+from ..storage.sqlite import SqliteStorage
 
 
 class IndexResult(NamedTuple):

--- a/src/concord/pipeline/load_members.py
+++ b/src/concord/pipeline/load_members.py
@@ -1,0 +1,102 @@
+"""Stage 1 — Members loader.
+
+Projects the ADR 0006 snapshot stream in ``data/members.jsonl`` into the
+``members`` and ``member_terms`` SQLite tables. The contract:
+
+* Read every snapshot. Group by ``key["bioguide_id"]``.
+* For each group, keep the snapshot with the latest ``fetched_at``.
+* For each kept snapshot, parse the payload into a typed
+  :class:`Member` + list of :class:`Term`s.
+* UPSERT the Member row on ``bioguide_id`` and DELETE-then-INSERT the
+  Term rows so the projection reflects exactly what the latest snapshot
+  says (no stale Terms left behind if the API ever drops one).
+
+Re-running the loader over an unchanged JSONL is a no-op (idempotent).
+Re-running over a JSONL that gained new snapshots converges the SQL
+state to the latest-snapshot projection.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from ..models import parse_member
+from ..storage.sqlite import SqliteStorage
+
+_log = logging.getLogger("concord.pipeline.load_members")
+
+
+class LoadStats(NamedTuple):
+    """Outcome of one :func:`load` invocation."""
+
+    members_written: int
+    terms_written: int
+    snapshots_read: int
+    malformed: int
+
+
+def load(*, jsonl_path: Path, db_path: Path) -> LoadStats:
+    """Load the JSONL snapshot stream into SQLite.
+
+    Returns the count of Members and Terms written plus diagnostics.
+    """
+    latest: dict[str, tuple[datetime, dict[str, Any]]] = {}
+    snapshots_read = 0
+    malformed = 0
+
+    with jsonl_path.open("r", encoding="utf-8") as fh:
+        for line_no, raw in enumerate(fh, 1):
+            line = raw.strip()
+            if not line:
+                continue
+            snapshots_read += 1
+            try:
+                envelope = json.loads(line)
+            except json.JSONDecodeError as exc:
+                malformed += 1
+                _log.warning("skipping malformed line %d: %s", line_no, exc)
+                continue
+            try:
+                bioguide_id = envelope["key"]["bioguide_id"]
+                fetched_at_raw = envelope["fetched_at"]
+                payload = envelope["payload"]
+                fetched_at = datetime.fromisoformat(fetched_at_raw)
+            except (KeyError, TypeError, ValueError) as exc:
+                malformed += 1
+                _log.warning("skipping line %d with bad envelope: %s", line_no, exc)
+                continue
+            current = latest.get(bioguide_id)
+            if current is None or fetched_at > current[0]:
+                latest[bioguide_id] = (fetched_at, payload)
+
+    members_written = 0
+    terms_written = 0
+
+    storage = SqliteStorage(db_path, load_vec=False)
+    try:
+        for bioguide_id, (fetched_at, payload) in latest.items():
+            try:
+                member, terms = parse_member(payload)
+            except Exception as exc:  # pragma: no cover - defensive parse guard
+                malformed += 1
+                _log.warning("skipping %s after parse failure: %s", bioguide_id, exc)
+                continue
+            storage.upsert_member(member, terms, fetched_at=fetched_at.isoformat())
+            members_written += 1
+            terms_written += len(terms)
+    finally:
+        storage.close()
+
+    return LoadStats(
+        members_written=members_written,
+        terms_written=terms_written,
+        snapshots_read=snapshots_read,
+        malformed=malformed,
+    )
+
+
+__all__ = ["LoadStats", "load"]

--- a/src/concord/pipeline/load_proceedings.py
+++ b/src/concord/pipeline/load_proceedings.py
@@ -28,10 +28,10 @@ from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import NamedTuple
 
-from .api import Client
-from .models import Issue, Proceeding
-from .storage.base import Storage
-from .text import TextFetchError
+from ..api import Client
+from ..models import Issue, Proceeding
+from ..storage.base import Storage
+from ..text import TextFetchError
 
 _log = logging.getLogger("concord.pipeline")
 

--- a/src/concord/scraper/__init__.py
+++ b/src/concord/scraper/__init__.py
@@ -1,0 +1,10 @@
+"""Stage 0 scrapers, one module per entity type.
+
+Each entity type gets its own scraper that paginates the relevant
+``api.congress.gov`` endpoint and appends to a per-entity JSONL file.
+
+- :mod:`concord.scraper.proceedings`
+- :mod:`concord.scraper.members`
+
+See ADR 0007 for the per-entity layout rationale.
+"""

--- a/src/concord/scraper/members.py
+++ b/src/concord/scraper/members.py
@@ -1,0 +1,77 @@
+"""Stage 0 — Members scraper.
+
+Walks ``api.congress.gov``'s ``/v3/member/congress/{congress}`` endpoint
+for each requested Congress and appends one ADR 0006 snapshot envelope
+to ``data/members.jsonl`` per Member returned. The Stage 1 loader is
+responsible for deduplicating by Bioguide ID — a Member who served in
+several Congresses will appear in each Congress's listing and produce
+one snapshot per appearance.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from datetime import datetime
+from pathlib import Path
+from typing import NamedTuple
+
+from ..api import Client
+
+
+class ScrapeProgressEvent(NamedTuple):
+    """Emitted by :func:`scrape` once per Congress, after its pagination
+    completes."""
+
+    congress: int
+    written_in_congress: int
+    total_written: int
+
+
+def scrape(
+    *,
+    client: Client,
+    congresses: Iterable[int],
+    storage_path: Path,
+    fetched_at: datetime,
+    progress: Callable[[ScrapeProgressEvent], None] | None = None,
+) -> int:
+    """Append one snapshot envelope per Member to ``storage_path``.
+
+    Returns the total number of snapshots written. The output file is
+    opened in append mode (created if missing); the parent directory is
+    created if needed.
+    """
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    total = 0
+    iso = fetched_at.isoformat()
+    with storage_path.open("a", encoding="utf-8") as fh:
+        for congress in congresses:
+            written_in_congress = 0
+            for payload in client.list_members(congress):
+                bioguide_id = payload.get("bioguideId")
+                if not bioguide_id:
+                    # Defensive: a Member without a bioguide_id can't be
+                    # keyed; skip rather than write an un-loadable line.
+                    continue
+                envelope = {
+                    "fetched_at": iso,
+                    "key": {"bioguide_id": bioguide_id},
+                    "payload": payload,
+                }
+                fh.write(json.dumps(envelope, ensure_ascii=False))
+                fh.write("\n")
+                written_in_congress += 1
+                total += 1
+            if progress is not None:
+                progress(
+                    ScrapeProgressEvent(
+                        congress=congress,
+                        written_in_congress=written_in_congress,
+                        total_written=total,
+                    )
+                )
+    return total
+
+
+__all__ = ["ScrapeProgressEvent", "scrape"]

--- a/src/concord/scraper/proceedings.py
+++ b/src/concord/scraper/proceedings.py
@@ -1,0 +1,90 @@
+"""Stage 0 — Proceedings scraper.
+
+Wires the api.congress.gov :class:`Client`, the article-text fetcher, and
+a :class:`Storage` backend together for a single date-range pull. This is
+the orchestration that used to live as ``_run_pull`` in ``concord.cli``;
+the CLI now delegates to :func:`scrape` so the per-entity scraper
+modules from ADR 0007 have a consistent shape.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import httpx
+import typer
+
+from ..api import ApiError, Client
+from ..pipeline.load_proceedings import ProgressEvent, PullResult, pull
+from ..storage.base import Storage
+from ..text import fetch_text
+
+#: Per-request timeout (seconds) for fetching article text from congress.gov.
+#: The default httpx timeout (5s) is too aggressive for occasional slow
+#: responses and triggers transport errors that abort multi-day pulls.
+TEXT_FETCH_TIMEOUT = 60.0
+
+
+def scrape(
+    *,
+    start: date,
+    end: date,
+    storage: Storage,
+    storage_label: str,
+    limit: int | None,
+    show_progress: bool,
+) -> PullResult:
+    """Pull every in-range article into ``storage`` and print a summary.
+
+    Wraps :func:`concord.pipeline.load_proceedings.pull` with the live
+    ``api.congress.gov`` :class:`Client` and a real ``httpx.Client`` for
+    the article-text fetch. Errors that prevent any work (missing API key,
+    failed client construction) exit with code 2 via :class:`typer.Exit`.
+    """
+    try:
+        api_client = Client()
+    except ApiError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    http_client = httpx.Client(timeout=TEXT_FETCH_TIMEOUT)
+
+    def _on_progress(event: ProgressEvent) -> None:
+        typer.echo(
+            f"{event.issue.issue_date}  "
+            f"vol {event.issue.volume} iss {event.issue.issue_number:>4}  "
+            f"+{event.issue_written:>4} written, "
+            f"{event.issue_skipped:>4} skipped, "
+            f"{event.issue_failed:>3} failed  "
+            f"(total: {event.total_written} / "
+            f"{event.total_skipped} / "
+            f"{event.total_failed})",
+            err=True,
+        )
+
+    try:
+        with api_client:
+            result = pull(
+                start,
+                end,
+                client=api_client,
+                fetch=lambda url: fetch_text(url, http_client),
+                storage=storage,
+                limit=limit,
+                progress=_on_progress if show_progress else None,
+            )
+    finally:
+        http_client.close()
+
+    summary = (
+        f"Wrote {result.written} new proceedings to {storage_label} "
+        f"(skipped {result.skipped} already present"
+    )
+    if result.failed:
+        summary += f", {result.failed} failed to fetch — will retry on next run"
+    summary += ")"
+    typer.echo(summary)
+    return result
+
+
+__all__ = ["TEXT_FETCH_TIMEOUT", "scrape"]

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -30,7 +30,7 @@ from typing import Any
 
 import sqlite_vec  # type: ignore[import-untyped]
 
-from ..models import Proceeding
+from ..models import Member, Proceeding, Term
 
 # Columns in the exact order they appear in the INSERT statement. Keeping
 # this list in one place makes it easy to add a column later: extend here,
@@ -124,7 +124,92 @@ CREATE TRIGGER IF NOT EXISTS chunks_au AFTER UPDATE ON chunks BEGIN
     INSERT INTO chunks_fts(chunks_fts, rowid, text) VALUES ('delete', old.id, old.text);
     INSERT INTO chunks_fts(rowid, text) VALUES (new.id, new.text);
 END;
+
+-- Members (Phase 1). Per-person identity fields; per-Term records the
+-- mutable career attributes (party, chamber, state, district). See ADR 0007.
+CREATE TABLE IF NOT EXISTS members (
+    bioguide_id  TEXT PRIMARY KEY,
+    first_name   TEXT NOT NULL,
+    middle_name  TEXT,
+    last_name    TEXT NOT NULL,
+    suffix       TEXT,
+    birth_year   INTEGER,
+    death_year   INTEGER,
+    display_name TEXT NOT NULL,
+    photo_url    TEXT,
+    biography    TEXT,
+    fetched_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS member_terms (
+    bioguide_id TEXT NOT NULL REFERENCES members(bioguide_id) ON DELETE CASCADE,
+    congress    INTEGER NOT NULL,
+    chamber     TEXT NOT NULL CHECK (chamber IN ('house', 'senate')),
+    party       TEXT,
+    state       TEXT NOT NULL,
+    district    INTEGER,
+    start_date  TEXT,
+    end_date    TEXT,
+    PRIMARY KEY (bioguide_id, congress, chamber)
+);
+
+CREATE INDEX IF NOT EXISTS idx_member_terms_congress
+    ON member_terms (congress);
+CREATE INDEX IF NOT EXISTS idx_member_terms_state
+    ON member_terms (state);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS members_fts USING fts5(
+    bioguide_id UNINDEXED,
+    direct_order_name,
+    inverted_order_name,
+    last_name,
+    tokenize = 'porter'
+);
 """
+
+# Column lists for members + member_terms tables. Mirrors the ``_PROCEEDING_COLUMNS``
+# pattern: one source of truth for INSERT order.
+_MEMBER_COLUMNS: tuple[str, ...] = (
+    "bioguide_id",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "suffix",
+    "birth_year",
+    "death_year",
+    "display_name",
+    "photo_url",
+    "biography",
+    "fetched_at",
+)
+
+_TERM_COLUMNS: tuple[str, ...] = (
+    "bioguide_id",
+    "congress",
+    "chamber",
+    "party",
+    "state",
+    "district",
+    "start_date",
+    "end_date",
+)
+
+_MEMBER_UPSERT_SQL = (
+    "INSERT INTO members ("
+    + ", ".join(_MEMBER_COLUMNS)
+    + ") VALUES ("
+    + ", ".join("?" for _ in _MEMBER_COLUMNS)
+    + ") ON CONFLICT(bioguide_id) DO UPDATE SET "
+    + ", ".join(f"{col} = excluded.{col}" for col in _MEMBER_COLUMNS if col != "bioguide_id")
+)
+
+_TERM_INSERT_SQL = (
+    "INSERT INTO member_terms ("
+    + ", ".join(_TERM_COLUMNS)
+    + ") VALUES ("
+    + ", ".join("?" for _ in _TERM_COLUMNS)
+    + ")"
+)
 
 # Vec-only schema. Only created when load_vec=True.
 _VEC_SCHEMA = """
@@ -285,6 +370,53 @@ class SqliteStorage:
             raise
         return len(rows)
 
+    # -- Members (Phase 1) ------------------------------------------------
+
+    def upsert_member(
+        self,
+        member: Member,
+        terms: Sequence[Term],
+        *,
+        fetched_at: str,
+    ) -> None:
+        """Project a Member + its Terms into SQLite atomically.
+
+        The Member row is UPSERTed on ``bioguide_id``; the Term rows for
+        this Member are replaced (DELETE-then-INSERT) so the projection
+        stays consistent with the latest snapshot, including the case
+        where the upstream API drops a Term that used to be present.
+        """
+        member_row = _row_from_member(member, fetched_at=fetched_at)
+        term_rows = [_row_from_term(t) for t in terms]
+        try:
+            self._conn.execute("BEGIN")
+            self._conn.execute(_MEMBER_UPSERT_SQL, member_row)
+            self._conn.execute(
+                "DELETE FROM member_terms WHERE bioguide_id = ?",
+                (member.bioguide_id,),
+            )
+            if term_rows:
+                self._conn.executemany(_TERM_INSERT_SQL, term_rows)
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+
+    def get_member(self, bioguide_id: str) -> sqlite3.Row | None:
+        cursor = self._conn.execute(
+            "SELECT * FROM members WHERE bioguide_id = ?",
+            (bioguide_id,),
+        )
+        return cursor.fetchone()
+
+    def terms_for_member(self, bioguide_id: str) -> list[sqlite3.Row]:
+        cursor = self._conn.execute(
+            "SELECT * FROM member_terms WHERE bioguide_id = ? "
+            "ORDER BY congress ASC, chamber ASC",
+            (bioguide_id,),
+        )
+        return cursor.fetchall()
+
     # -- introspection ----------------------------------------------------
 
     @property
@@ -330,3 +462,16 @@ def _row_from_proceeding(proceeding: Proceeding) -> tuple[Any, ...]:
     """Project a :class:`Proceeding` into the column tuple expected by SQL."""
     dumped: dict[str, Any] = proceeding.model_dump(mode="json")
     return tuple(dumped[col] for col in _PROCEEDING_COLUMNS)
+
+
+def _row_from_member(member: Member, *, fetched_at: str) -> tuple[Any, ...]:
+    """Project a :class:`Member` into the column tuple expected by SQL."""
+    dumped: dict[str, Any] = member.model_dump(mode="json")
+    dumped["fetched_at"] = fetched_at
+    return tuple(dumped[col] for col in _MEMBER_COLUMNS)
+
+
+def _row_from_term(term: Term) -> tuple[Any, ...]:
+    """Project a :class:`Term` into the column tuple expected by SQL."""
+    dumped: dict[str, Any] = term.model_dump(mode="json")
+    return tuple(dumped[col] for col in _TERM_COLUMNS)

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -407,12 +407,12 @@ class SqliteStorage:
             "SELECT * FROM members WHERE bioguide_id = ?",
             (bioguide_id,),
         )
-        return cursor.fetchone()
+        row: sqlite3.Row | None = cursor.fetchone()
+        return row
 
     def terms_for_member(self, bioguide_id: str) -> list[sqlite3.Row]:
         cursor = self._conn.execute(
-            "SELECT * FROM member_terms WHERE bioguide_id = ? "
-            "ORDER BY congress ASC, chamber ASC",
+            "SELECT * FROM member_terms WHERE bioguide_id = ? ORDER BY congress ASC, chamber ASC",
             (bioguide_id,),
         )
         return cursor.fetchall()

--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -202,8 +202,7 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
             "total": total_proceedings,
             "page": page,
             "page_size": SEARCH_PAGE_SIZE,
-            "has_next": include_proceedings
-            and (offset + SEARCH_PAGE_SIZE) < total_proceedings,
+            "has_next": include_proceedings and (offset + SEARCH_PAGE_SIZE) < total_proceedings,
             "has_prev": page > 1,
             "sections": _SECTION_OPTIONS,
             "member_hits": member_hits,

--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -48,6 +48,14 @@ SEARCH_RATE_LIMIT = "30/minute"
 #: Page size for search results.
 SEARCH_PAGE_SIZE = 20
 
+#: Page size for the ``/members`` browse-only index.
+MEMBERS_PAGE_SIZE = 50
+
+#: Cap on Member hits surfaced in a federated ``/search``. Members are an
+#: at-most-N peek alongside Proceedings; deeper exploration goes through
+#: ``/members``.
+MEMBER_RESULT_LIMIT = 10
+
 _HERE = Path(__file__).parent
 _TEMPLATES_DIR = _HERE / "templates"
 _STATIC_DIR = _HERE / "static"
@@ -137,6 +145,10 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
         date_to: str | None = Query(None, alias="to", description="YYYY-MM-DD"),
         section: str | None = Query(None, description="Senate Section, House Section, etc."),
         page: int = Query(1, ge=1, description="1-based page index."),
+        members_on: str = Query("on", alias="members", description="'on' to include Members."),
+        proceedings_on: str = Query(
+            "on", alias="proceedings", description="'on' to include Proceedings."
+        ),
         db: sqlite3.Connection = Depends(get_db),  # noqa: B008 - FastAPI Depends pattern
         embedder: Embedder = Depends(get_embedder),  # noqa: B008 - FastAPI Depends pattern
     ) -> Response:
@@ -144,30 +156,42 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
         date_to_parsed = _parse_optional_date(date_to)
         offset = (page - 1) * SEARCH_PAGE_SIZE
 
-        results = search_mod.search(
-            db,
-            embedder,
-            query=q,
-            date_from=date_from_parsed,
-            date_to=date_to_parsed,
-            section=section,
-            limit=SEARCH_PAGE_SIZE,
-            offset=offset,
-        )
+        include_members = members_on == "on"
+        include_proceedings = proceedings_on == "on"
 
-        # Build snippets for display. Keyword path tried first; fall back
-        # to semantic truncation if FTS5 returned nothing for this chunk
-        # (i.e. it matched only via the vector index).
-        rendered_results = []
-        for r in results.results:
+        # -- Members section ---------------------------------------------
+        member_hits: list[search_mod.MemberHit] = []
+        if include_members and q.strip():
             try:
-                snip = keyword_snippet(db, r.chunk_id, q) if q.strip() else ""
+                member_hits = search_mod.search_members(db, query=q, limit=MEMBER_RESULT_LIMIT)
             except sqlite3.OperationalError:
-                # FTS5 query syntax errors land here; fall back to a semantic snippet.
-                snip = ""
-            if not snip:
-                snip = semantic_snippet(r.chunk_text)
-            rendered_results.append({"result": r, "snippet": snip})
+                # FTS5 query syntax errors land here; show no Members
+                # rather than 500 on a malformed query.
+                member_hits = []
+
+        # -- Proceedings section -----------------------------------------
+        rendered_results: list[dict[str, Any]] = []
+        total_proceedings = 0
+        if include_proceedings:
+            results = search_mod.search(
+                db,
+                embedder,
+                query=q,
+                date_from=date_from_parsed,
+                date_to=date_to_parsed,
+                section=section,
+                limit=SEARCH_PAGE_SIZE,
+                offset=offset,
+            )
+            total_proceedings = results.total
+            for r in results.results:
+                try:
+                    snip = keyword_snippet(db, r.chunk_id, q) if q.strip() else ""
+                except sqlite3.OperationalError:
+                    snip = ""
+                if not snip:
+                    snip = semantic_snippet(r.chunk_text)
+                rendered_results.append({"result": r, "snippet": snip})
 
         context = {
             "query": q,
@@ -175,12 +199,16 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
             "to_date": date_to or "",
             "section": section or "",
             "results": rendered_results,
-            "total": results.total,
+            "total": total_proceedings,
             "page": page,
             "page_size": SEARCH_PAGE_SIZE,
-            "has_next": (offset + SEARCH_PAGE_SIZE) < results.total,
+            "has_next": include_proceedings
+            and (offset + SEARCH_PAGE_SIZE) < total_proceedings,
             "has_prev": page > 1,
             "sections": _SECTION_OPTIONS,
+            "member_hits": member_hits,
+            "include_members": include_members,
+            "include_proceedings": include_proceedings,
         }
 
         template = "_results.html" if _is_htmx(request) else "search.html"
@@ -202,6 +230,68 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
             )
         return templates.TemplateResponse(  # type: ignore[no-any-return]
             request, "proceeding.html", {"p": row}
+        )
+
+    @app.get("/members", response_class=HTMLResponse)
+    def members_index(
+        request: Request,
+        chamber: str | None = Query(None, description="'house', 'senate', or omitted."),
+        party: str | None = Query(None, description="Filter on a party name."),
+        page: int = Query(1, ge=1, description="1-based page index."),
+        db: sqlite3.Connection = Depends(get_db),  # noqa: B008 - FastAPI Depends pattern
+    ) -> Response:
+        offset = (page - 1) * MEMBERS_PAGE_SIZE
+        # Normalize chamber checkbox params: the form sends either "house",
+        # "senate", or omits entirely. Reject anything else to "show all".
+        chamber_filter = chamber if chamber in {"house", "senate"} else None
+        rows, total = search_mod.list_current_members(
+            db,
+            chamber=chamber_filter,
+            party=party or None,
+            limit=MEMBERS_PAGE_SIZE,
+            offset=offset,
+        )
+        context = {
+            "members": rows,
+            "total": total,
+            "page": page,
+            "page_size": MEMBERS_PAGE_SIZE,
+            "has_next": offset + MEMBERS_PAGE_SIZE < total,
+            "has_prev": page > 1,
+            "chamber": chamber_filter or "",
+            "party": party or "",
+        }
+        return templates.TemplateResponse(  # type: ignore[no-any-return]
+            request, "members/list.html", context
+        )
+
+    @app.get("/members/{bioguide_id}", response_class=HTMLResponse)
+    def member_profile(
+        request: Request,
+        bioguide_id: str,
+        db: sqlite3.Connection = Depends(get_db),  # noqa: B008 - FastAPI Depends pattern
+    ) -> Response:
+        member = search_mod.get_member(db, bioguide_id)
+        if member is None:
+            return templates.TemplateResponse(  # type: ignore[no-any-return]
+                request,
+                "404.html",
+                {"granule_id": bioguide_id},
+                status_code=404,
+            )
+        terms = search_mod.terms_for_member(db, bioguide_id)
+        current_term = next(
+            (
+                t
+                for t in terms
+                if t["end_date"] is None or t["end_date"] >= date.today().isoformat()
+            ),
+            None,
+        )
+        return templates.TemplateResponse(  # type: ignore[no-any-return]
+            request,
+            "members/profile.html",
+            {"member": member, "terms": terms, "current_term": current_term},
         )
 
     @app.get("/healthz")
@@ -235,4 +325,10 @@ def _parse_optional_date(value: str | None) -> date | None:
         ) from exc
 
 
-__all__: list[Any] = ["SEARCH_PAGE_SIZE", "SEARCH_RATE_LIMIT", "create_app"]
+__all__: list[Any] = [
+    "MEMBERS_PAGE_SIZE",
+    "MEMBER_RESULT_LIMIT",
+    "SEARCH_PAGE_SIZE",
+    "SEARCH_RATE_LIMIT",
+    "create_app",
+]

--- a/src/concord/web/search.py
+++ b/src/concord/web/search.py
@@ -257,3 +257,170 @@ def get_proceeding(db: sqlite3.Connection, granule_id: str) -> dict[str, Any] | 
     if row is None:
         return None
     return dict(row)
+
+
+# -- Members (Phase 1) ------------------------------------------------------
+
+
+class MemberHit(BaseModel):
+    """One row of the federated ``/search`` Members section."""
+
+    bioguide_id: str
+    display_name: str
+    last_name: str
+    photo_url: str | None
+    is_current: bool
+    last_active_congress: int | None
+    current_chamber: str | None  # "house" / "senate" / None
+    current_state: str | None
+    current_party: str | None
+
+
+def search_members(
+    db: sqlite3.Connection,
+    *,
+    query: str,
+    limit: int = 10,
+) -> list[MemberHit]:
+    """FTS5 search over Member names, ordered for ambiguous-query disambiguation.
+
+    Returns at most ``limit`` hits. An empty / whitespace-only query short
+    circuits to ``[]`` without touching the database. Results are sorted
+    ``(is_current DESC, last_active_congress DESC)`` so a query like
+    ``"Sanders"`` surfaces the currently-serving Sanders ahead of any
+    historical namesakes (Phase 1 plan, "Disambiguation").
+    """
+    if not query.strip():
+        return []
+
+    safe = '"' + query.replace('"', '""') + '"'
+    rows = db.execute(
+        """
+        SELECT
+            m.bioguide_id        AS bioguide_id,
+            m.display_name       AS display_name,
+            m.last_name          AS last_name,
+            m.photo_url          AS photo_url,
+            MAX(t.congress)      AS last_active_congress,
+            MAX(CASE WHEN t.end_date IS NULL OR t.end_date >= date('now') THEN 1 ELSE 0 END)
+                                 AS is_current_flag
+        FROM members_fts f
+        JOIN members m   ON m.bioguide_id = f.bioguide_id
+        LEFT JOIN member_terms t ON t.bioguide_id = m.bioguide_id
+        WHERE f.members_fts MATCH ?
+        GROUP BY m.bioguide_id
+        ORDER BY is_current_flag DESC, last_active_congress DESC, m.last_name ASC
+        LIMIT ?
+        """,
+        (safe, limit),
+    ).fetchall()
+
+    hits: list[MemberHit] = []
+    for row in rows:
+        bioguide_id = row["bioguide_id"]
+        # Resolve the "current" term's metadata for the card line on the
+        # results page. Falls back to the most-recent term if none current.
+        term_row = db.execute(
+            """
+            SELECT chamber, state, party
+            FROM member_terms
+            WHERE bioguide_id = ?
+            ORDER BY
+                CASE WHEN end_date IS NULL OR end_date >= date('now') THEN 0 ELSE 1 END,
+                congress DESC
+            LIMIT 1
+            """,
+            (bioguide_id,),
+        ).fetchone()
+
+        hits.append(
+            MemberHit(
+                bioguide_id=bioguide_id,
+                display_name=row["display_name"],
+                last_name=row["last_name"],
+                photo_url=row["photo_url"],
+                is_current=bool(row["is_current_flag"]),
+                last_active_congress=row["last_active_congress"],
+                current_chamber=term_row["chamber"] if term_row else None,
+                current_state=term_row["state"] if term_row else None,
+                current_party=term_row["party"] if term_row else None,
+            )
+        )
+    return hits
+
+
+def get_member(db: sqlite3.Connection, bioguide_id: str) -> dict[str, Any] | None:
+    row = db.execute(
+        "SELECT * FROM members WHERE bioguide_id = ?", (bioguide_id,)
+    ).fetchone()
+    if row is None:
+        return None
+    return dict(row)
+
+
+def terms_for_member(
+    db: sqlite3.Connection, bioguide_id: str
+) -> list[dict[str, Any]]:
+    rows = db.execute(
+        "SELECT * FROM member_terms WHERE bioguide_id = ? "
+        "ORDER BY congress DESC, chamber ASC",
+        (bioguide_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def list_current_members(
+    db: sqlite3.Connection,
+    *,
+    chamber: str | None = None,  # "house" / "senate" / None
+    party: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return ``(rows, total)`` for currently-serving Members.
+
+    Each row carries the Member identity fields plus the current Term's
+    ``chamber``, ``state``, ``district``, ``party`` so the index page can
+    render a one-liner per Member without an N+1 follow-up query.
+    """
+    where = ["(t.end_date IS NULL OR t.end_date >= date('now'))"]
+    params: list[Any] = []
+    if chamber in {"house", "senate"}:
+        where.append("t.chamber = ?")
+        params.append(chamber)
+    if party:
+        where.append("t.party = ?")
+        params.append(party)
+    where_sql = " AND ".join(where)
+
+    (total,) = db.execute(
+        f"""
+        SELECT COUNT(DISTINCT m.bioguide_id)
+        FROM members m
+        JOIN member_terms t ON t.bioguide_id = m.bioguide_id
+        WHERE {where_sql}
+        """,
+        params,
+    ).fetchone()
+
+    rows = db.execute(
+        f"""
+        SELECT
+            m.bioguide_id  AS bioguide_id,
+            m.display_name AS display_name,
+            m.last_name    AS last_name,
+            m.photo_url    AS photo_url,
+            t.chamber      AS chamber,
+            t.state        AS state,
+            t.district     AS district,
+            t.party        AS party
+        FROM members m
+        JOIN member_terms t ON t.bioguide_id = m.bioguide_id
+        WHERE {where_sql}
+        GROUP BY m.bioguide_id
+        ORDER BY t.state ASC, m.last_name ASC
+        LIMIT ? OFFSET ?
+        """,
+        [*params, limit, offset],
+    ).fetchall()
+    return [dict(r) for r in rows], int(total)

--- a/src/concord/web/search.py
+++ b/src/concord/web/search.py
@@ -350,20 +350,15 @@ def search_members(
 
 
 def get_member(db: sqlite3.Connection, bioguide_id: str) -> dict[str, Any] | None:
-    row = db.execute(
-        "SELECT * FROM members WHERE bioguide_id = ?", (bioguide_id,)
-    ).fetchone()
+    row = db.execute("SELECT * FROM members WHERE bioguide_id = ?", (bioguide_id,)).fetchone()
     if row is None:
         return None
     return dict(row)
 
 
-def terms_for_member(
-    db: sqlite3.Connection, bioguide_id: str
-) -> list[dict[str, Any]]:
+def terms_for_member(db: sqlite3.Connection, bioguide_id: str) -> list[dict[str, Any]]:
     rows = db.execute(
-        "SELECT * FROM member_terms WHERE bioguide_id = ? "
-        "ORDER BY congress DESC, chamber ASC",
+        "SELECT * FROM member_terms WHERE bioguide_id = ? ORDER BY congress DESC, chamber ASC",
         (bioguide_id,),
     ).fetchall()
     return [dict(r) for r in rows]

--- a/src/concord/web/templates/_results.html
+++ b/src/concord/web/templates/_results.html
@@ -1,41 +1,119 @@
+{% if query %}
+  <div class="mb-4 flex flex-wrap gap-4 text-sm text-stone-600">
+    <label class="flex items-center gap-1">
+      <input
+        type="checkbox" name="members" value="on"
+        form=""
+        {% if include_members %}checked{% endif %}
+        hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&members={% if include_members %}{% else %}on{% endif %}&proceedings={% if include_proceedings %}on{% endif %}"
+        hx-target="main"
+        hx-push-url="true"
+      >
+      <span>Members</span>
+    </label>
+    <label class="flex items-center gap-1">
+      <input
+        type="checkbox" name="proceedings" value="on"
+        form=""
+        {% if include_proceedings %}checked{% endif %}
+        hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&members={% if include_members %}on{% endif %}&proceedings={% if include_proceedings %}{% else %}on{% endif %}"
+        hx-target="main"
+        hx-push-url="true"
+      >
+      <span>Proceedings</span>
+    </label>
+  </div>
+{% endif %}
+
 {% if not query %}
   <p class="text-stone-500">Enter a query above to search.</p>
-{% elif total == 0 %}
-  <p class="text-stone-600">
-    No proceedings match <span class="font-mono">&ldquo;{{ query }}&rdquo;</span>.
-  </p>
 {% else %}
-  <p class="text-sm text-stone-500 mb-4">
-    {{ total }} proceeding{% if total != 1 %}s{% endif %} matching
-    <span class="font-mono">&ldquo;{{ query }}&rdquo;</span>
-    — page {{ page }}.
-  </p>
-  <ol class="space-y-6">
-    {% for entry in results %}
-      {% include "_result_card.html" %}
-    {% endfor %}
-  </ol>
+  {% if include_members %}
+    <section class="mb-8">
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-3">
+        Members ({{ member_hits|length }})
+      </h2>
+      {% if member_hits %}
+        <ul class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {% for m in member_hits %}
+            <li class="flex items-center gap-3 border border-stone-200 rounded p-3 bg-white">
+              {% if m.photo_url %}
+                <img
+                  src="{{ m.photo_url }}"
+                  alt=""
+                  class="w-12 h-12 rounded-full object-cover border border-stone-200"
+                  loading="lazy"
+                >
+              {% else %}
+                <div class="w-12 h-12 rounded-full bg-stone-100 border border-stone-200"></div>
+              {% endif %}
+              <div class="min-w-0">
+                <a
+                  href="/members/{{ m.bioguide_id }}"
+                  class="font-medium text-stone-900 hover:text-stone-700 truncate block"
+                >{{ m.display_name }}</a>
+                <div class="text-xs text-stone-500 truncate">
+                  {% if m.current_chamber %}
+                    {{ "Sen." if m.current_chamber == "senate" else "Rep." }}
+                  {% endif %}
+                  {% if m.current_state %}{{ m.current_state }}{% endif %}
+                  {% if m.current_party %} · {{ m.current_party }}{% endif %}
+                  {% if not m.is_current %} · former{% endif %}
+                </div>
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="text-stone-500 text-sm">
+          No Members match <span class="font-mono">&ldquo;{{ query }}&rdquo;</span>.
+        </p>
+      {% endif %}
+    </section>
+  {% endif %}
 
-  {% if has_prev or has_next %}
-    <nav class="mt-8 flex justify-between text-sm">
-      {% if has_prev %}
-        <a
-          class="text-stone-600 hover:text-stone-900 underline"
-          href="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page - 1 }}"
-          hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page - 1 }}"
-          hx-target="main"
-          hx-push-url="true"
-        >&larr; Previous</a>
-      {% else %}<span></span>{% endif %}
-      {% if has_next %}
-        <a
-          class="text-stone-600 hover:text-stone-900 underline"
-          href="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page + 1 }}"
-          hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page + 1 }}"
-          hx-target="main"
-          hx-push-url="true"
-        >Next &rarr;</a>
-      {% else %}<span></span>{% endif %}
-    </nav>
+  {% if include_proceedings %}
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-3">
+        Proceedings ({{ total }})
+      </h2>
+      {% if total == 0 %}
+        <p class="text-stone-600">
+          No proceedings match <span class="font-mono">&ldquo;{{ query }}&rdquo;</span>.
+        </p>
+      {% else %}
+        <p class="text-sm text-stone-500 mb-4">
+          page {{ page }}.
+        </p>
+        <ol class="space-y-6">
+          {% for entry in results %}
+            {% include "_result_card.html" %}
+          {% endfor %}
+        </ol>
+
+        {% if has_prev or has_next %}
+          <nav class="mt-8 flex justify-between text-sm">
+            {% if has_prev %}
+              <a
+                class="text-stone-600 hover:text-stone-900 underline"
+                href="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page - 1 }}"
+                hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page - 1 }}"
+                hx-target="main"
+                hx-push-url="true"
+              >&larr; Previous</a>
+            {% else %}<span></span>{% endif %}
+            {% if has_next %}
+              <a
+                class="text-stone-600 hover:text-stone-900 underline"
+                href="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page + 1 }}"
+                hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&page={{ page + 1 }}"
+                hx-target="main"
+                hx-push-url="true"
+              >Next &rarr;</a>
+            {% else %}<span></span>{% endif %}
+          </nav>
+        {% endif %}
+      {% endif %}
+    </section>
   {% endif %}
 {% endif %}

--- a/src/concord/web/templates/base.html
+++ b/src/concord/web/templates/base.html
@@ -16,6 +16,10 @@
           Concord
         </a>
         <span class="text-sm text-stone-500">— search the Congressional Record</span>
+        <nav class="ml-auto text-sm flex gap-3">
+          <a href="/" class="text-stone-600 hover:text-stone-900">Search</a>
+          <a href="/members" class="text-stone-600 hover:text-stone-900">Members</a>
+        </nav>
       </div>
       <form
         hx-get="/search"

--- a/src/concord/web/templates/members/list.html
+++ b/src/concord/web/templates/members/list.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+{% block title %}Members — Concord{% endblock %}
+{% block content %}
+<div>
+  <div class="flex items-baseline justify-between mb-4">
+    <h1 class="text-2xl font-serif font-semibold text-stone-900">Members</h1>
+    <span class="text-sm text-stone-500">{{ total }} currently serving</span>
+  </div>
+
+  <form method="get" action="/members" class="mb-6 flex flex-wrap gap-4 text-sm text-stone-600">
+    <fieldset class="flex flex-wrap gap-3">
+      <legend class="text-stone-500 uppercase tracking-wide text-xs mr-2">Chamber</legend>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="chamber" value="" {% if not chamber %}checked{% endif %}>
+        <span>All</span>
+      </label>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="chamber" value="house" {% if chamber == "house" %}checked{% endif %}>
+        <span>House</span>
+      </label>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="chamber" value="senate" {% if chamber == "senate" %}checked{% endif %}>
+        <span>Senate</span>
+      </label>
+    </fieldset>
+    <fieldset class="flex flex-wrap gap-3">
+      <legend class="text-stone-500 uppercase tracking-wide text-xs mr-2">Party</legend>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="party" value="" {% if not party %}checked{% endif %}>
+        <span>All</span>
+      </label>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="party" value="Democratic" {% if party == "Democratic" %}checked{% endif %}>
+        <span>D</span>
+      </label>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="party" value="Republican" {% if party == "Republican" %}checked{% endif %}>
+        <span>R</span>
+      </label>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="party" value="Independent" {% if party == "Independent" %}checked{% endif %}>
+        <span>I</span>
+      </label>
+    </fieldset>
+    <button
+      type="submit"
+      class="rounded bg-stone-900 px-3 py-1 text-white text-xs font-medium hover:bg-stone-700"
+    >Apply</button>
+  </form>
+
+  {% if members %}
+    <ul class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      {% for m in members %}
+        <li class="flex items-center gap-3 border border-stone-200 rounded p-3 bg-white">
+          {% if m.photo_url %}
+            <img
+              src="{{ m.photo_url }}"
+              alt=""
+              class="w-12 h-12 rounded-full object-cover border border-stone-200"
+              loading="lazy"
+            >
+          {% else %}
+            <div class="w-12 h-12 rounded-full bg-stone-100 border border-stone-200"></div>
+          {% endif %}
+          <div class="min-w-0">
+            <a
+              href="/members/{{ m.bioguide_id }}"
+              class="font-medium text-stone-900 hover:text-stone-700 truncate block"
+            >{{ m.display_name }}</a>
+            <div class="text-xs text-stone-500 truncate">
+              {{ "Sen." if m.chamber == "senate" else "Rep." }}
+              {{ m.state }}{% if m.district %}-{{ "%02d"|format(m.district) }}{% endif %}
+              {% if m.party %} · {{ m.party }}{% endif %}
+            </div>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+
+    {% if has_prev or has_next %}
+      <nav class="mt-8 flex justify-between text-sm">
+        {% if has_prev %}
+          <a
+            class="text-stone-600 hover:text-stone-900 underline"
+            href="/members?chamber={{ chamber }}&party={{ party|urlencode }}&page={{ page - 1 }}"
+          >&larr; Previous</a>
+        {% else %}<span></span>{% endif %}
+        {% if has_next %}
+          <a
+            class="text-stone-600 hover:text-stone-900 underline"
+            href="/members?chamber={{ chamber }}&party={{ party|urlencode }}&page={{ page + 1 }}"
+          >Next &rarr;</a>
+        {% else %}<span></span>{% endif %}
+      </nav>
+    {% endif %}
+  {% else %}
+    <p class="text-stone-600">No Members match the current filters.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/concord/web/templates/members/profile.html
+++ b/src/concord/web/templates/members/profile.html
@@ -1,0 +1,111 @@
+{% extends "base.html" %}
+{% block title %}{{ member.display_name }} — Concord{% endblock %}
+{% block content %}
+<article class="grid grid-cols-1 md:grid-cols-4 gap-6">
+  <aside class="md:col-span-1 text-sm text-stone-600 space-y-3">
+    {% if member.photo_url %}
+      <img
+        src="{{ member.photo_url }}"
+        alt=""
+        class="w-full rounded border border-stone-200"
+      >
+    {% endif %}
+    {% if current_term %}
+      <div>
+        <div class="uppercase text-xs tracking-wide text-stone-400">Currently serving</div>
+        <div>
+          {{ "Senator" if current_term.chamber == "senate" else "Representative" }}
+          for {{ current_term.state }}{% if current_term.district %}-{{ "%02d"|format(current_term.district) }}{% endif %}
+        </div>
+        {% if current_term.party %}<div>{{ current_term.party }}</div>{% endif %}
+      </div>
+    {% else %}
+      <div class="text-stone-500">Not currently serving.</div>
+    {% endif %}
+    {% if member.birth_year %}
+      <div>
+        <div class="uppercase text-xs tracking-wide text-stone-400">Born</div>
+        <div>{{ member.birth_year }}{% if member.death_year %} – {{ member.death_year }}{% endif %}</div>
+      </div>
+    {% endif %}
+    <div class="text-xs text-stone-400">
+      Bioguide: <span class="font-mono">{{ member.bioguide_id }}</span>
+    </div>
+    <div class="text-xs text-stone-400">
+      Snapshot: {{ member.fetched_at }}
+    </div>
+  </aside>
+
+  <div class="md:col-span-3 space-y-8">
+    <h1 class="text-2xl font-serif font-semibold">{{ member.display_name }}</h1>
+
+    {% if member.biography %}
+      <section>
+        <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Biography</h2>
+        {% if member.biography|length > 300 %}
+          <details>
+            <summary class="cursor-pointer text-stone-700">
+              {{ member.biography[:300] }}…
+              <span class="text-stone-500 text-xs ml-1">(expand)</span>
+            </summary>
+            <p class="mt-2 leading-relaxed text-stone-800">{{ member.biography }}</p>
+          </details>
+        {% else %}
+          <p class="leading-relaxed text-stone-800">{{ member.biography }}</p>
+        {% endif %}
+      </section>
+    {% endif %}
+
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Term history</h2>
+      {% if terms %}
+        <table class="w-full text-sm">
+          <thead class="text-left text-xs uppercase tracking-wide text-stone-500">
+            <tr>
+              <th class="py-1 pr-3">Congress</th>
+              <th class="py-1 pr-3">Chamber</th>
+              <th class="py-1 pr-3">State</th>
+              <th class="py-1 pr-3">District</th>
+              <th class="py-1 pr-3">Party</th>
+              <th class="py-1 pr-3">Years</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for t in terms %}
+              <tr class="border-t border-stone-100">
+                <td class="py-1 pr-3">{{ t.congress }}</td>
+                <td class="py-1 pr-3">{{ t.chamber|capitalize }}</td>
+                <td class="py-1 pr-3">{{ t.state }}</td>
+                <td class="py-1 pr-3">{% if t.district %}{{ "%02d"|format(t.district) }}{% else %}—{% endif %}</td>
+                <td class="py-1 pr-3">{{ t.party or "—" }}</td>
+                <td class="py-1 pr-3 text-stone-500">
+                  {{ t.start_date[:4] if t.start_date else "?" }} –
+                  {{ t.end_date[:4] if t.end_date else "present" }}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="text-stone-500">No term history recorded.</p>
+      {% endif %}
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-sm uppercase tracking-wide text-stone-500">Coming in later phases</h2>
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Sponsored bills (Phase 2)</div>
+        <div class="text-xs">Bills this Member introduced or cosponsored will appear here.</div>
+      </div>
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Recent votes (Phase 3)</div>
+        <div class="text-xs">Recent roll-call positions will appear here.</div>
+      </div>
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Mentioned in proceedings (Phase 6)</div>
+        <div class="text-xs">Floor statements that name this Member will appear here.</div>
+      </div>
+    </section>
+  </div>
+</article>
+{% endblock %}

--- a/tests/_snapshots.py
+++ b/tests/_snapshots.py
@@ -1,0 +1,33 @@
+"""Shared helper for constructing the ADR 0006 snapshot envelope.
+
+Every entity-test module that exercises a mutable entity (Members from
+Phase 1, Bills/Votes/etc. from later phases) uses :func:`wrap_snapshot`
+to keep the envelope shape consistent.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+def wrap_snapshot(
+    payload: dict[str, Any],
+    *,
+    fetched_at: datetime,
+    key: dict[str, Any],
+) -> dict[str, Any]:
+    """Build one ADR-0006-shaped snapshot envelope around ``payload``.
+
+    Returns a dict whose keys are exactly ``fetched_at``, ``key``,
+    ``payload`` — matching :class:`concord.models.MemberSnapshot` and the
+    JSONL row shape the scraper appends.
+    """
+    return {
+        "fetched_at": fetched_at.isoformat(),
+        "key": key,
+        "payload": payload,
+    }
+
+
+__all__ = ["wrap_snapshot"]

--- a/tests/fixtures/api/members/current_house.json
+++ b/tests/fixtures/api/members/current_house.json
@@ -1,0 +1,62 @@
+{
+  "members": [
+    {
+      "bioguideId": "O000172",
+      "name": "Ocasio-Cortez, Alexandria",
+      "directOrderName": "Alexandria Ocasio-Cortez",
+      "invertedOrderName": "Ocasio-Cortez, Alexandria",
+      "firstName": "Alexandria",
+      "lastName": "Ocasio-Cortez",
+      "partyName": "Democratic",
+      "state": "New York",
+      "district": 14,
+      "depiction": {
+        "imageUrl": "https://www.congress.gov/img/member/o000172.jpg",
+        "attribution": "Image courtesy of the Member"
+      },
+      "terms": {
+        "item": [
+          {
+            "chamber": "House of Representatives",
+            "congress": 117,
+            "startYear": 2021,
+            "endYear": 2023,
+            "stateCode": "NY",
+            "stateName": "New York",
+            "district": 14,
+            "partyName": "Democratic"
+          },
+          {
+            "chamber": "House of Representatives",
+            "congress": 118,
+            "startYear": 2023,
+            "endYear": 2025,
+            "stateCode": "NY",
+            "stateName": "New York",
+            "district": 14,
+            "partyName": "Democratic"
+          },
+          {
+            "chamber": "House of Representatives",
+            "congress": 119,
+            "startYear": 2025,
+            "stateCode": "NY",
+            "stateName": "New York",
+            "district": 14,
+            "partyName": "Democratic"
+          }
+        ]
+      },
+      "updateDate": "2026-01-15T00:00:00Z",
+      "url": "https://api.congress.gov/v3/member/O000172"
+    }
+  ],
+  "pagination": {
+    "count": 1
+  },
+  "request": {
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/fixtures/api/members/current_senate.json
+++ b/tests/fixtures/api/members/current_senate.json
@@ -1,0 +1,69 @@
+{
+  "members": [
+    {
+      "bioguideId": "S000033",
+      "name": "Sanders, Bernard",
+      "directOrderName": "Bernard Sanders",
+      "invertedOrderName": "Sanders, Bernard",
+      "firstName": "Bernard",
+      "lastName": "Sanders",
+      "birthYear": "1941",
+      "partyName": "Independent",
+      "state": "Vermont",
+      "district": null,
+      "depiction": {
+        "imageUrl": "https://www.congress.gov/img/member/s000033.jpg"
+      },
+      "terms": {
+        "item": [
+          {
+            "chamber": "House of Representatives",
+            "congress": 102,
+            "startYear": 1991,
+            "endYear": 1993,
+            "stateCode": "VT",
+            "stateName": "Vermont",
+            "district": 0,
+            "partyName": "Independent"
+          },
+          {
+            "chamber": "Senate",
+            "congress": 117,
+            "startYear": 2021,
+            "endYear": 2023,
+            "stateCode": "VT",
+            "stateName": "Vermont",
+            "partyName": "Independent"
+          },
+          {
+            "chamber": "Senate",
+            "congress": 118,
+            "startYear": 2023,
+            "endYear": 2025,
+            "stateCode": "VT",
+            "stateName": "Vermont",
+            "partyName": "Independent"
+          },
+          {
+            "chamber": "Senate",
+            "congress": 119,
+            "startYear": 2025,
+            "stateCode": "VT",
+            "stateName": "Vermont",
+            "partyName": "Independent"
+          }
+        ]
+      },
+      "updateDate": "2026-01-15T00:00:00Z",
+      "url": "https://api.congress.gov/v3/member/S000033"
+    }
+  ],
+  "pagination": {
+    "count": 1
+  },
+  "request": {
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/fixtures/api/members/historical.json
+++ b/tests/fixtures/api/members/historical.json
@@ -1,0 +1,50 @@
+{
+  "members": [
+    {
+      "bioguideId": "J000301",
+      "name": "Jeffords, James M.",
+      "directOrderName": "James M. Jeffords",
+      "invertedOrderName": "Jeffords, James M.",
+      "firstName": "James",
+      "middleName": "M.",
+      "lastName": "Jeffords",
+      "birthYear": "1934",
+      "deathYear": "2014",
+      "depiction": {
+        "imageUrl": "https://www.congress.gov/img/member/j000301.jpg"
+      },
+      "terms": {
+        "item": [
+          {
+            "chamber": "Senate",
+            "congress": 116,
+            "startYear": 2019,
+            "endYear": 2021,
+            "stateCode": "VT",
+            "stateName": "Vermont",
+            "partyName": "Republican"
+          },
+          {
+            "chamber": "Senate",
+            "congress": 117,
+            "startYear": 2021,
+            "endYear": 2023,
+            "stateCode": "VT",
+            "stateName": "Vermont",
+            "partyName": "Independent"
+          }
+        ]
+      },
+      "updateDate": "2014-08-19T00:00:00Z",
+      "url": "https://api.congress.gov/v3/member/J000301"
+    }
+  ],
+  "pagination": {
+    "count": 1
+  },
+  "request": {
+    "congress": "117",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -431,3 +431,43 @@ class TestRetry429:
             client.list_issues()
         # HTTP-date form not supported; falls back to exponential.
         assert sleeps == [1.0]
+
+
+# -- list_members ------------------------------------------------------------
+
+
+class TestListMembers:
+    def test_iterates_single_page(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/members/current_house.json").read_text())
+        client = _make_client(lambda r: _json_response(payload))
+        with client:
+            members = list(client.list_members(congress=119))
+        assert len(members) == 1
+        assert members[0]["bioguideId"] == "O000172"
+
+    def test_paginates_until_no_next(self, fixtures_dir: Path) -> None:
+        page1 = json.loads((fixtures_dir / "api/members/current_house.json").read_text())
+        page1["pagination"] = {"next": "https://example.invalid/next", "count": 2}
+        page2 = json.loads((fixtures_dir / "api/members/current_senate.json").read_text())
+
+        responses = iter([page1, page2])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response(next(responses))
+
+        client = _make_client(handler)
+        with client:
+            members = list(client.list_members(congress=119))
+        assert [m["bioguideId"] for m in members] == ["O000172", "S000033"]
+
+    def test_passes_congress_into_path(self) -> None:
+        captured: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request.url.path)
+            return _json_response({"members": [], "pagination": {"count": 0}})
+
+        client = _make_client(handler)
+        with client:
+            list(client.list_members(congress=118))
+        assert captured == ["/v3/member/congress/118"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,8 +15,9 @@ import pytest
 from typer.testing import CliRunner
 
 import concord.cli as cli_module
+import concord.scraper.proceedings as scraper_proceedings_module
 from concord.api import ENV_API_KEY, ApiError
-from concord.pipeline import PullResult
+from concord.pipeline.load_proceedings import PullResult
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -42,14 +43,14 @@ def with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def stub_pull(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
-    """Replace ``concord.cli.pull`` with a recorder; return the call log."""
+    """Replace ``concord.scraper.proceedings.pull`` with a recorder; return the call log."""
     calls: list[dict[str, Any]] = []
 
     def fake_pull(start: date, end: date, **kwargs: Any) -> PullResult:
         calls.append({"start": start, "end": end, **kwargs})
         return PullResult(written=3, skipped=1)
 
-    monkeypatch.setattr(cli_module, "pull", fake_pull)
+    monkeypatch.setattr(scraper_proceedings_module, "pull", fake_pull)
     return calls
 
 
@@ -58,7 +59,7 @@ def stub_pull(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
 
 class TestHelp:
     def test_help_lists_all_flags(self, runner: CliRunner) -> None:
-        result = runner.invoke(cli_module.app, ["pull", "--help"])
+        result = runner.invoke(cli_module.app, ["scrape", "proceedings", "--help"])
         assert result.exit_code == 0
         # All four flags must appear in --help.
         plain = _strip(result.output)
@@ -77,7 +78,7 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -102,7 +103,7 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-01",
                 "--to",
@@ -126,7 +127,7 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -151,7 +152,7 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -173,7 +174,7 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -198,7 +199,7 @@ class TestArgParsing:
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(
             cli_module.app,
-            ["pull", "--from", "2026-05-22", "--to", "2026-05-22"],
+            ["scrape", "proceedings", "--from", "2026-05-22", "--to", "2026-05-22"],
         )
         assert result.exit_code == 0, result.output
         # Default path is ./proceedings.jsonl
@@ -214,7 +215,7 @@ class TestArgParsing:
     ) -> None:
         result = runner.invoke(
             cli_module.app,
-            ["pull", "--from", bad_date, "--to", "2026-05-22"],
+            ["scrape", "proceedings", "--from", bad_date, "--to", "2026-05-22"],
         )
         assert result.exit_code != 0
         # stub_pull should not have been called.
@@ -236,7 +237,7 @@ class TestSuccessOutput:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -269,7 +270,7 @@ class TestMissingApiKey:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -298,11 +299,11 @@ class TestMissingApiKey:
         def boom(**_: Any) -> Any:
             raise ApiError("simulated init failure")
 
-        monkeypatch.setattr(cli_module, "Client", boom)
+        monkeypatch.setattr(scraper_proceedings_module, "Client", boom)
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -342,7 +343,7 @@ class TestMongoBackend:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -378,7 +379,7 @@ class TestMongoBackend:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -415,7 +416,7 @@ def _write_jsonl(path: Path, granule_ids: list[str]) -> None:
 
 class TestLoadCommand:
     def test_help_lists_all_flags(self, runner: CliRunner) -> None:
-        result = runner.invoke(cli_module.app, ["load", "--help"])
+        result = runner.invoke(cli_module.app, ["load", "proceedings", "--help"])
         assert result.exit_code == 0
         plain = _strip(result.output)
         for flag in ["--jsonl", "--db", "--limit"]:
@@ -432,7 +433,7 @@ class TestLoadCommand:
 
         result = runner.invoke(
             cli_module.app,
-            ["load", "--jsonl", str(jsonl), "--db", str(db)],
+            ["load", "proceedings", "--jsonl", str(jsonl), "--db", str(db)],
         )
         assert result.exit_code == 0, result.output
         plain = _strip(result.output)
@@ -454,9 +455,9 @@ class TestLoadCommand:
         db = tmp_path / "out.db"
         _write_jsonl(jsonl, ["CREC-2026-05-22-pt1-PgD551-1", "CREC-2026-05-22-pt1-PgD551-2"])
 
-        first = runner.invoke(cli_module.app, ["load", "--jsonl", str(jsonl), "--db", str(db)])
+        first = runner.invoke(cli_module.app, ["load", "proceedings", "--jsonl", str(jsonl), "--db", str(db)])
         assert first.exit_code == 0
-        second = runner.invoke(cli_module.app, ["load", "--jsonl", str(jsonl), "--db", str(db)])
+        second = runner.invoke(cli_module.app, ["load", "proceedings", "--jsonl", str(jsonl), "--db", str(db)])
         assert second.exit_code == 0, second.output
         plain = _strip(second.output)
         assert "Loaded 0 new proceedings" in plain
@@ -481,7 +482,7 @@ class TestLoadCommand:
         )
         result = runner.invoke(
             cli_module.app,
-            ["load", "--jsonl", str(jsonl), "--db", str(db), "--limit", "2"],
+            ["load", "proceedings", "--jsonl", str(jsonl), "--db", str(db), "--limit", "2"],
         )
         assert result.exit_code == 0, result.output
         plain = _strip(result.output)
@@ -512,7 +513,7 @@ class TestLoadCommand:
 
         result = runner.invoke(
             cli_module.app,
-            ["load", "--jsonl", str(jsonl), "--db", str(db)],
+            ["load", "proceedings", "--jsonl", str(jsonl), "--db", str(db)],
         )
         assert result.exit_code == 0, result.output
         plain = _strip(result.output)
@@ -533,7 +534,7 @@ class TestLoadCommand:
 
         result = runner.invoke(
             cli_module.app,
-            ["load", "--jsonl", str(jsonl), "--db", str(db)],
+            ["load", "proceedings", "--jsonl", str(jsonl), "--db", str(db)],
         )
         assert result.exit_code == 0, result.output
         # Blank lines aren't malformed — they're just skipped silently.
@@ -548,7 +549,7 @@ class TestLoadCommand:
         result = runner.invoke(
             cli_module.app,
             [
-                "load",
+                "load", "proceedings",
                 "--jsonl",
                 str(tmp_path / "does-not-exist.jsonl"),
                 "--db",
@@ -623,7 +624,7 @@ class _FakeOpenAIClient:
 
 class TestIndexCommand:
     def test_help_lists_all_flags(self, runner: CliRunner) -> None:
-        result = runner.invoke(cli_module.app, ["index", "--help"])
+        result = runner.invoke(cli_module.app, ["index", "proceedings", "--help"])
         assert result.exit_code == 0
         plain = _strip(result.output)
         for flag in ["--db", "--limit"]:
@@ -636,7 +637,7 @@ class TestIndexCommand:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv(cli_module.ENV_OPENAI_API_KEY, "sk-test")
-        result = runner.invoke(cli_module.app, ["index", "--db", str(tmp_path / "missing.db")])
+        result = runner.invoke(cli_module.app, ["index", "proceedings", "--db", str(tmp_path / "missing.db")])
         assert result.exit_code == 2
         plain = _strip(result.output) + _strip(result.stderr or "")
         assert "not found" in plain
@@ -651,7 +652,7 @@ class TestIndexCommand:
         monkeypatch.delenv(cli_module.ENV_OPENAI_API_KEY, raising=False)
         db = tmp_path / "out.db"
         _seed_db_for_index(db, ["CREC-2026-05-22-pt1-PgD551-1"])
-        result = runner.invoke(cli_module.app, ["index", "--db", str(db)])
+        result = runner.invoke(cli_module.app, ["index", "proceedings", "--db", str(db)])
         assert result.exit_code == 2
         plain = _strip(result.output) + _strip(result.stderr or "")
         assert cli_module.ENV_OPENAI_API_KEY in plain
@@ -672,7 +673,7 @@ class TestIndexCommand:
 
         monkeypatch.setattr(openai, "OpenAI", lambda *a, **kw: _FakeOpenAIClient())
 
-        result = runner.invoke(cli_module.app, ["index", "--db", str(db)])
+        result = runner.invoke(cli_module.app, ["index", "proceedings", "--db", str(db)])
         assert result.exit_code == 0, result.output
         plain = _strip(result.output)
         assert "Indexed:" in plain
@@ -790,7 +791,7 @@ class TestDefaults:
         result = runner.invoke(
             cli_module.app,
             [
-                "pull",
+                "scrape", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--storage",
@@ -808,7 +809,7 @@ class TestDefaults:
 
 class TestRunCommand:
     def test_help_lists_all_flags(self, runner: CliRunner) -> None:
-        result = runner.invoke(cli_module.app, ["run", "--help"])
+        result = runner.invoke(cli_module.app, ["run", "proceedings", "--help"])
         assert result.exit_code == 0
         plain = _strip(result.output)
         for flag in ["--from", "--to", "--storage", "--db", "--limit"]:
@@ -822,8 +823,8 @@ class TestRunCommand:
         tmp_path: Path,
     ) -> None:
         """`concord run` should call _run_pull, _run_load, _run_index in order."""
-        from concord.indexing import IndexResult
-        from concord.pipeline import PullResult
+        from concord.pipeline.index_proceedings import IndexResult
+        from concord.pipeline.load_proceedings import PullResult
 
         monkeypatch.setenv(cli_module.ENV_OPENAI_API_KEY, "sk-test")
         calls: list[str] = []
@@ -853,7 +854,7 @@ class TestRunCommand:
         result = runner.invoke(
             cli_module.app,
             [
-                "run",
+                "run", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -880,7 +881,7 @@ class TestRunCommand:
         result = runner.invoke(
             cli_module.app,
             [
-                "run",
+                "run", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--storage",
@@ -902,7 +903,7 @@ class TestRunCommand:
         result = runner.invoke(
             cli_module.app,
             [
-                "run",
+                "run", "proceedings",
                 "--from",
                 "2026-05-22",
                 "--storage",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,7 +78,8 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -103,7 +104,8 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-01",
                 "--to",
@@ -127,7 +129,8 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -152,7 +155,8 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -174,7 +178,8 @@ class TestArgParsing:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -237,7 +242,8 @@ class TestSuccessOutput:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -270,7 +276,8 @@ class TestMissingApiKey:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -303,7 +310,8 @@ class TestMissingApiKey:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -343,7 +351,8 @@ class TestMongoBackend:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -379,7 +388,8 @@ class TestMongoBackend:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -455,9 +465,10 @@ class TestLoadCommand:
         db = tmp_path / "out.db"
         _write_jsonl(jsonl, ["CREC-2026-05-22-pt1-PgD551-1", "CREC-2026-05-22-pt1-PgD551-2"])
 
-        first = runner.invoke(cli_module.app, ["load", "proceedings", "--jsonl", str(jsonl), "--db", str(db)])
+        args = ["load", "proceedings", "--jsonl", str(jsonl), "--db", str(db)]
+        first = runner.invoke(cli_module.app, args)
         assert first.exit_code == 0
-        second = runner.invoke(cli_module.app, ["load", "proceedings", "--jsonl", str(jsonl), "--db", str(db)])
+        second = runner.invoke(cli_module.app, args)
         assert second.exit_code == 0, second.output
         plain = _strip(second.output)
         assert "Loaded 0 new proceedings" in plain
@@ -549,7 +560,8 @@ class TestLoadCommand:
         result = runner.invoke(
             cli_module.app,
             [
-                "load", "proceedings",
+                "load",
+                "proceedings",
                 "--jsonl",
                 str(tmp_path / "does-not-exist.jsonl"),
                 "--db",
@@ -637,7 +649,10 @@ class TestIndexCommand:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv(cli_module.ENV_OPENAI_API_KEY, "sk-test")
-        result = runner.invoke(cli_module.app, ["index", "proceedings", "--db", str(tmp_path / "missing.db")])
+        result = runner.invoke(
+            cli_module.app,
+            ["index", "proceedings", "--db", str(tmp_path / "missing.db")],
+        )
         assert result.exit_code == 2
         plain = _strip(result.output) + _strip(result.stderr or "")
         assert "not found" in plain
@@ -791,7 +806,8 @@ class TestDefaults:
         result = runner.invoke(
             cli_module.app,
             [
-                "scrape", "proceedings",
+                "scrape",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--storage",
@@ -854,7 +870,8 @@ class TestRunCommand:
         result = runner.invoke(
             cli_module.app,
             [
-                "run", "proceedings",
+                "run",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--to",
@@ -881,7 +898,8 @@ class TestRunCommand:
         result = runner.invoke(
             cli_module.app,
             [
-                "run", "proceedings",
+                "run",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--storage",
@@ -903,7 +921,8 @@ class TestRunCommand:
         result = runner.invoke(
             cli_module.app,
             [
-                "run", "proceedings",
+                "run",
+                "proceedings",
                 "--from",
                 "2026-05-22",
                 "--storage",

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from concord.chunking import Chunker, ChunkerConfig
 from concord.embedding import EMBEDDING_DIM, Embedder
-from concord.indexing import IndexResult, ProgressEvent, index
+from concord.pipeline.index_proceedings import IndexResult, ProgressEvent, index
 from concord.models import Article, Issue, Proceeding
 from concord.storage import SqliteStorage
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from concord.chunking import Chunker, ChunkerConfig
 from concord.embedding import EMBEDDING_DIM, Embedder
-from concord.pipeline.index_proceedings import IndexResult, ProgressEvent, index
 from concord.models import Article, Issue, Proceeding
+from concord.pipeline.index_proceedings import IndexResult, ProgressEvent, index
 from concord.storage import SqliteStorage
 
 

--- a/tests/test_models_members.py
+++ b/tests/test_models_members.py
@@ -13,8 +13,6 @@ from typing import Any
 import pytest
 
 from concord.models import (
-    Chamber,
-    Member,
     MemberSnapshot,
     Term,
     normalize_state,
@@ -33,7 +31,7 @@ class TestNormalization:
             ("Vermont", "VT"),
             ("New York", "NY"),
             ("vermont", "VT"),  # case-insensitive
-            ("VT", "VT"),       # pass-through for codes
+            ("VT", "VT"),  # pass-through for codes
             ("Puerto Rico", "PR"),
             (None, None),
         ],
@@ -69,7 +67,7 @@ class TestParseMemberCurrentHouse:
 
     def test_current_term_has_no_end_date(self, payload: dict[str, Any]) -> None:
         _, terms = parse_member(payload)
-        current = [t for t in terms if t.congress == 119][0]
+        current = next(t for t in terms if t.congress == 119)
         assert current.end_date is None
         assert current.start_date == "2025-01-01"
 

--- a/tests/test_models_members.py
+++ b/tests/test_models_members.py
@@ -1,0 +1,163 @@
+"""Tests for Member / Term / MemberSnapshot models.
+
+Covers (1) parsing real API payloads into typed records, (2) the
+ADR 0006 envelope round-trip, and (3) the state/chamber normalization
+the projection layer performs at the boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from concord.models import (
+    Chamber,
+    Member,
+    MemberSnapshot,
+    Term,
+    normalize_state,
+    parse_member,
+)
+
+from ._snapshots import wrap_snapshot
+
+FIXED_FETCHED_AT = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC)
+
+
+class TestNormalization:
+    @pytest.mark.parametrize(
+        "input_, expected",
+        [
+            ("Vermont", "VT"),
+            ("New York", "NY"),
+            ("vermont", "VT"),  # case-insensitive
+            ("VT", "VT"),       # pass-through for codes
+            ("Puerto Rico", "PR"),
+            (None, None),
+        ],
+    )
+    def test_normalize_state(self, input_: str | None, expected: str | None) -> None:
+        assert normalize_state(input_) == expected
+
+
+class TestParseMemberCurrentHouse:
+    @pytest.fixture
+    def payload(self, load_json_fixture: Any) -> dict[str, Any]:
+        return load_json_fixture("api/members/current_house.json")["members"][0]
+
+    def test_parses_identity_fields(self, payload: dict[str, Any]) -> None:
+        member, _ = parse_member(payload)
+        assert member.bioguide_id == "O000172"
+        assert member.first_name == "Alexandria"
+        assert member.last_name == "Ocasio-Cortez"
+        assert member.display_name == "Alexandria Ocasio-Cortez"
+        assert member.photo_url == "https://www.congress.gov/img/member/o000172.jpg"
+
+    def test_parses_terms(self, payload: dict[str, Any]) -> None:
+        _, terms = parse_member(payload)
+        assert len(terms) == 3
+        congresses = sorted(t.congress for t in terms)
+        assert congresses == [117, 118, 119]
+        for t in terms:
+            assert t.bioguide_id == "O000172"
+            assert t.chamber == "house"
+            assert t.state == "NY"
+            assert t.district == 14
+            assert t.party == "Democratic"
+
+    def test_current_term_has_no_end_date(self, payload: dict[str, Any]) -> None:
+        _, terms = parse_member(payload)
+        current = [t for t in terms if t.congress == 119][0]
+        assert current.end_date is None
+        assert current.start_date == "2025-01-01"
+
+
+class TestParseMemberCurrentSenate:
+    @pytest.fixture
+    def payload(self, load_json_fixture: Any) -> dict[str, Any]:
+        return load_json_fixture("api/members/current_senate.json")["members"][0]
+
+    def test_senator_has_no_district(self, payload: dict[str, Any]) -> None:
+        _, terms = parse_member(payload)
+        senate_terms = [t for t in terms if t.chamber == "senate"]
+        assert len(senate_terms) == 3
+        for t in senate_terms:
+            assert t.district is None
+
+    def test_mixed_chamber_history_preserved(self, payload: dict[str, Any]) -> None:
+        _, terms = parse_member(payload)
+        chambers = {(t.congress, t.chamber) for t in terms}
+        # Sanders served one term in the House (102nd) and three in the Senate.
+        assert (102, "house") in chambers
+        assert (119, "senate") in chambers
+
+    def test_member_carries_birth_year(self, payload: dict[str, Any]) -> None:
+        member, _ = parse_member(payload)
+        assert member.birth_year == 1941
+
+
+class TestParseHistoricalMember:
+    @pytest.fixture
+    def payload(self, load_json_fixture: Any) -> dict[str, Any]:
+        return load_json_fixture("api/members/historical.json")["members"][0]
+
+    def test_death_year_parsed(self, payload: dict[str, Any]) -> None:
+        member, _ = parse_member(payload)
+        assert member.death_year == 2014
+
+    def test_party_change_preserved_per_term(self, payload: dict[str, Any]) -> None:
+        _, terms = parse_member(payload)
+        parties = {t.congress: t.party for t in terms}
+        # Two terms with different parties.
+        assert parties[116] == "Republican"
+        assert parties[117] == "Independent"
+
+    def test_end_date_populated_for_ended_term(self, payload: dict[str, Any]) -> None:
+        _, terms = parse_member(payload)
+        ended = [t for t in terms if t.end_date is not None]
+        assert ended, "expected at least one term with an end date"
+
+
+class TestSnapshotEnvelope:
+    def test_round_trip(self) -> None:
+        payload = {"bioguideId": "X000001", "name": "Doe, John"}
+        envelope = wrap_snapshot(
+            payload,
+            fetched_at=FIXED_FETCHED_AT,
+            key={"bioguide_id": "X000001"},
+        )
+        snapshot = MemberSnapshot.model_validate(envelope)
+        assert snapshot.fetched_at == FIXED_FETCHED_AT
+        assert snapshot.key == {"bioguide_id": "X000001"}
+        assert snapshot.payload == payload
+
+    def test_envelope_keys_exact(self) -> None:
+        envelope = wrap_snapshot(
+            {"x": 1},
+            fetched_at=FIXED_FETCHED_AT,
+            key={"bioguide_id": "Y000001"},
+        )
+        assert set(envelope.keys()) == {"fetched_at", "key", "payload"}
+
+
+class TestTermValidation:
+    def test_chamber_normalizes_long_form(self) -> None:
+        term = Term(
+            bioguide_id="X000001",
+            congress=119,
+            chamber="House of Representatives",  # API's verbose form
+            state="VT",
+            district=1,
+        )
+        assert term.chamber == "house"
+
+    def test_state_normalizes_full_name(self) -> None:
+        term = Term(
+            bioguide_id="X000001",
+            congress=119,
+            chamber="senate",
+            state="Vermont",
+        )
+        assert term.state == "VT"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -17,7 +17,7 @@ import pytest
 
 from concord.api import Client
 from concord.models import Article, Issue, Proceeding
-from concord.pipeline import pull
+from concord.pipeline.load_proceedings import pull
 from concord.storage import JsonlStorage
 from concord.text import fetch_text
 

--- a/tests/test_pipeline_members.py
+++ b/tests/test_pipeline_members.py
@@ -1,0 +1,208 @@
+"""Tests for the Members Stage 1 (load) and Stage 2 (index) pipelines.
+
+Drives the JSONL → SQLite projection against the captured API fixtures
+and asserts (a) snapshot dedup keeps the latest ``fetched_at`` per
+Bioguide ID, (b) Term rows are replaced on each load (not appended),
+(c) the FTS5 index round-trips a name query back to the right
+``bioguide_id``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from concord.pipeline.index_members import index as index_members
+from concord.pipeline.load_members import load as load_members
+from concord.storage.sqlite import SqliteStorage
+
+from ._snapshots import wrap_snapshot
+
+FIXED_FETCHED_AT = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC)
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    here = Path(__file__).parent / "fixtures" / "api" / "members"
+    return json.loads((here / name).read_text())
+
+
+def _write_jsonl(path: Path, envelopes: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(e) for e in envelopes) + "\n",
+        encoding="utf-8",
+    )
+
+
+class TestLoadMembers:
+    def test_projects_member_and_terms(self, tmp_path: Path) -> None:
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        payload = _fixture("current_house.json")["members"][0]
+        _write_jsonl(
+            jsonl,
+            [
+                wrap_snapshot(
+                    payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
+                )
+            ],
+        )
+
+        stats = load_members(jsonl_path=jsonl, db_path=db)
+        assert stats.members_written == 1
+        assert stats.terms_written == 3
+
+        with SqliteStorage(db, load_vec=False) as storage:
+            row = storage.get_member("O000172")
+            assert row is not None
+            assert row["display_name"] == "Alexandria Ocasio-Cortez"
+            terms = storage.terms_for_member("O000172")
+            assert {t["congress"] for t in terms} == {117, 118, 119}
+
+    def test_latest_snapshot_wins(self, tmp_path: Path) -> None:
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        payload = _fixture("current_house.json")["members"][0]
+        older = wrap_snapshot(
+            {**payload, "directOrderName": "OLD NAME"},
+            fetched_at=FIXED_FETCHED_AT - timedelta(days=30),
+            key={"bioguide_id": "O000172"},
+        )
+        newer = wrap_snapshot(
+            payload,
+            fetched_at=FIXED_FETCHED_AT,
+            key={"bioguide_id": "O000172"},
+        )
+        _write_jsonl(jsonl, [older, newer])
+
+        load_members(jsonl_path=jsonl, db_path=db)
+
+        with SqliteStorage(db, load_vec=False) as storage:
+            row = storage.get_member("O000172")
+            assert row is not None
+            assert row["display_name"] == "Alexandria Ocasio-Cortez"
+
+    def test_terms_are_not_duplicated_on_reload(self, tmp_path: Path) -> None:
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        payload = _fixture("current_house.json")["members"][0]
+        envelope = wrap_snapshot(
+            payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
+        )
+        _write_jsonl(jsonl, [envelope, envelope, envelope])
+
+        stats = load_members(jsonl_path=jsonl, db_path=db)
+        assert stats.snapshots_read == 3
+
+        with SqliteStorage(db, load_vec=False) as storage:
+            terms = storage.terms_for_member("O000172")
+            # Three identical snapshots collapse to one Member with three
+            # distinct Terms — not nine.
+            assert len(terms) == 3
+
+    def test_malformed_lines_counted_not_fatal(self, tmp_path: Path) -> None:
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        payload = _fixture("current_senate.json")["members"][0]
+        good = json.dumps(
+            wrap_snapshot(
+                payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}
+            )
+        )
+        jsonl.write_text(
+            "\n".join(
+                [
+                    "{not valid json",
+                    '{"missing": "envelope-keys"}',
+                    good,
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        stats = load_members(jsonl_path=jsonl, db_path=db)
+        assert stats.malformed == 2
+        assert stats.members_written == 1
+
+    def test_multiple_members_loaded(self, tmp_path: Path) -> None:
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        house = _fixture("current_house.json")["members"][0]
+        senate = _fixture("current_senate.json")["members"][0]
+        _write_jsonl(
+            jsonl,
+            [
+                wrap_snapshot(
+                    house, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
+                ),
+                wrap_snapshot(
+                    senate, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}
+                ),
+            ],
+        )
+
+        stats = load_members(jsonl_path=jsonl, db_path=db)
+        assert stats.members_written == 2
+
+        with SqliteStorage(db, load_vec=False) as storage:
+            assert storage.get_member("O000172") is not None
+            assert storage.get_member("S000033") is not None
+
+
+class TestIndexMembers:
+    def test_populates_fts(self, tmp_path: Path) -> None:
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        house = _fixture("current_house.json")["members"][0]
+        senate = _fixture("current_senate.json")["members"][0]
+        _write_jsonl(
+            jsonl,
+            [
+                wrap_snapshot(
+                    house, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
+                ),
+                wrap_snapshot(
+                    senate, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}
+                ),
+            ],
+        )
+        load_members(jsonl_path=jsonl, db_path=db)
+
+        stats = index_members(db_path=db)
+        assert stats.indexed_members == 2
+
+        with SqliteStorage(db, load_vec=False) as storage:
+            rows = storage.connection.execute(
+                "SELECT bioguide_id FROM members_fts WHERE members_fts MATCH ?",
+                ("Sanders",),
+            ).fetchall()
+            assert [r["bioguide_id"] for r in rows] == ["S000033"]
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        payload = _fixture("current_house.json")["members"][0]
+        _write_jsonl(
+            jsonl,
+            [
+                wrap_snapshot(
+                    payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
+                )
+            ],
+        )
+        load_members(jsonl_path=jsonl, db_path=db)
+
+        first = index_members(db_path=db)
+        second = index_members(db_path=db)
+        assert first.indexed_members == 1
+        assert second.indexed_members == 1
+
+        with SqliteStorage(db, load_vec=False) as storage:
+            (count,) = storage.connection.execute(
+                "SELECT COUNT(*) FROM members_fts"
+            ).fetchone()
+            assert count == 1

--- a/tests/test_pipeline_members.py
+++ b/tests/test_pipeline_members.py
@@ -14,8 +14,6 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from concord.pipeline.index_members import index as index_members
 from concord.pipeline.load_members import load as load_members
 from concord.storage.sqlite import SqliteStorage
@@ -44,11 +42,7 @@ class TestLoadMembers:
         payload = _fixture("current_house.json")["members"][0]
         _write_jsonl(
             jsonl,
-            [
-                wrap_snapshot(
-                    payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
-                )
-            ],
+            [wrap_snapshot(payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"})],
         )
 
         stats = load_members(jsonl_path=jsonl, db_path=db)
@@ -108,9 +102,7 @@ class TestLoadMembers:
         db = tmp_path / "test.db"
         payload = _fixture("current_senate.json")["members"][0]
         good = json.dumps(
-            wrap_snapshot(
-                payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}
-            )
+            wrap_snapshot(payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"})
         )
         jsonl.write_text(
             "\n".join(
@@ -136,12 +128,8 @@ class TestLoadMembers:
         _write_jsonl(
             jsonl,
             [
-                wrap_snapshot(
-                    house, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
-                ),
-                wrap_snapshot(
-                    senate, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}
-                ),
+                wrap_snapshot(house, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}),
+                wrap_snapshot(senate, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}),
             ],
         )
 
@@ -162,12 +150,8 @@ class TestIndexMembers:
         _write_jsonl(
             jsonl,
             [
-                wrap_snapshot(
-                    house, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
-                ),
-                wrap_snapshot(
-                    senate, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}
-                ),
+                wrap_snapshot(house, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}),
+                wrap_snapshot(senate, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}),
             ],
         )
         load_members(jsonl_path=jsonl, db_path=db)
@@ -188,11 +172,7 @@ class TestIndexMembers:
         payload = _fixture("current_house.json")["members"][0]
         _write_jsonl(
             jsonl,
-            [
-                wrap_snapshot(
-                    payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
-                )
-            ],
+            [wrap_snapshot(payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"})],
         )
         load_members(jsonl_path=jsonl, db_path=db)
 
@@ -202,7 +182,5 @@ class TestIndexMembers:
         assert second.indexed_members == 1
 
         with SqliteStorage(db, load_vec=False) as storage:
-            (count,) = storage.connection.execute(
-                "SELECT COUNT(*) FROM members_fts"
-            ).fetchone()
+            (count,) = storage.connection.execute("SELECT COUNT(*) FROM members_fts").fetchone()
             assert count == 1

--- a/tests/test_scraper_members.py
+++ b/tests/test_scraper_members.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-import pytest
 
 from concord.api import Client
 from concord.scraper.members import ScrapeProgressEvent, scrape

--- a/tests/test_scraper_members.py
+++ b/tests/test_scraper_members.py
@@ -1,0 +1,149 @@
+"""Integration tests for the Members Stage 0 scraper.
+
+Drives :func:`concord.scraper.members.scrape` end-to-end against the
+captured ``tests/fixtures/api/members/*.json`` fixtures via
+``httpx.MockTransport``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from concord.api import Client
+from concord.scraper.members import ScrapeProgressEvent, scrape
+
+FIXED_FETCHED_AT = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC)
+
+
+def _client_serving(payloads_by_congress: dict[int, dict[str, Any]]) -> Client:
+    """Build a test Client that returns the right payload per ``congress``.
+
+    Single page per congress, ``pagination`` is left empty so the iterator
+    terminates after one call.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Path is ``/v3/member/congress/{n}``
+        parts = request.url.path.split("/")
+        congress = int(parts[-1])
+        body = payloads_by_congress.get(congress, {"members": [], "pagination": {}})
+        return httpx.Response(
+            200,
+            content=json.dumps(body),
+            headers={"content-type": "application/json"},
+        )
+
+    return Client(
+        api_key="test-key",
+        transport=httpx.MockTransport(handler),
+        sleep=lambda _s: None,
+    )
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    here = Path(__file__).parent / "fixtures" / "api" / "members"
+    return json.loads((here / name).read_text())
+
+
+class TestScrape:
+    def test_writes_one_envelope_per_member(self, tmp_path: Path) -> None:
+        out = tmp_path / "members.jsonl"
+        client = _client_serving({119: _load_fixture("current_house.json")})
+
+        with client:
+            n = scrape(
+                client=client,
+                congresses=[119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+            )
+
+        assert n == 1
+        lines = out.read_text().splitlines()
+        assert len(lines) == 1
+        envelope = json.loads(lines[0])
+        assert envelope["fetched_at"] == FIXED_FETCHED_AT.isoformat()
+        assert envelope["key"] == {"bioguide_id": "O000172"}
+        assert envelope["payload"]["bioguideId"] == "O000172"
+
+    def test_writes_across_multiple_congresses(self, tmp_path: Path) -> None:
+        out = tmp_path / "members.jsonl"
+        client = _client_serving(
+            {
+                117: _load_fixture("historical.json"),
+                119: _load_fixture("current_senate.json"),
+            }
+        )
+
+        with client:
+            n = scrape(
+                client=client,
+                congresses=[117, 119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+            )
+
+        assert n == 2
+        envelopes = [json.loads(line) for line in out.read_text().splitlines()]
+        keys = [e["key"]["bioguide_id"] for e in envelopes]
+        assert keys == ["J000301", "S000033"]
+
+    def test_appends_does_not_truncate(self, tmp_path: Path) -> None:
+        out = tmp_path / "members.jsonl"
+        out.write_text('{"existing": true}\n', encoding="utf-8")
+        client = _client_serving({119: _load_fixture("current_house.json")})
+
+        with client:
+            scrape(
+                client=client,
+                congresses=[119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+            )
+
+        lines = out.read_text().splitlines()
+        assert lines[0] == '{"existing": true}'
+        assert len(lines) == 2
+
+    def test_emits_per_congress_progress(self, tmp_path: Path) -> None:
+        events: list[ScrapeProgressEvent] = []
+        out = tmp_path / "members.jsonl"
+        client = _client_serving(
+            {
+                117: _load_fixture("historical.json"),
+                119: _load_fixture("current_senate.json"),
+            }
+        )
+
+        with client:
+            scrape(
+                client=client,
+                congresses=[117, 119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+                progress=events.append,
+            )
+
+        assert [e.congress for e in events] == [117, 119]
+        assert events[0].total_written == 1
+        assert events[1].total_written == 2
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        out = tmp_path / "nested" / "data" / "members.jsonl"
+        client = _client_serving({119: _load_fixture("current_house.json")})
+
+        with client:
+            scrape(
+                client=client,
+                congresses=[119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+            )
+
+        assert out.exists()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,9 @@
 """Smoke tests proving the project skeleton is wired up correctly."""
 
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import concord
@@ -12,3 +16,85 @@ def test_package_importable() -> None:
 def test_fixtures_dir_exists(fixtures_dir: Path) -> None:
     assert fixtures_dir.exists()
     assert fixtures_dir.is_dir()
+
+
+def test_members_end_to_end(tmp_path: Path) -> None:
+    """One smoke test exercises Stage 1 → Stage 2 → web for Members.
+
+    Skips Stage 0 (network) and instead writes a hand-built JSONL of
+    three snapshots, then loads + indexes + queries the FastAPI app.
+    Asserts the acceptance-criteria HTTP routes all return 200.
+    """
+    from fastapi.testclient import TestClient
+
+    from concord.embedding import EMBEDDING_DIM, Embedder
+    from concord.pipeline.index_members import index as index_members
+    from concord.pipeline.load_members import load as load_members
+    from concord.web.app import create_app
+
+    here = Path(__file__).parent / "fixtures" / "api" / "members"
+    payloads = [
+        json.loads((here / "current_house.json").read_text())["members"][0],
+        json.loads((here / "current_senate.json").read_text())["members"][0],
+        json.loads((here / "historical.json").read_text())["members"][0],
+    ]
+
+    fetched_at = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC).isoformat()
+    jsonl = tmp_path / "members.jsonl"
+    jsonl.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "fetched_at": fetched_at,
+                    "key": {"bioguide_id": p["bioguideId"]},
+                    "payload": p,
+                }
+            )
+            for p in payloads
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    db = tmp_path / "test.db"
+    # Touch the DB with load_vec=True so the chunks_vec virtual table
+    # exists. /search would 500 trying to query it otherwise — a real
+    # deployment would have run `concord run proceedings` first.
+    from concord.storage.sqlite import SqliteStorage as _SqliteStorage
+
+    _SqliteStorage(db).close()
+
+    load_stats = load_members(jsonl_path=jsonl, db_path=db)
+    assert load_stats.members_written == 3
+    index_stats = index_members(db_path=db)
+    assert index_stats.indexed_members == 3
+
+    # Minimal embedder stub — search_proceedings is exercised but the
+    # underlying chunks table is empty, so the embedder is called with
+    # the query but the result set is empty. That's fine for the smoke.
+    class _StubResp:
+        def __init__(self, vectors: list[list[float]]) -> None:
+            self.data = [type("D", (), {"embedding": v})() for v in vectors]
+
+    class _StubEmb:
+        def create(self, *, model: str, input: list[str]) -> _StubResp:
+            return _StubResp([[0.5] * EMBEDDING_DIM for _ in input])
+
+    class _Stub:
+        embeddings = _StubEmb()
+
+    app = create_app(db, embedder=Embedder(_Stub()))
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/members")
+    assert resp.status_code == 200
+    assert "Ocasio-Cortez" in resp.text
+
+    resp = client.get("/members/S000033")
+    assert resp.status_code == 200
+    assert "Sanders" in resp.text
+
+    resp = client.get("/search?q=Sanders")
+    assert resp.status_code == 200
+    assert "Members" in resp.text
+    assert "Sanders" in resp.text

--- a/tests/test_storage_members_sqlite.py
+++ b/tests/test_storage_members_sqlite.py
@@ -1,0 +1,160 @@
+"""Tests for the Members/member_terms SQLite storage layer.
+
+Covers the projection of typed :class:`Member` + :class:`Term` records
+into the new schema, plus the UPSERT-on-bioguide + DELETE-then-INSERT
+contract that keeps the SQL state consistent with the latest snapshot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from concord.models import Member, Term
+from concord.storage.sqlite import SqliteStorage
+
+
+def _member(bioguide_id: str = "O000172", **overrides: object) -> Member:
+    defaults = dict(
+        bioguide_id=bioguide_id,
+        first_name="Alexandria",
+        last_name="Ocasio-Cortez",
+        display_name="Alexandria Ocasio-Cortez",
+        photo_url="https://example.invalid/o000172.jpg",
+        birth_year=1989,
+    )
+    defaults.update(overrides)
+    return Member(**defaults)  # type: ignore[arg-type]
+
+
+def _term(
+    bioguide_id: str = "O000172",
+    *,
+    congress: int = 119,
+    chamber: str = "house",
+    state: str = "NY",
+    district: int | None = 14,
+    party: str | None = "Democratic",
+    start_date: str | None = "2025-01-01",
+    end_date: str | None = None,
+) -> Term:
+    return Term(
+        bioguide_id=bioguide_id,
+        congress=congress,
+        chamber=chamber,  # type: ignore[arg-type]
+        state=state,
+        district=district,
+        party=party,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> SqliteStorage:
+    s = SqliteStorage(tmp_path / "test.db", load_vec=False)
+    yield s
+    s.close()
+
+
+class TestUpsertMember:
+    def test_inserts_member_and_terms(self, storage: SqliteStorage) -> None:
+        storage.upsert_member(
+            _member(),
+            [
+                _term(congress=117, end_date="2023-01-01"),
+                _term(congress=118, end_date="2025-01-01"),
+                _term(congress=119),  # current
+            ],
+            fetched_at="2026-05-25T14:02:11+00:00",
+        )
+
+        row = storage.get_member("O000172")
+        assert row is not None
+        assert row["display_name"] == "Alexandria Ocasio-Cortez"
+        assert row["fetched_at"] == "2026-05-25T14:02:11+00:00"
+
+        terms = storage.terms_for_member("O000172")
+        assert {t["congress"] for t in terms} == {117, 118, 119}
+        for t in terms:
+            assert t["chamber"] == "house"
+            assert t["state"] == "NY"
+            assert t["district"] == 14
+
+    def test_upsert_replaces_member_row(self, storage: SqliteStorage) -> None:
+        storage.upsert_member(
+            _member(display_name="Old Name"),
+            [_term()],
+            fetched_at="2026-01-01T00:00:00+00:00",
+        )
+        storage.upsert_member(
+            _member(display_name="New Name"),
+            [_term()],
+            fetched_at="2026-05-25T00:00:00+00:00",
+        )
+        row = storage.get_member("O000172")
+        assert row is not None
+        assert row["display_name"] == "New Name"
+        assert row["fetched_at"] == "2026-05-25T00:00:00+00:00"
+
+    def test_terms_are_replaced_not_appended(self, storage: SqliteStorage) -> None:
+        """A second load must not duplicate Term rows for the same Member."""
+        storage.upsert_member(
+            _member(),
+            [_term(congress=118, end_date="2025-01-01"), _term(congress=119)],
+            fetched_at="2026-05-01T00:00:00+00:00",
+        )
+        # Second load: API now reports only the current Congress.
+        storage.upsert_member(
+            _member(),
+            [_term(congress=119)],
+            fetched_at="2026-05-25T00:00:00+00:00",
+        )
+        terms = storage.terms_for_member("O000172")
+        assert [t["congress"] for t in terms] == [119]
+
+    def test_senator_has_null_district(self, storage: SqliteStorage) -> None:
+        storage.upsert_member(
+            _member(bioguide_id="S000033", last_name="Sanders", display_name="Bernard Sanders"),
+            [_term(bioguide_id="S000033", chamber="senate", state="VT", district=None)],
+            fetched_at="2026-05-25T00:00:00+00:00",
+        )
+        terms = storage.terms_for_member("S000033")
+        assert terms[0]["district"] is None
+
+    def test_chamber_check_constraint(self, storage: SqliteStorage) -> None:
+        """SQLite CHECK constraint rejects unknown chamber values.
+
+        Bypasses the pydantic validator (which would normalize ``"foo"``)
+        by writing the bad value via raw SQL.
+        """
+        import sqlite3
+
+        storage.connection.execute(
+            "INSERT INTO members (bioguide_id, first_name, last_name, display_name, fetched_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("X000001", "X", "Y", "X Y", "2026-05-25T00:00:00+00:00"),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            storage.connection.execute(
+                "INSERT INTO member_terms (bioguide_id, congress, chamber, state) "
+                "VALUES (?, ?, ?, ?)",
+                ("X000001", 119, "bogus", "VT"),
+            )
+
+
+class TestMembersFtsTable:
+    def test_table_exists_and_is_writeable(self, storage: SqliteStorage) -> None:
+        """The ``index members`` stage will populate this; here we just
+        sanity-check the schema is queryable."""
+        storage.connection.execute(
+            "INSERT INTO members_fts(bioguide_id, direct_order_name, inverted_order_name, last_name) "
+            "VALUES (?, ?, ?, ?)",
+            ("O000172", "Alexandria Ocasio-Cortez", "Ocasio-Cortez, Alexandria", "Ocasio-Cortez"),
+        )
+        rows = storage.connection.execute(
+            "SELECT bioguide_id FROM members_fts WHERE members_fts MATCH ?",
+            ("Ocasio",),
+        ).fetchall()
+        assert [r["bioguide_id"] for r in rows] == ["O000172"]

--- a/tests/test_storage_members_sqlite.py
+++ b/tests/test_storage_members_sqlite.py
@@ -149,7 +149,8 @@ class TestMembersFtsTable:
         """The ``index members`` stage will populate this; here we just
         sanity-check the schema is queryable."""
         storage.connection.execute(
-            "INSERT INTO members_fts(bioguide_id, direct_order_name, inverted_order_name, last_name) "
+            "INSERT INTO members_fts"
+            "(bioguide_id, direct_order_name, inverted_order_name, last_name) "
             "VALUES (?, ?, ?, ?)",
             ("O000172", "Alexandria Ocasio-Cortez", "Ocasio-Cortez, Alexandria", "Ocasio-Cortez"),
         )

--- a/tests/test_web_members.py
+++ b/tests/test_web_members.py
@@ -106,6 +106,7 @@ def _seed_members(storage: SqliteStorage) -> None:
 
     # Populate the FTS index the same way `concord index members` would.
     from concord.pipeline.index_members import index as index_members
+
     storage.close()
     index_members(db_path=storage.path)
 

--- a/tests/test_web_members.py
+++ b/tests/test_web_members.py
@@ -1,0 +1,208 @@
+"""Integration tests for the Members web routes.
+
+Covers ``/members`` (browse list with chamber/party filters), the
+``/members/{bioguide_id}`` profile page, and the federated ``/search``
+that surfaces Members alongside Proceedings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from concord.embedding import EMBEDDING_DIM, Embedder
+from concord.models import Member, Term
+from concord.storage.sqlite import SqliteStorage
+from concord.web.app import create_app
+
+
+class _StubData:
+    def __init__(self, vec: list[float]) -> None:
+        self.embedding = vec
+
+
+class _StubResponse:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self.data = [_StubData(v) for v in vectors]
+
+
+class _StubEmbeddings:
+    def create(self, *, model: str, input: list[str]) -> _StubResponse:
+        return _StubResponse([[0.5] * EMBEDDING_DIM for _ in input])
+
+
+class _StubOpenAI:
+    embeddings = _StubEmbeddings()
+
+
+def _seed_members(storage: SqliteStorage) -> None:
+    """Three Members: two currently serving (one D House, one I Senate),
+    one historical (party-changing Republican-then-Independent Senator)."""
+    storage.upsert_member(
+        Member(
+            bioguide_id="O000172",
+            first_name="Alexandria",
+            last_name="Ocasio-Cortez",
+            display_name="Alexandria Ocasio-Cortez",
+            photo_url="https://example.invalid/o.jpg",
+        ),
+        [
+            Term(
+                bioguide_id="O000172",
+                congress=119,
+                chamber="house",
+                state="NY",
+                district=14,
+                party="Democratic",
+                start_date="2025-01-01",
+            ),
+        ],
+        fetched_at="2026-05-25T00:00:00+00:00",
+    )
+    storage.upsert_member(
+        Member(
+            bioguide_id="S000033",
+            first_name="Bernard",
+            last_name="Sanders",
+            display_name="Bernard Sanders",
+            birth_year=1941,
+        ),
+        [
+            Term(
+                bioguide_id="S000033",
+                congress=119,
+                chamber="senate",
+                state="VT",
+                party="Independent",
+                start_date="2025-01-01",
+            ),
+        ],
+        fetched_at="2026-05-25T00:00:00+00:00",
+    )
+    storage.upsert_member(
+        Member(
+            bioguide_id="J000301",
+            first_name="James",
+            last_name="Jeffords",
+            display_name="James M. Jeffords",
+            birth_year=1934,
+            death_year=2014,
+        ),
+        [
+            Term(
+                bioguide_id="J000301",
+                congress=116,
+                chamber="senate",
+                state="VT",
+                party="Republican",
+                start_date="2019-01-01",
+                end_date="2021-01-01",
+            ),
+        ],
+        fetched_at="2026-05-25T00:00:00+00:00",
+    )
+
+    # Populate the FTS index the same way `concord index members` would.
+    from concord.pipeline.index_members import index as index_members
+    storage.close()
+    index_members(db_path=storage.path)
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db_path = tmp_path / "test.db"
+    storage = SqliteStorage(db_path)
+    _seed_members(storage)
+    app = create_app(db_path, embedder=Embedder(_StubOpenAI()))
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestMembersIndex:
+    def test_lists_currently_serving(self, client: TestClient) -> None:
+        resp = client.get("/members")
+        assert resp.status_code == 200
+        body = resp.text
+        # Both currently-serving members appear.
+        assert "Alexandria Ocasio-Cortez" in body
+        assert "Bernard Sanders" in body
+        # The historical Jeffords does NOT appear in the default index.
+        assert "Jeffords" not in body
+
+    def test_chamber_filter_house(self, client: TestClient) -> None:
+        resp = client.get("/members?chamber=house")
+        assert resp.status_code == 200
+        assert "Ocasio-Cortez" in resp.text
+        assert "Sanders" not in resp.text
+
+    def test_chamber_filter_senate(self, client: TestClient) -> None:
+        resp = client.get("/members?chamber=senate")
+        assert resp.status_code == 200
+        assert "Sanders" in resp.text
+        assert "Ocasio-Cortez" not in resp.text
+
+    def test_party_filter(self, client: TestClient) -> None:
+        resp = client.get("/members?party=Democratic")
+        assert resp.status_code == 200
+        assert "Ocasio-Cortez" in resp.text
+        assert "Sanders" not in resp.text
+
+    def test_combined_filters(self, client: TestClient) -> None:
+        resp = client.get("/members?chamber=senate&party=Independent")
+        assert resp.status_code == 200
+        assert "Sanders" in resp.text
+        assert "Ocasio-Cortez" not in resp.text
+
+
+class TestMemberProfile:
+    def test_renders_known_bioguide(self, client: TestClient) -> None:
+        resp = client.get("/members/S000033")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Bernard Sanders" in body
+        assert "Senate" in body or "Senator" in body
+        # Future-phase placeholders should be present.
+        assert "Sponsored bills" in body
+        assert "Recent votes" in body
+        assert "Mentioned in proceedings" in body
+
+    def test_unknown_bioguide_404(self, client: TestClient) -> None:
+        resp = client.get("/members/X999999")
+        assert resp.status_code == 404
+
+
+class TestFederatedSearch:
+    def test_search_returns_members_section(self, client: TestClient) -> None:
+        resp = client.get("/search?q=Sanders")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Members" in body
+        assert "Bernard Sanders" in body
+
+    def test_members_off_suppresses_members_section(self, client: TestClient) -> None:
+        resp = client.get("/search?q=Sanders&proceedings=on&members=")
+        assert resp.status_code == 200
+        body = resp.text
+        # When members are off, the member card for Sanders should not render.
+        # (The query string still gets echoed; check for the member-card photo URL
+        # instead, which only appears when the member result actually renders.)
+        assert "example.invalid" not in body
+
+    def test_proceedings_off_suppresses_proceedings_section(self, client: TestClient) -> None:
+        resp = client.get("/search?q=Sanders&members=on&proceedings=")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Members" in body
+        # When proceedings are off, the "Proceedings (N)" header should not appear.
+        assert "Proceedings (" not in body
+
+    def test_ambiguous_query_disambiguates_to_current(self, client: TestClient) -> None:
+        # Both Sanders and Jeffords are linked to "VT" via their last_name
+        # field, but the test query "Vermont" doesn't hit names. Use a
+        # broader query that catches both, then assert current ones appear.
+        # The members_fts has Last/First/display, so query on a shared
+        # substring of multiple historical/current senators.
+        resp = client.get("/search?q=Bernard")
+        assert resp.status_code == 200
+        assert "Bernard Sanders" in resp.text


### PR DESCRIPTION
## Summary

Implements [docs/plans/phase-1-members.md](docs/plans/phase-1-members.md): adds Members as Concord's first peer entity to Proceedings, restructures Stage 0/1 into per-entity subpackages, and federates `/search`.

## What changed

**Refactor (Section 1 of the plan)**
- `src/concord/scraper/{__init__,proceedings,members}.py` and `src/concord/pipeline/{__init__,load_proceedings,index_proceedings,load_members,index_members}.py` subpackages per ADR 0007. Old flat `pipeline.py` / `indexing.py` are gone.
- CLI renamed: `concord <stage> <entity>` is the canonical shape — `scrape proceedings`, `load proceedings`, `index proceedings`, `run proceedings`, plus new `scrape/load/index/run members`. Bare verbs (`concord pull`, `concord load`, …) are removed, not aliased.

**Models & storage (Section 2)**
- `Member`, `Term`, `MemberSnapshot` Pydantic models with chamber/state normalization at the boundary (`parse_member()`).
- New SQLite schema: `members`, `member_terms` (CHECK constraint on chamber, FK cascade), `members_fts` (FTS5, porter tokenizer).
- `SqliteStorage.upsert_member()` does UPSERT on bioguide_id + DELETE-then-INSERT on Terms so re-loading converges to the latest snapshot.

**Ingest (Section 3)**
- `Client.list_members(congress)` paginates `/v3/member/congress/{n}`.
- Members scraper appends ADR 0006 envelopes `{fetched_at, key, payload}` to `data/members.jsonl`.
- Loader groups by `bioguide_id`, keeps latest `fetched_at`, projects into SQLite.
- FTS5 indexer is truncate-then-repopulate (idempotent).
- `tests/_snapshots.py` exports `wrap_snapshot()` for every future mutable-entity test module.

**Web (Section 5)**
- `/members` browse list with chamber + party filters, paginated 50/page, ordered `(state ASC, last_name ASC)`.
- `/members/{bioguide_id}` profile: photo, current-role line, biography (collapses if >300 chars via `<details>`), term history table, Phase 2/3/6 placeholder boxes.
- `/search` federated: queries `members_fts` and the existing chunks RRF pipeline independently, renders two grouped sections. Inline `☑ Members ☑ Proceedings` checkboxes above the results; unchecking either suppresses its section and its query. Disambiguation sort is `(is_current DESC, last_active_congress DESC)` so `q=Sanders` surfaces the current Sanders ahead of historical namesakes.
- Nav link to `/members` in the shared header.

**Docs**
- ADRs 0006 (snapshot-on-fetch), 0007 (parallel pipelines per entity), 0008 (chunks generalize beyond Proceedings).
- CONTEXT.md gains an "Entities" section defining Member / Bioguide ID / Term / Chamber / Party.
- Phase 1 plan + the parent roadmap + scoping doc are checked in under `docs/plans/`.

## Why

Phase 1 of the multi-entity expansion. Members are chosen first because they're the smallest entity in the planned set, mostly stable (Bioguide IDs are immutable), and the prerequisite for every later phase — Bills cite sponsors, Votes cite per-Member positions, Stage 3 Enrichment mentions Members in Proceeding text. Shipping Members early de-risks the architectural shift to multi-entity ingest before the harder mutable entities (Bills, Votes) arrive.

## Test plan

- [x] `pytest` — full suite (294 tests), all green
- [x] `concord scrape proceedings --help`, `concord run members --help` show the new command shapes
- [x] `concord pull` errors with typer's "no such command" (rename is hard, not aliased)
- [ ] Manual smoke against live data: `concord run members --congresses 119` then `concord serve` and click through `/members` + `/search?q=<known senator surname>` to verify both sections render and filter checkboxes suppress each independently
- [ ] Verify `concord scrape proceedings --from <recent-date>` regression — the rename hasn't broken the existing flow

## Notes for the reviewer

- Three captured-style fixtures under `tests/fixtures/api/members/` are synthetic but match the real API field shape (mixed list-endpoint + detail-endpoint fields). `parse_member()` is the only thing that touches the raw shape; everything downstream consumes typed `Member` + `Term`.
- The previously-existing `text.py` retry-policy work that was in the working tree at the start of this branch is intentionally **not** in this PR — it's an unrelated change that should land separately.
- ADR 0008 is referenced for completeness but **not** exercised by Phase 1 (Members aren't chunked). Phase 5 will require the chunks-table migration it specifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)