### PR TITLE
Fix member_terms: inject queried congress into snapshot envelope

### DIFF
--- a/src/concord/models.py
+++ b/src/concord/models.py
@@ -325,7 +325,7 @@ class MemberSnapshot(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     fetched_at: datetime
-    key: dict[str, str]
+    key: dict[str, str | int]
     payload: dict[str, Any]
 
 
@@ -348,12 +348,12 @@ def _split_inverted_name(name: str) -> tuple[str, str]:
     return first, last
 
 
-def parse_member(payload: dict[str, Any]) -> tuple[Member, list[Term]]:
-    """Project a raw ``/member`` payload into a :class:`Member` + its :class:`Term`s.
+def parse_member_identity(payload: dict[str, Any]) -> Member:
+    """Project a raw ``/member`` payload into the identity-only :class:`Member` row.
 
-    Tolerates the union of fields returned by the list endpoint
-    (``/v3/member/congress/{congress}``) and the detail endpoint
-    (``/v3/member/{bioguideId}``). Missing optional fields become ``None``.
+    Identity fields (name, birth year, photo) are the same regardless of
+    which Congress the API was queried for, so this is the half of a member
+    payload that's safe to project without knowing the queried Congress.
     """
     bioguide_id = str(payload["bioguideId"])
 
@@ -374,7 +374,7 @@ def parse_member(payload: dict[str, Any]) -> tuple[Member, list[Term]]:
     depiction = payload.get("depiction") or {}
     photo_url = depiction.get("imageUrl") if isinstance(depiction, dict) else None
 
-    member = Member(
+    return Member(
         bioguide_id=bioguide_id,
         first_name=first_name or "",
         middle_name=payload.get("middleName"),
@@ -387,58 +387,122 @@ def parse_member(payload: dict[str, Any]) -> tuple[Member, list[Term]]:
         biography=payload.get("biography"),
     )
 
-    # Top-level fallback state/district/party for term rows that don't carry their own
-    # (the list endpoint flattens these onto the member rather than per-term).
+
+def parse_member_term(payload: dict[str, Any], *, congress: int) -> Term | None:
+    """Project a raw ``/member`` payload + queried Congress into one :class:`Term`.
+
+    The ``/v3/member/congress/{n}`` list endpoint omits ``congress`` from
+    each ``terms.item`` — and returns the **same** payload for every
+    Congress a Member served in. So a single payload can't tell us which
+    Congresses it represents; the queried ``congress`` argument provides
+    the missing context.
+
+    Returns the Term row for ``(bioguide_id, congress, chamber)`` where
+    ``chamber`` is found by matching ``congress``'s years against the
+    payload's ``terms.item`` ranges. Returns ``None`` if no item covers
+    the Congress (the payload contradicts its own listing — log + skip
+    rather than 500).
+    """
+    bioguide_id = str(payload["bioguideId"])
+    items = _extract_term_items(payload)
+    item = _term_item_for_congress(items, congress)
+    if item is None:
+        return None
+
+    chamber_raw = item.get("chamber")
+    if chamber_raw is None:
+        return None
+    chamber = _normalize_chamber(chamber_raw)
+    if chamber not in {"house", "senate"}:
+        return None
+
     top_state = payload.get("state")
     top_district = payload.get("district")
     top_party = payload.get("partyName")
 
-    terms_raw = payload.get("terms")
-    items: list[dict[str, Any]] = []
-    if isinstance(terms_raw, dict):
-        items = list(terms_raw.get("item") or [])
-    elif isinstance(terms_raw, list):
-        items = list(terms_raw)
+    state = item.get("stateCode") or item.get("stateName") or top_state
+    if not state:
+        return None
 
-    terms: list[Term] = []
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        congress = item.get("congress")
-        if congress is None:
-            continue
-        chamber_raw = item.get("chamber")
-        if chamber_raw is None:
-            continue
-        chamber = _normalize_chamber(chamber_raw)
-        if chamber not in {"house", "senate"}:
-            continue
-        state = item.get("stateCode") or item.get("stateName") or top_state
-        if not state:
-            continue
-        district = item.get("district")
-        if district is None and chamber == "house":
-            district = top_district
-        if isinstance(district, str):
-            try:
-                district = int(district)
-            except ValueError:
-                district = None
-        if chamber == "senate":
+    district = item.get("district")
+    if district is None and chamber == "house":
+        district = top_district
+    if isinstance(district, str):
+        try:
+            district = int(district)
+        except ValueError:
             district = None
-        terms.append(
-            Term(
-                bioguide_id=bioguide_id,
-                congress=int(congress),
-                chamber=chamber,
-                party=item.get("partyName") or top_party,
-                state=state,  # validator normalizes to 2-letter
-                district=district,
-                start_date=_year_to_iso(item.get("startYear")),
-                end_date=_year_to_iso(item.get("endYear")),
-            )
-        )
-    return member, terms
+    if chamber == "senate":
+        district = None
+
+    # Clip the chamber-career window (API's startYear/endYear) to this
+    # Congress's window. Each (member, congress) row should describe the
+    # service inside that Congress, not the broader career stretch.
+    cong_start_year = 2 * congress + 1787  # Congress 1 began 1789-01-03
+    cong_end_year = 2 * congress + 1789  # = next Congress's start year
+
+    api_start = _coerce_int(item.get("startYear"))
+    if api_start is not None and api_start > cong_start_year:
+        start_date = f"{api_start:04d}-01-03"  # joined mid-Congress
+    else:
+        start_date = f"{cong_start_year:04d}-01-03"
+
+    api_end = _coerce_int(item.get("endYear"))
+    if api_end is not None and api_end < cong_end_year:
+        end_date = f"{api_end:04d}-01-03"  # left mid-Congress
+    else:
+        end_date = f"{cong_end_year:04d}-01-03"
+
+    return Term(
+        bioguide_id=bioguide_id,
+        congress=congress,
+        chamber=chamber,
+        party=item.get("partyName") or top_party,
+        state=state,  # validator normalizes to 2-letter
+        district=district,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+def parse_member(payload: dict[str, Any], *, congress: int) -> tuple[Member, Term | None]:
+    """Convenience wrapper: identity + one Term for the queried Congress."""
+    return parse_member_identity(payload), parse_member_term(payload, congress=congress)
+
+
+def _extract_term_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Pull the ``terms.item`` list from a /member payload, tolerating both
+    list-endpoint (``{"terms": {"item": [...]}}``) and detail-endpoint
+    (``{"terms": [...]}``) shapes."""
+    terms_raw = payload.get("terms")
+    if isinstance(terms_raw, dict):
+        return [i for i in (terms_raw.get("item") or []) if isinstance(i, dict)]
+    if isinstance(terms_raw, list):
+        return [i for i in terms_raw if isinstance(i, dict)]
+    return []
+
+
+def _term_item_for_congress(items: list[dict[str, Any]], congress: int) -> dict[str, Any] | None:
+    """Return the term item whose year range contains ``congress``, or None.
+
+    A term item covers Congress N if its ``startYear`` falls on or before
+    N's last year, and its ``endYear`` (when set) falls on or after N's
+    first year. If multiple items overlap, returns the last match — useful
+    for the rare member who switches chambers mid-Congress (a member is
+    only listed under one chamber per Congress in practice).
+    """
+    cong_first_year = 2 * congress + 1787
+    cong_last_year = cong_first_year + 1
+    match: dict[str, Any] | None = None
+    for item in items:
+        start = _coerce_int(item.get("startYear"))
+        if start is None or start > cong_last_year:
+            continue
+        end = _coerce_int(item.get("endYear"))
+        if end is not None and end < cong_first_year:
+            continue
+        match = item
+    return match
 
 
 def _coerce_int(value: Any) -> int | None:
@@ -448,23 +512,3 @@ def _coerce_int(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
-
-
-def _year_to_iso(value: Any) -> str | None:
-    """Normalize a ``startYear``/``endYear`` integer to an ISO date string.
-
-    The API returns just a year; we project it to ``YYYY-01-01`` for start
-    dates and leave end dates ``None`` when the API omits them (current
-    service). Year-only inputs are preserved as-is so callers that pass an
-    already-ISO date round-trip cleanly.
-    """
-    if value is None or value == "":
-        return None
-    if isinstance(value, int):
-        return f"{value:04d}-01-01"
-    text = str(value).strip()
-    if not text:
-        return None
-    if text.isdigit() and len(text) == 4:
-        return f"{int(text):04d}-01-01"
-    return text

--- a/src/concord/pipeline/load_members.py
+++ b/src/concord/pipeline/load_members.py
@@ -1,15 +1,25 @@
 """Stage 1 — Members loader.
 
 Projects the ADR 0006 snapshot stream in ``data/members.jsonl`` into the
-``members`` and ``member_terms`` SQLite tables. The contract:
+``members`` and ``member_terms`` SQLite tables.
 
-* Read every snapshot. Group by ``key["bioguide_id"]``.
-* For each group, keep the snapshot with the latest ``fetched_at``.
-* For each kept snapshot, parse the payload into a typed
-  :class:`Member` + list of :class:`Term`s.
-* UPSERT the Member row on ``bioguide_id`` and DELETE-then-INSERT the
-  Term rows so the projection reflects exactly what the latest snapshot
-  says (no stale Terms left behind if the API ever drops one).
+The natural key for a Member snapshot is the composite
+``(bioguide_id, congress)``: the ``/v3/member/congress/{n}`` list endpoint
+returns the **same** payload for every Congress a Member served in, so
+the queried Congress is the only thing that distinguishes consecutive
+snapshots. The scraper stores that Congress in ``key["congress"]``; the
+loader uses it to project one Term row per (member, congress) the API
+listed them in.
+
+Contract:
+
+* Read every snapshot. Group by ``(key["bioguide_id"], key["congress"])``.
+* For each group, keep the snapshot with the latest ``fetched_at`` — one
+  authoritative payload per (member, congress) cell.
+* For each kept snapshot, project a single Term for the queried Congress.
+* For each Member, UPSERT the identity row (from the latest snapshot
+  overall for that bioguide_id) and DELETE-then-INSERT every Term that
+  any snapshot produced for them.
 
 Re-running the loader over an unchanged JSONL is a no-op (idempotent).
 Re-running over a JSONL that gained new snapshots converges the SQL
@@ -24,7 +34,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, NamedTuple
 
-from ..models import parse_member
+from ..models import Term, parse_member_identity, parse_member_term
 from ..storage.sqlite import SqliteStorage
 
 _log = logging.getLogger("concord.pipeline.load_members")
@@ -44,7 +54,12 @@ def load(*, jsonl_path: Path, db_path: Path) -> LoadStats:
 
     Returns the count of Members and Terms written plus diagnostics.
     """
-    latest: dict[str, tuple[datetime, dict[str, Any]]] = {}
+    # Latest snapshot per (bioguide_id, congress) — the natural key.
+    latest_per_cell: dict[tuple[str, int], tuple[datetime, dict[str, Any]]] = {}
+    # Latest snapshot per bioguide_id, ignoring congress — for the
+    # Member identity row, which doesn't vary by Congress.
+    latest_per_member: dict[str, tuple[datetime, dict[str, Any]]] = {}
+
     snapshots_read = 0
     malformed = 0
 
@@ -61,30 +76,61 @@ def load(*, jsonl_path: Path, db_path: Path) -> LoadStats:
                 _log.warning("skipping malformed line %d: %s", line_no, exc)
                 continue
             try:
-                bioguide_id = envelope["key"]["bioguide_id"]
-                fetched_at_raw = envelope["fetched_at"]
+                key = envelope["key"]
+                bioguide_id = key["bioguide_id"]
+                congress = int(key["congress"])
+                fetched_at = datetime.fromisoformat(envelope["fetched_at"])
                 payload = envelope["payload"]
-                fetched_at = datetime.fromisoformat(fetched_at_raw)
             except (KeyError, TypeError, ValueError) as exc:
+                # Envelopes from before the composite-key migration lack
+                # ``congress`` and aren't loadable here — they need a
+                # re-scrape to restore the queried-Congress signal.
                 malformed += 1
                 _log.warning("skipping line %d with bad envelope: %s", line_no, exc)
                 continue
-            current = latest.get(bioguide_id)
-            if current is None or fetched_at > current[0]:
-                latest[bioguide_id] = (fetched_at, payload)
+
+            cell = (bioguide_id, congress)
+            current_cell = latest_per_cell.get(cell)
+            if current_cell is None or fetched_at > current_cell[0]:
+                latest_per_cell[cell] = (fetched_at, payload)
+
+            current_member = latest_per_member.get(bioguide_id)
+            if current_member is None or fetched_at > current_member[0]:
+                latest_per_member[bioguide_id] = (fetched_at, payload)
+
+    # Project each (bioguide_id, congress) snapshot into one Term row.
+    terms_by_member: dict[str, list[Term]] = {}
+    for (bioguide_id, congress), (_, payload) in latest_per_cell.items():
+        try:
+            term = parse_member_term(payload, congress=congress)
+        except Exception as exc:  # pragma: no cover - defensive parse guard
+            malformed += 1
+            _log.warning("skipping term %s/%d after parse failure: %s", bioguide_id, congress, exc)
+            continue
+        if term is None:
+            # The payload didn't include a terms.item covering ``congress``
+            # — the API contradicted its own listing. Log + skip.
+            _log.warning(
+                "no terms.item covers Congress %d in payload for %s; skipping that Term row",
+                congress,
+                bioguide_id,
+            )
+            continue
+        terms_by_member.setdefault(bioguide_id, []).append(term)
 
     members_written = 0
     terms_written = 0
 
     storage = SqliteStorage(db_path, load_vec=False)
     try:
-        for bioguide_id, (fetched_at, payload) in latest.items():
+        for bioguide_id, (fetched_at, payload) in latest_per_member.items():
             try:
-                member, terms = parse_member(payload)
+                member = parse_member_identity(payload)
             except Exception as exc:  # pragma: no cover - defensive parse guard
                 malformed += 1
                 _log.warning("skipping %s after parse failure: %s", bioguide_id, exc)
                 continue
+            terms = terms_by_member.get(bioguide_id, [])
             storage.upsert_member(member, terms, fetched_at=fetched_at.isoformat())
             members_written += 1
             terms_written += len(terms)

--- a/src/concord/scraper/members.py
+++ b/src/concord/scraper/members.py
@@ -56,7 +56,13 @@ def scrape(
                     continue
                 envelope = {
                     "fetched_at": iso,
-                    "key": {"bioguide_id": bioguide_id},
+                    # Composite key: the same Member appears in the listing
+                    # for every Congress they served in, and the payload is
+                    # identical across those queries. Without ``congress``
+                    # in the key we'd lose track of which Congress this
+                    # snapshot represents and the loader would collapse
+                    # multi-Congress careers into a single Term row.
+                    "key": {"bioguide_id": bioguide_id, "congress": congress},
                     "payload": payload,
                 }
                 fh.write(json.dumps(envelope, ensure_ascii=False))

--- a/tests/fixtures/api/members/current_house.json
+++ b/tests/fixtures/api/members/current_house.json
@@ -18,32 +18,7 @@
         "item": [
           {
             "chamber": "House of Representatives",
-            "congress": 117,
-            "startYear": 2021,
-            "endYear": 2023,
-            "stateCode": "NY",
-            "stateName": "New York",
-            "district": 14,
-            "partyName": "Democratic"
-          },
-          {
-            "chamber": "House of Representatives",
-            "congress": 118,
-            "startYear": 2023,
-            "endYear": 2025,
-            "stateCode": "NY",
-            "stateName": "New York",
-            "district": 14,
-            "partyName": "Democratic"
-          },
-          {
-            "chamber": "House of Representatives",
-            "congress": 119,
-            "startYear": 2025,
-            "stateCode": "NY",
-            "stateName": "New York",
-            "district": 14,
-            "partyName": "Democratic"
+            "startYear": 2019
           }
         ]
       },

--- a/tests/fixtures/api/members/current_senate.json
+++ b/tests/fixtures/api/members/current_senate.json
@@ -18,39 +18,12 @@
         "item": [
           {
             "chamber": "House of Representatives",
-            "congress": 102,
             "startYear": 1991,
-            "endYear": 1993,
-            "stateCode": "VT",
-            "stateName": "Vermont",
-            "district": 0,
-            "partyName": "Independent"
+            "endYear": 2007
           },
           {
             "chamber": "Senate",
-            "congress": 117,
-            "startYear": 2021,
-            "endYear": 2023,
-            "stateCode": "VT",
-            "stateName": "Vermont",
-            "partyName": "Independent"
-          },
-          {
-            "chamber": "Senate",
-            "congress": 118,
-            "startYear": 2023,
-            "endYear": 2025,
-            "stateCode": "VT",
-            "stateName": "Vermont",
-            "partyName": "Independent"
-          },
-          {
-            "chamber": "Senate",
-            "congress": 119,
-            "startYear": 2025,
-            "stateCode": "VT",
-            "stateName": "Vermont",
-            "partyName": "Independent"
+            "startYear": 2007
           }
         ]
       },

--- a/tests/fixtures/api/members/historical.json
+++ b/tests/fixtures/api/members/historical.json
@@ -10,28 +10,22 @@
       "lastName": "Jeffords",
       "birthYear": "1934",
       "deathYear": "2014",
+      "partyName": "Independent",
+      "state": "Vermont",
       "depiction": {
         "imageUrl": "https://www.congress.gov/img/member/j000301.jpg"
       },
       "terms": {
         "item": [
           {
-            "chamber": "Senate",
-            "congress": 116,
-            "startYear": 2019,
-            "endYear": 2021,
-            "stateCode": "VT",
-            "stateName": "Vermont",
-            "partyName": "Republican"
+            "chamber": "House of Representatives",
+            "startYear": 1975,
+            "endYear": 1989
           },
           {
             "chamber": "Senate",
-            "congress": 117,
-            "startYear": 2021,
-            "endYear": 2023,
-            "stateCode": "VT",
-            "stateName": "Vermont",
-            "partyName": "Independent"
+            "startYear": 1989,
+            "endYear": 2007
           }
         ]
       },
@@ -41,10 +35,5 @@
   ],
   "pagination": {
     "count": 1
-  },
-  "request": {
-    "congress": "117",
-    "contentType": "application/json",
-    "format": "json"
   }
 }

