### PR TITLE
load members: no-op on missing JSONL instead of erroring

### DIFF
--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -398,8 +398,14 @@ def _run_load_members(
 ) -> tuple[int, int]:
     """Return ``(members_written, terms_written)``."""
     if not storage_path.exists():
-        typer.echo(f"error: input file not found: {storage_path}", err=True)
-        raise typer.Exit(code=2)
+        # No input file is a no-op, not an error: load is idempotent and
+        # callable in any order. The user probably hasn't run scrape yet —
+        # tell them what they need.
+        typer.echo(
+            f"No input file at {storage_path} — "
+            f"run `concord scrape members` first. Nothing to load."
+        )
+        return 0, 0
 
     from .pipeline.load_members import load as load_members
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1015,3 +1015,30 @@ class TestProgress:
         # Exit calls commit -> newline.
         assert s.getvalue().endswith("\n")
         assert "only update" in s.getvalue()
+
+
+# -- `concord load members` --------------------------------------------------
+
+
+class TestLoadMembersCommand:
+    def test_missing_jsonl_is_a_no_op(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """`load members` with no input file is informational, not an error."""
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "load",
+                "members",
+                "--storage",
+                str(tmp_path / "missing.jsonl"),
+                "--db",
+                str(tmp_path / "out.db"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        plain = _strip(result.output)
+        assert "No input file" in plain
+        assert "scrape members" in plain


### PR DESCRIPTION
## Summary

`concord load members` was exiting with code 2 when `data/members.jsonl` didn't exist:

\`\`\`
# concord load members
error: input file not found: data/members.jsonl
\`\`\`

This is friction in two real scenarios: (1) running stages out of order before any scrape has happened, and (2) `concord run members` where an earlier stage silently produced no file — the failure surfaces as a confusing error in the load step rather than at the source.

Load is otherwise idempotent: re-running with the same input is a no-op. Making it idempotent on "no input file" too is the consistent behavior — print what to do next and exit 0.

## Changes

- `_run_load_members` in [src/concord/cli.py](src/concord/cli.py): missing file → informational message + exit 0 instead of error + exit 2.
- Regression test in [tests/test_cli.py](tests/test_cli.py).

The proceedings loader still errors on a missing JSONL. Intentional — not in scope for this bug, and proceedings has a longer-standing contract there. Happy to extend the change if reviewers want consistency.

## Test plan

- [x] `pytest` (307 tests, all green)
- [x] Manual: `concord load members --storage /tmp/missing.jsonl --db /tmp/test.db` prints "No input file at … — run \`concord scrape members\` first. Nothing to load." and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)