--- a/tests/test_models_members.py
+++ b/tests/test_models_members.py
@@ -1,8 +1,15 @@
 """Tests for Member / Term / MemberSnapshot models.
 
-Covers (1) parsing real API payloads into typed records, (2) the
-ADR 0006 envelope round-trip, and (3) the state/chamber normalization
-the projection layer performs at the boundary.
+Covers (1) parsing the identity half of a real API payload, (2) the
+per-Congress Term projection that takes the queried Congress as input,
+(3) the ADR 0006 snapshot envelope round-trip, and (4) the
+state/chamber normalization the projection layer performs at the
+boundary.
+
+The list endpoint ``/v3/member/congress/{n}`` returns the **same**
+payload regardless of which Congress you queried, so a Term row's
+``congress`` can only come from the scraper's queried-Congress
+context — see :class:`TestParseMemberTerm`.
 """
 
 from __future__ import annotations
@@ -17,6 +24,8 @@ from concord.models import (
     Term,
     normalize_state,
     parse_member,
+    parse_member_identity,
+    parse_member_term,
 )
 
 from ._snapshots import wrap_snapshot
@@ -40,82 +49,134 @@ class TestNormalization:
         assert normalize_state(input_) == expected
 
 
-class TestParseMemberCurrentHouse:
-    @pytest.fixture
-    def payload(self, load_json_fixture: Any) -> dict[str, Any]:
-        return load_json_fixture("api/members/current_house.json")["members"][0]
+# -- Identity (Member-row) parsing ------------------------------------------
 
-    def test_parses_identity_fields(self, payload: dict[str, Any]) -> None:
-        member, _ = parse_member(payload)
+
+class TestParseMemberIdentity:
+    """Identity fields don't depend on the queried Congress."""
+
+    def test_parses_house_member(self, load_json_fixture: Any) -> None:
+        payload = load_json_fixture("api/members/current_house.json")["members"][0]
+        member = parse_member_identity(payload)
         assert member.bioguide_id == "O000172"
         assert member.first_name == "Alexandria"
         assert member.last_name == "Ocasio-Cortez"
         assert member.display_name == "Alexandria Ocasio-Cortez"
         assert member.photo_url == "https://www.congress.gov/img/member/o000172.jpg"
 
-    def test_parses_terms(self, payload: dict[str, Any]) -> None:
-        _, terms = parse_member(payload)
-        assert len(terms) == 3
-        congresses = sorted(t.congress for t in terms)
-        assert congresses == [117, 118, 119]
-        for t in terms:
-            assert t.bioguide_id == "O000172"
-            assert t.chamber == "house"
-            assert t.state == "NY"
-            assert t.district == 14
-            assert t.party == "Democratic"
-
-    def test_current_term_has_no_end_date(self, payload: dict[str, Any]) -> None:
-        _, terms = parse_member(payload)
-        current = next(t for t in terms if t.congress == 119)
-        assert current.end_date is None
-        assert current.start_date == "2025-01-01"
-
-
-class TestParseMemberCurrentSenate:
-    @pytest.fixture
-    def payload(self, load_json_fixture: Any) -> dict[str, Any]:
-        return load_json_fixture("api/members/current_senate.json")["members"][0]
-
-    def test_senator_has_no_district(self, payload: dict[str, Any]) -> None:
-        _, terms = parse_member(payload)
-        senate_terms = [t for t in terms if t.chamber == "senate"]
-        assert len(senate_terms) == 3
-        for t in senate_terms:
-            assert t.district is None
-
-    def test_mixed_chamber_history_preserved(self, payload: dict[str, Any]) -> None:
-        _, terms = parse_member(payload)
-        chambers = {(t.congress, t.chamber) for t in terms}
-        # Sanders served one term in the House (102nd) and three in the Senate.
-        assert (102, "house") in chambers
-        assert (119, "senate") in chambers
-
-    def test_member_carries_birth_year(self, payload: dict[str, Any]) -> None:
-        member, _ = parse_member(payload)
+    def test_parses_senate_member_with_birth_year(self, load_json_fixture: Any) -> None:
+        payload = load_json_fixture("api/members/current_senate.json")["members"][0]
+        member = parse_member_identity(payload)
+        assert member.bioguide_id == "S000033"
         assert member.birth_year == 1941
+        assert member.death_year is None
 
-
-class TestParseHistoricalMember:
-    @pytest.fixture
-    def payload(self, load_json_fixture: Any) -> dict[str, Any]:
-        return load_json_fixture("api/members/historical.json")["members"][0]
-
-    def test_death_year_parsed(self, payload: dict[str, Any]) -> None:
-        member, _ = parse_member(payload)
+    def test_parses_historical_member_with_death_year(self, load_json_fixture: Any) -> None:
+        payload = load_json_fixture("api/members/historical.json")["members"][0]
+        member = parse_member_identity(payload)
+        assert member.bioguide_id == "J000301"
+        assert member.middle_name == "M."
         assert member.death_year == 2014
 
-    def test_party_change_preserved_per_term(self, payload: dict[str, Any]) -> None:
-        _, terms = parse_member(payload)
-        parties = {t.congress: t.party for t in terms}
-        # Two terms with different parties.
-        assert parties[116] == "Republican"
-        assert parties[117] == "Independent"
 
-    def test_end_date_populated_for_ended_term(self, payload: dict[str, Any]) -> None:
-        _, terms = parse_member(payload)
-        ended = [t for t in terms if t.end_date is not None]
-        assert ended, "expected at least one term with an end date"
+# -- Per-Congress Term parsing ----------------------------------------------
+
+
+class TestParseMemberTerm:
+    """The Term row depends on the queried Congress.
+
+    Each test calls :func:`parse_member_term` with a specific Congress
+    and verifies the returned row reflects (a) the right chamber for
+    that Congress's year range, (b) Congress-clipped start/end dates.
+    """
+
+    def test_current_house_member_in_119th(self, load_json_fixture: Any) -> None:
+        payload = load_json_fixture("api/members/current_house.json")["members"][0]
+        term = parse_member_term(payload, congress=119)
+        assert term is not None
+        assert term.bioguide_id == "O000172"
+        assert term.congress == 119
+        assert term.chamber == "house"
+        assert term.state == "NY"
+        assert term.district == 14
+        assert term.party == "Democratic"
+        # Congress 119 spans 2025 (Jan 3) - 2027 (Jan 3).
+        assert term.start_date == "2025-01-03"
+        assert term.end_date == "2027-01-03"
+
+    def test_same_payload_three_congresses_three_terms(self, load_json_fixture: Any) -> None:
+        """Heart of the bug — identical payloads for different Congresses
+        must produce different Term rows."""
+        payload = load_json_fixture("api/members/current_house.json")["members"][0]
+        terms = [parse_member_term(payload, congress=c) for c in (117, 118, 119)]
+        assert all(t is not None for t in terms)
+        assert [t.congress for t in terms] == [117, 118, 119]  # type: ignore[union-attr]
+        assert all(t.chamber == "house" for t in terms)  # type: ignore[union-attr]
+
+    def test_senator_in_each_listed_congress(self, load_json_fixture: Any) -> None:
+        """Sanders' Senate term started 2007 (110th); query each subsequent
+        Congress and confirm the right chamber surfaces."""
+        payload = load_json_fixture("api/members/current_senate.json")["members"][0]
+        for congress in (110, 115, 118, 119):
+            term = parse_member_term(payload, congress=congress)
+            assert term is not None
+            assert term.chamber == "senate"
+            assert term.district is None
+            assert term.congress == congress
+
+    def test_chamber_switch_resolved_by_year_range(self, load_json_fixture: Any) -> None:
+        """Sanders served in the House before the Senate — querying a
+        Congress in his House-tenure window resolves to ``house``."""
+        payload = load_json_fixture("api/members/current_senate.json")["members"][0]
+        house_term = parse_member_term(payload, congress=102)  # 1991-1993
+        assert house_term is not None
+        assert house_term.chamber == "house"
+
+    def test_returns_none_for_congress_outside_terms(self, load_json_fixture: Any) -> None:
+        """If no terms.item covers the queried Congress, return None."""
+        payload = load_json_fixture("api/members/historical.json")["members"][0]
+        # Jeffords left the Senate in 2007; querying Congress 116 (2019-2021)
+        # finds no matching term.
+        term = parse_member_term(payload, congress=116)
+        assert term is None
+
+    def test_left_mid_congress_carries_end_year(self, load_json_fixture: Any) -> None:
+        """Jeffords' last Senate Congress was the 109th (2005-2007). His
+        endYear=2007 falls inside that Congress's window, so end_date
+        reflects the actual departure year."""
+        payload = load_json_fixture("api/members/historical.json")["members"][0]
+        term = parse_member_term(payload, congress=109)
+        assert term is not None
+        assert term.end_date == "2007-01-03"
+
+    def test_top_level_state_falls_back_when_term_has_none(self, load_json_fixture: Any) -> None:
+        """The list endpoint puts ``state`` at the top level, not in each
+        terms.item — the parser uses the top-level fallback."""
+        payload = load_json_fixture("api/members/current_senate.json")["members"][0]
+        term = parse_member_term(payload, congress=119)
+        assert term is not None
+        assert term.state == "VT"
+
+
+# -- Combined parse_member helper -------------------------------------------
+
+
+class TestParseMemberWrapper:
+    def test_returns_identity_and_one_term(self, load_json_fixture: Any) -> None:
+        payload = load_json_fixture("api/members/current_house.json")["members"][0]
+        member, term = parse_member(payload, congress=119)
+        assert member.bioguide_id == "O000172"
+        assert term is not None
+        assert term.congress == 119
+
+    def test_term_is_none_when_congress_outside_range(self, load_json_fixture: Any) -> None:
+        payload = load_json_fixture("api/members/historical.json")["members"][0]
+        member, term = parse_member(payload, congress=119)
+        assert member.bioguide_id == "J000301"
+        assert term is None
+
+
+# -- Snapshot envelope shape -------------------------------------------------
 
 
 class TestSnapshotEnvelope:
@@ -124,20 +185,24 @@ class TestSnapshotEnvelope:
         envelope = wrap_snapshot(
             payload,
             fetched_at=FIXED_FETCHED_AT,
-            key={"bioguide_id": "X000001"},
+            key={"bioguide_id": "X000001", "congress": 119},
         )
         snapshot = MemberSnapshot.model_validate(envelope)
         assert snapshot.fetched_at == FIXED_FETCHED_AT
-        assert snapshot.key == {"bioguide_id": "X000001"}
+        assert snapshot.key == {"bioguide_id": "X000001", "congress": 119}
         assert snapshot.payload == payload
 
     def test_envelope_keys_exact(self) -> None:
         envelope = wrap_snapshot(
             {"x": 1},
             fetched_at=FIXED_FETCHED_AT,
-            key={"bioguide_id": "Y000001"},
+            key={"bioguide_id": "Y000001", "congress": 118},
         )
         assert set(envelope.keys()) == {"fetched_at", "key", "payload"}
+        assert envelope["key"] == {"bioguide_id": "Y000001", "congress": 118}
+
+
+# -- Term model validators ---------------------------------------------------
 
 
 class TestTermValidation:

--- a/tests/test_pipeline_members.py
+++ b/tests/test_pipeline_members.py
@@ -1,10 +1,11 @@
 """Tests for the Members Stage 1 (load) and Stage 2 (index) pipelines.
 
-Drives the JSONL → SQLite projection against the captured API fixtures
-and asserts (a) snapshot dedup keeps the latest ``fetched_at`` per
-Bioguide ID, (b) Term rows are replaced on each load (not appended),
-(c) the FTS5 index round-trips a name query back to the right
-``bioguide_id``.
+The natural key for a Member snapshot is the composite
+``(bioguide_id, congress)``. Each test writes envelopes whose ``key``
+carries both, then asserts that the loader produces one Term row per
+(bioguide_id, congress) cell — even when the underlying payload is
+identical across Congresses (the central scrape-time bug this test
+module exists to lock in).
 """
 
 from __future__ import annotations
@@ -35,14 +36,50 @@ def _write_jsonl(path: Path, envelopes: list[dict[str, Any]]) -> None:
     )
 
 
+def _envelope_for(
+    payload: dict[str, Any],
+    *,
+    congress: int,
+    fetched_at: datetime = FIXED_FETCHED_AT,
+) -> dict[str, Any]:
+    return wrap_snapshot(
+        payload,
+        fetched_at=fetched_at,
+        key={"bioguide_id": payload["bioguideId"], "congress": congress},
+    )
+
+
 class TestLoadMembers:
-    def test_projects_member_and_terms(self, tmp_path: Path) -> None:
+    def test_one_snapshot_yields_one_term(self, tmp_path: Path) -> None:
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        payload = _fixture("current_house.json")["members"][0]
+        _write_jsonl(jsonl, [_envelope_for(payload, congress=119)])
+
+        stats = load_members(jsonl_path=jsonl, db_path=db)
+        assert stats.members_written == 1
+        assert stats.terms_written == 1
+
+        with SqliteStorage(db, load_vec=False) as storage:
+            row = storage.get_member("O000172")
+            assert row is not None
+            assert row["display_name"] == "Alexandria Ocasio-Cortez"
+            terms = storage.terms_for_member("O000172")
+            assert [t["congress"] for t in terms] == [119]
+
+    def test_three_congresses_yield_three_terms(self, tmp_path: Path) -> None:
+        """The central regression: same payload, different Congresses,
+        three distinct Term rows."""
         jsonl = tmp_path / "members.jsonl"
         db = tmp_path / "test.db"
         payload = _fixture("current_house.json")["members"][0]
         _write_jsonl(
             jsonl,
-            [wrap_snapshot(payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"})],
+            [
+                _envelope_for(payload, congress=117),
+                _envelope_for(payload, congress=118),
+                _envelope_for(payload, congress=119),
+            ],
         )
 
         stats = load_members(jsonl_path=jsonl, db_path=db)
@@ -50,60 +87,90 @@ class TestLoadMembers:
         assert stats.terms_written == 3
 
         with SqliteStorage(db, load_vec=False) as storage:
-            row = storage.get_member("O000172")
-            assert row is not None
-            assert row["display_name"] == "Alexandria Ocasio-Cortez"
             terms = storage.terms_for_member("O000172")
             assert {t["congress"] for t in terms} == {117, 118, 119}
+            for t in terms:
+                assert t["chamber"] == "house"
+                assert t["state"] == "NY"
+                assert t["district"] == 14
 
-    def test_latest_snapshot_wins(self, tmp_path: Path) -> None:
+    def test_chamber_switch_resolves_by_congress(self, tmp_path: Path) -> None:
+        """Sanders' payload has both House (1991-2007) and Senate (2007-now)
+        items. The right chamber is picked by year range per Congress."""
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        payload = _fixture("current_senate.json")["members"][0]
+        _write_jsonl(
+            jsonl,
+            [
+                _envelope_for(payload, congress=102),  # in House
+                _envelope_for(payload, congress=119),  # in Senate
+            ],
+        )
+
+        load_members(jsonl_path=jsonl, db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            terms = storage.terms_for_member("S000033")
+            chambers_by_congress = {t["congress"]: t["chamber"] for t in terms}
+            assert chambers_by_congress == {102: "house", 119: "senate"}
+
+    def test_latest_snapshot_wins_per_cell(self, tmp_path: Path) -> None:
+        """Two snapshots for the same (member, congress) — newer fetched_at
+        wins for that cell."""
         jsonl = tmp_path / "members.jsonl"
         db = tmp_path / "test.db"
         payload = _fixture("current_house.json")["members"][0]
-        older = wrap_snapshot(
+        older = _envelope_for(
             {**payload, "directOrderName": "OLD NAME"},
+            congress=119,
             fetched_at=FIXED_FETCHED_AT - timedelta(days=30),
-            key={"bioguide_id": "O000172"},
         )
-        newer = wrap_snapshot(
-            payload,
-            fetched_at=FIXED_FETCHED_AT,
-            key={"bioguide_id": "O000172"},
-        )
+        newer = _envelope_for(payload, congress=119)
         _write_jsonl(jsonl, [older, newer])
 
         load_members(jsonl_path=jsonl, db_path=db)
-
         with SqliteStorage(db, load_vec=False) as storage:
             row = storage.get_member("O000172")
             assert row is not None
             assert row["display_name"] == "Alexandria Ocasio-Cortez"
 
     def test_terms_are_not_duplicated_on_reload(self, tmp_path: Path) -> None:
+        """Re-loading the same envelopes produces the same final state."""
         jsonl = tmp_path / "members.jsonl"
         db = tmp_path / "test.db"
         payload = _fixture("current_house.json")["members"][0]
-        envelope = wrap_snapshot(
-            payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}
-        )
+        envelope = _envelope_for(payload, congress=119)
         _write_jsonl(jsonl, [envelope, envelope, envelope])
 
-        stats = load_members(jsonl_path=jsonl, db_path=db)
-        assert stats.snapshots_read == 3
+        load_members(jsonl_path=jsonl, db_path=db)
 
         with SqliteStorage(db, load_vec=False) as storage:
             terms = storage.terms_for_member("O000172")
-            # Three identical snapshots collapse to one Member with three
-            # distinct Terms — not nine.
-            assert len(terms) == 3
+            assert len(terms) == 1  # one (member, congress) cell
+
+    def test_legacy_envelope_without_congress_is_malformed(self, tmp_path: Path) -> None:
+        """An envelope from before the composite-key migration lacks
+        ``congress`` in the key. Count it as malformed (and warn) rather
+        than guess the queried Congress from the payload."""
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        payload = _fixture("current_house.json")["members"][0]
+        legacy = {
+            "fetched_at": FIXED_FETCHED_AT.isoformat(),
+            "key": {"bioguide_id": "O000172"},  # no congress
+            "payload": payload,
+        }
+        jsonl.write_text(json.dumps(legacy) + "\n", encoding="utf-8")
+
+        stats = load_members(jsonl_path=jsonl, db_path=db)
+        assert stats.malformed == 1
+        assert stats.members_written == 0
 
     def test_malformed_lines_counted_not_fatal(self, tmp_path: Path) -> None:
         jsonl = tmp_path / "members.jsonl"
         db = tmp_path / "test.db"
         payload = _fixture("current_senate.json")["members"][0]
-        good = json.dumps(
-            wrap_snapshot(payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"})
-        )
+        good = json.dumps(_envelope_for(payload, congress=119))
         jsonl.write_text(
             "\n".join(
                 [
@@ -128,8 +195,8 @@ class TestLoadMembers:
         _write_jsonl(
             jsonl,
             [
-                wrap_snapshot(house, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}),
-                wrap_snapshot(senate, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}),
+                _envelope_for(house, congress=119),
+                _envelope_for(senate, congress=119),
             ],
         )
 
@@ -139,6 +206,20 @@ class TestLoadMembers:
         with SqliteStorage(db, load_vec=False) as storage:
             assert storage.get_member("O000172") is not None
             assert storage.get_member("S000033") is not None
+
+    def test_payload_without_matching_term_skips_only_that_cell(self, tmp_path: Path) -> None:
+        """If the API listed a Member for Congress N but their terms.item
+        doesn't cover N, log + skip the Term row (don't 500)."""
+        jsonl = tmp_path / "members.jsonl"
+        db = tmp_path / "test.db"
+        payload = _fixture("historical.json")["members"][0]
+        # Jeffords' terms end in 2007 — Congress 119 (2025-2027) falls
+        # outside any term's range. Member identity still gets stored.
+        _write_jsonl(jsonl, [_envelope_for(payload, congress=119)])
+
+        stats = load_members(jsonl_path=jsonl, db_path=db)
+        assert stats.members_written == 1
+        assert stats.terms_written == 0
 
 
 class TestIndexMembers:
@@ -150,8 +231,8 @@ class TestIndexMembers:
         _write_jsonl(
             jsonl,
             [
-                wrap_snapshot(house, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"}),
-                wrap_snapshot(senate, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "S000033"}),
+                _envelope_for(house, congress=119),
+                _envelope_for(senate, congress=119),
             ],
         )
         load_members(jsonl_path=jsonl, db_path=db)
@@ -170,10 +251,7 @@ class TestIndexMembers:
         jsonl = tmp_path / "members.jsonl"
         db = tmp_path / "test.db"
         payload = _fixture("current_house.json")["members"][0]
-        _write_jsonl(
-            jsonl,
-            [wrap_snapshot(payload, fetched_at=FIXED_FETCHED_AT, key={"bioguide_id": "O000172"})],
-        )
+        _write_jsonl(jsonl, [_envelope_for(payload, congress=119)])
         load_members(jsonl_path=jsonl, db_path=db)
 
         first = index_members(db_path=db)

--- a/tests/test_scraper_members.py
+++ b/tests/test_scraper_members.py
@@ -68,7 +68,7 @@ class TestScrape:
         assert len(lines) == 1
         envelope = json.loads(lines[0])
         assert envelope["fetched_at"] == FIXED_FETCHED_AT.isoformat()
-        assert envelope["key"] == {"bioguide_id": "O000172"}
+        assert envelope["key"] == {"bioguide_id": "O000172", "congress": 119}
         assert envelope["payload"]["bioguideId"] == "O000172"
 
     def test_writes_across_multiple_congresses(self, tmp_path: Path) -> None:
@@ -132,6 +132,31 @@ class TestScrape:
         assert [e.congress for e in events] == [117, 119]
         assert events[0].total_written == 1
         assert events[1].total_written == 2
+
+    def test_same_member_in_multiple_congresses_writes_distinct_envelopes(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression — the list endpoint returns identical payloads for the
+        same Member across every Congress they served in. Without the queried
+        Congress in the envelope key, the loader would collapse them and only
+        produce one Term row instead of three."""
+        out = tmp_path / "members.jsonl"
+        fixture = _load_fixture("current_senate.json")
+        client = _client_serving({117: fixture, 118: fixture, 119: fixture})
+
+        with client:
+            n = scrape(
+                client=client,
+                congresses=[117, 118, 119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+            )
+
+        assert n == 3
+        envelopes = [json.loads(line) for line in out.read_text().splitlines()]
+        # Same bioguide_id, distinct congress, distinct envelopes.
+        assert [e["key"]["bioguide_id"] for e in envelopes] == ["S000033"] * 3
+        assert [e["key"]["congress"] for e in envelopes] == [117, 118, 119]
 
     def test_creates_parent_directory(self, tmp_path: Path) -> None:
         out = tmp_path / "nested" / "data" / "members.jsonl"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -41,16 +41,23 @@ def test_members_end_to_end(tmp_path: Path) -> None:
 
     fetched_at = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC).isoformat()
     jsonl = tmp_path / "members.jsonl"
+    # The two current Members get a 119 snapshot; the historical one
+    # gets a 109 snapshot (the last Congress Jeffords was in the Senate).
+    snapshots = [
+        (payloads[0], 119),
+        (payloads[1], 119),
+        (payloads[2], 109),
+    ]
     jsonl.write_text(
         "\n".join(
             json.dumps(
                 {
                     "fetched_at": fetched_at,
-                    "key": {"bioguide_id": p["bioguideId"]},
+                    "key": {"bioguide_id": p["bioguideId"], "congress": congress},
                     "payload": p,
                 }
             )
-            for p in payloads
+            for p, congress in snapshots
         )
         + "\n",
         encoding="utf-8",


### PR DESCRIPTION
## The bug

Two related bugs, both rooted in the same misunderstanding of the \`/v3/member/congress/{n}\` list endpoint:

1. After \`concord run members\`, the \`members\` table filled up but \`member_terms\` stayed empty.
2. (My earlier attempt at a fix would have produced just one Term row per member — the start-Congress — instead of one per Congress they served in.)

## Root cause

The list endpoint returns the **same payload** for a Member regardless of which Congress you queried. The \`terms.item\` array carries only \`chamber\`, \`startYear\`, \`endYear\` — never \`congress\`. So when I scraped Congresses 117, 118, 119:

- Three queries → three identical payloads for each Member who served in all three
- All three envelopes had \`key = {\"bioguide_id\": X}\`, so the loader collapsed them
- Even after deriving \`congress\` from \`startYear\` (my first attempt), every Term row pointed to the **start** of the chamber-career stretch (e.g. Sanders → only Congress 110), not the queried Congresses

The queried Congress is information the API never emits. The scraper has to inject it.

## The fix

**Composite snapshot key.** Envelopes are now keyed on \`{\"bioguide_id\": X, \"congress\": N}\`. Each (Member, Congress) cell gets one snapshot — the API's \"this Member served in Congress N\" assertion captured directly in the JSONL.

**Per-Congress Term projection.** \`parse_member\` splits into:
- \`parse_member_identity(payload)\` — name, birth year, photo. Congress-independent.
- \`parse_member_term(payload, *, congress)\` — finds the \`terms.item\` whose year range covers the queried Congress and projects exactly one \`Term\` row whose \`start_date\`/\`end_date\` is clipped to that Congress's window.

**Loader groups by composite key.** Each (bioguide_id, congress) cell becomes one Term row. Sanders across 117/118/119 now produces three Senate Term rows, each with distinct start/end dates matching its Congress.

## Files

- [src/concord/scraper/members.py](src/concord/scraper/members.py) — composite key in envelope
- [src/concord/models.py](src/concord/models.py) — \`parse_member_identity\` + \`parse_member_term\` + \`_term_item_for_congress\` helper
- [src/concord/pipeline/load_members.py](src/concord/pipeline/load_members.py) — group by composite, union terms per member
- [tests/fixtures/api/members/](tests/fixtures/api/members/) — fixtures rewritten to match real list-endpoint shape (one \`terms.item\` per chamber-tenure, \`endYear\` omitted when ongoing)
- Tests overhauled across [test_models_members.py](tests/test_models_members.py), [test_pipeline_members.py](tests/test_pipeline_members.py), [test_scraper_members.py](tests/test_scraper_members.py), [test_smoke.py](tests/test_smoke.py) with the central regression: same payload + three Congress queries → three Term rows.

## Migration

Snapshot envelopes from before this PR lack \`congress\` in the key — they can't be loaded. To recover:

\`\`\`sh
rm data/members.jsonl
rm data/proceedings.db  # or just DELETE FROM members, member_terms, members_fts
concord run members --congresses 117,118,119
\`\`\`

The loader treats legacy envelopes as malformed (with a warning) rather than guessing.

## Test plan

- [x] \`pytest\` (314 tests, all green)
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy src\` clean
- [ ] Manual: re-scrape + re-load, confirm \`member_terms\` has the expected ~535×N rows (where N = number of Congresses scraped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)