### PR TITLE
Phase 2a — Bills (basic) ingest + web surface

### DIFF
--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -47,6 +47,11 @@ ARTICLES_PAGE_SIZE = 250
 #: Per-page size when walking ``/member/congress/{congress}``.
 MEMBERS_PAGE_SIZE = 250
 
+#: Per-page size when walking ``/bill/{congress}/{billType}``. The API
+#: caps at 250; using the max keeps pagination cost down on a 6K-bill
+#: Congress.
+BILLS_PAGE_SIZE = 250
+
 #: Cap on a single backoff delay, in seconds. Applied to both the exponential
 #: schedule and Retry-After values so a server-suggested 1-hour wait can't
 #: silently stall the pipeline.
@@ -200,6 +205,53 @@ class Client:
                 # Defensive: server advertises "next" but returned nothing.
                 return
             offset += MEMBERS_PAGE_SIZE
+
+    def list_bills(self, congress: int, bill_type: str) -> Iterator[dict[str, Any]]:
+        """Yield every Bill stub for one Congress + bill type.
+
+        Walks ``GET /v3/bill/{congress}/{bill_type}`` until
+        ``pagination.next`` is absent. Returns raw stub dicts — the full
+        identity record lives on :meth:`get_bill_detail`. ``bill_type``
+        is canonicalized to lowercase before URL formatting; the API
+        accepts both cases but the rest of the codebase stores lowercase.
+        """
+        bt = bill_type.lower()
+        offset = 0
+        path = f"/bill/{congress}/{bt}"
+        while True:
+            payload = self._get(path, params={"limit": BILLS_PAGE_SIZE, "offset": offset})
+            page_count = 0
+            for raw in payload.get("bills", []):
+                yield raw
+                page_count += 1
+            if "next" not in payload.get("pagination", {}):
+                return
+            if page_count == 0:
+                # Defensive: server advertises "next" but returned nothing.
+                return
+            offset += BILLS_PAGE_SIZE
+
+    def get_bill_detail(
+        self,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+    ) -> dict[str, Any]:
+        """Fetch the detail record for one Bill.
+
+        Returns the ``bill`` object from ``/v3/bill/{c}/{t}/{n}`` — the
+        full identity payload (sponsor, latestAction, policyArea, …).
+        ``bill_type`` is canonicalized to lowercase before URL formatting.
+        """
+        bt = bill_type.lower()
+        payload = self._get(f"/bill/{congress}/{bt}/{bill_number}")
+        bill = payload.get("bill")
+        if not isinstance(bill, dict):
+            raise ApiError(
+                f"expected 'bill' object in detail response for "
+                f"{congress}/{bt}/{bill_number}; got {type(bill).__name__}"
+            )
+        return bill
 
     # -- internals -----------------------------------------------------------
 

--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -34,9 +34,10 @@ import json
 import logging
 import os
 import sys
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import IO, Annotated
+from typing import IO, Annotated, Any
 
 import typer
 from pydantic import ValidationError
@@ -63,9 +64,23 @@ DEFAULT_JSONL = Path("./data/proceedings.jsonl")
 DEFAULT_MEMBERS_JSONL = Path("./data/members.jsonl")
 DEFAULT_DB = Path("./data/proceedings.db")
 
+#: Default storage directory for Bills (and the other Phase 2b
+#: sub-endpoint JSONLs once they exist). One directory because ADR 0009
+#: splits a multi-endpoint entity into multiple sibling files.
+DEFAULT_BILLS_STORAGE_DIR = Path("./data")
+
 #: Congresses scraped by ``concord scrape members`` when ``--congresses``
 #: is not passed. Matches the Phase 1 roadmap scope.
 DEFAULT_MEMBER_CONGRESSES = (117, 118, 119)
+
+#: Congresses scraped by ``concord scrape bills`` when ``--congresses``
+#: is not passed. Matches the Phase 2 roadmap scope.
+DEFAULT_BILL_CONGRESSES = (117, 118, 119)
+
+#: All eight legislative Bill type codes. Used both as the
+#: ``concord scrape bills --bill-types`` default and as the validator
+#: for the ``/bills/{...}/{bill_type}/...`` URL segment.
+DEFAULT_BILL_TYPES = ("hr", "hres", "hjres", "hconres", "s", "sres", "sjres", "sconres")
 
 
 class Progress:
@@ -189,20 +204,45 @@ def _require_openai_key() -> None:
         raise typer.Exit(code=2)
 
 
-def _parse_congresses(raw: str) -> list[int]:
-    """Parse ``--congresses 117,118,119`` into ``[117, 118, 119]``."""
-    out: list[int] = []
+def _parse_csv(raw: str, *, name: str, coerce: "Callable[[str], Any]") -> "list[Any]":
+    """Parse a comma-separated CLI option into a list of values.
+
+    ``coerce`` is applied to each non-empty token (e.g. ``int`` for
+    ``--congresses``, ``str.lower`` for ``--bill-types``). ``name`` is
+    used in error messages.
+    """
+    out: list[Any] = []
     for part in raw.split(","):
         token = part.strip()
         if not token:
             continue
         try:
-            out.append(int(token))
-        except ValueError as exc:
-            raise typer.BadParameter(f"expected comma-separated integers, got {raw!r}") from exc
+            out.append(coerce(token))
+        except (TypeError, ValueError) as exc:
+            raise typer.BadParameter(f"bad value in --{name}: {token!r}") from exc
     if not out:
-        raise typer.BadParameter(f"no congresses parsed from {raw!r}")
+        raise typer.BadParameter(f"no values parsed from --{name} {raw!r}")
     return out
+
+
+def _parse_congresses(raw: str) -> list[int]:
+    """Parse ``--congresses 117,118,119`` into ``[117, 118, 119]``."""
+    return _parse_csv(raw, name="congresses", coerce=int)
+
+
+def _parse_bill_types(raw: str) -> list[str]:
+    """Parse ``--bill-types hr,s,...`` into lowercased codes.
+
+    Rejects unknown codes against :data:`DEFAULT_BILL_TYPES` so a typo
+    fails fast instead of producing zero scraper output.
+    """
+    parsed = _parse_csv(raw, name="bill-types", coerce=str.lower)
+    unknown = [t for t in parsed if t not in DEFAULT_BILL_TYPES]
+    if unknown:
+        raise typer.BadParameter(
+            f"unknown bill type(s): {', '.join(unknown)}. Valid: {', '.join(DEFAULT_BILL_TYPES)}"
+        )
+    return parsed
 
 
 # ---------------------------------------------------------------------------
@@ -430,6 +470,101 @@ def _run_index_members(
     result = index_members(db_path=db_path)
     typer.echo(f"Indexed {result.indexed_members} member(s) into members_fts.")
     return result.indexed_members
+
+
+# ---------------------------------------------------------------------------
+# Bills stage workers
+# ---------------------------------------------------------------------------
+
+
+def _run_scrape_bills(
+    *,
+    congresses: list[int],
+    bill_types: list[str],
+    storage_dir: Path,
+    limit: int | None,
+    show_progress: bool,
+) -> int:
+    from .api import ApiError
+    from .scraper import bills as bills_scraper
+
+    try:
+        api_client = Client()
+    except ApiError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    progress = Progress(enabled=show_progress)
+
+    def _on_progress(event: bills_scraper.ScrapeProgressEvent) -> None:
+        progress.update(
+            f"  congress {event.congress:>3}  {event.bill_type:<7}  "
+            f"+{event.bills_written:>5} written  "
+            f"({event.bills_seen} seen)"
+        )
+
+    try:
+        with api_client:
+            stats = bills_scraper.scrape_basic(
+                client=api_client,
+                congresses=congresses,
+                storage_dir=storage_dir,
+                fetched_at=datetime.now(UTC),
+                bill_types=bill_types,
+                limit=limit,
+                progress=_on_progress if show_progress else None,
+            )
+    finally:
+        progress.commit()
+
+    typer.echo(
+        f"Wrote {stats.bills_written} bill snapshot(s) to "
+        f"{storage_dir / bills_scraper.BILLS_JSONL_NAME} "
+        f"across {len(congresses)} congress(es) x {len(bill_types)} bill type(s)."
+    )
+    return stats.bills_written
+
+
+def _run_load_bills(
+    *,
+    storage_dir: Path,
+    db_path: Path,
+    limit: int | None,
+) -> int:
+    from .pipeline.load_bills import load as load_bills
+    from .scraper.bills import BILLS_JSONL_NAME
+
+    jsonl_path = storage_dir / BILLS_JSONL_NAME
+    if not jsonl_path.exists():
+        typer.echo(
+            f"No input file at {jsonl_path} — run `concord scrape bills` first. Nothing to load."
+        )
+        return 0
+
+    stats = load_bills(storage_dir=storage_dir, db_path=db_path, limit=limit)
+    typer.echo(
+        f"Loaded {stats.bills_written} bill(s) into {db_path} "
+        f"(read {stats.snapshots_read} snapshot(s)"
+        + (f", {stats.malformed} malformed" if stats.malformed else "")
+        + ")."
+    )
+    return stats.bills_written
+
+
+def _run_index_bills(
+    *,
+    db_path: Path,
+    limit: int | None,
+) -> int:
+    if not db_path.exists():
+        typer.echo(f"error: database not found: {db_path}", err=True)
+        raise typer.Exit(code=2)
+
+    from .pipeline.index_bills import index as index_bills
+
+    stats = index_bills(db_path=db_path, limit=limit)
+    typer.echo(f"Indexed {stats.indexed_bills} bill(s) into bills_fts.")
+    return stats.indexed_bills
 
 
 # ---------------------------------------------------------------------------
@@ -801,6 +936,182 @@ def run_members_command(
 
     typer.echo("→ Stage 2: index", err=True)
     _run_index_members(db_path=db_path)
+
+    typer.echo("✓ Done.", err=True)
+
+
+# ---------------------------------------------------------------------------
+# Subcommands — Bills
+# ---------------------------------------------------------------------------
+
+
+@scrape_app.command("bills")
+def scrape_bills_command(
+    congresses: Annotated[
+        str,
+        typer.Option(
+            "--congresses",
+            help="Comma-separated list of congress numbers to scrape.",
+        ),
+    ] = ",".join(str(c) for c in DEFAULT_BILL_CONGRESSES),
+    bill_types: Annotated[
+        str,
+        typer.Option(
+            "--bill-types",
+            help="Comma-separated list of Bill type codes (hr, s, hjres, …).",
+        ),
+    ] = ",".join(DEFAULT_BILL_TYPES),
+    storage_dir: Annotated[
+        Path,
+        typer.Option(
+            "--storage-dir",
+            help="Directory holding bills.jsonl (and Phase 2b's sibling files).",
+        ),
+    ] = DEFAULT_BILLS_STORAGE_DIR,
+    limit: Annotated[
+        int | None,
+        typer.Option(
+            "--limit",
+            help="Maximum number of detail snapshots to write across all pairs.",
+        ),
+    ] = None,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help="Print a stderr line per (congress, bill_type) pair.",
+        ),
+    ] = True,
+) -> None:
+    """Snapshot Bill identity records into ``<storage-dir>/bills.jsonl``.
+
+    For each ``(congress, bill_type)`` pair the list endpoint is walked
+    to discover Bill numbers, then the detail endpoint is fetched per
+    bill and one ADR 0006 envelope is appended per detail response.
+    Re-running appends new snapshots; the Stage 1 loader projects the
+    latest per key into SQLite.
+    """
+    parsed_congresses = _parse_congresses(congresses)
+    parsed_types = _parse_bill_types(bill_types)
+    _run_scrape_bills(
+        congresses=parsed_congresses,
+        bill_types=parsed_types,
+        storage_dir=storage_dir,
+        limit=limit,
+        show_progress=show_progress,
+    )
+
+
+@load_app.command("bills")
+def load_bills_command(
+    storage_dir: Annotated[
+        Path,
+        typer.Option(
+            "--storage-dir",
+            help="Directory holding bills.jsonl (from `concord scrape bills`).",
+        ),
+    ] = DEFAULT_BILLS_STORAGE_DIR,
+    db_path: Annotated[
+        Path,
+        typer.Option("--db", help="SQLite database. Created if missing."),
+    ] = DEFAULT_DB,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", help="Maximum number of bills to UPSERT."),
+    ] = None,
+) -> None:
+    """Project the latest Bill snapshot per key into SQLite.
+
+    Populates the ``bills`` table. Re-running is safe: an UPSERT on
+    ``bill_id`` keeps the row consistent with the JSONL's latest
+    snapshot per ``(congress, bill_type, bill_number)``.
+    """
+    _run_load_bills(storage_dir=storage_dir, db_path=db_path, limit=limit)
+
+
+@index_app.command("bills")
+def index_bills_command(
+    db_path: Annotated[
+        Path,
+        typer.Option("--db", help="SQLite database written by `concord load bills`."),
+    ] = DEFAULT_DB,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", help="Cap on rows written to bills_fts."),
+    ] = None,
+) -> None:
+    """Populate the ``bills_fts`` FTS5 virtual table.
+
+    Truncates and repopulates ``bills_fts`` from the current ``bills``
+    table. Idempotent.
+    """
+    _run_index_bills(db_path=db_path, limit=limit)
+
+
+@run_app.command("bills")
+def run_bills_command(
+    congresses: Annotated[
+        str,
+        typer.Option(
+            "--congresses",
+            help="Comma-separated list of congress numbers to scrape.",
+        ),
+    ] = ",".join(str(c) for c in DEFAULT_BILL_CONGRESSES),
+    bill_types: Annotated[
+        str,
+        typer.Option(
+            "--bill-types",
+            help="Comma-separated list of Bill type codes.",
+        ),
+    ] = ",".join(DEFAULT_BILL_TYPES),
+    storage_dir: Annotated[
+        Path,
+        typer.Option("--storage-dir", help="JSONL canonical store directory."),
+    ] = DEFAULT_BILLS_STORAGE_DIR,
+    db_path: Annotated[
+        Path,
+        typer.Option("--db", help="SQLite derived store. Created if missing."),
+    ] = DEFAULT_DB,
+    limit: Annotated[
+        int | None,
+        typer.Option(
+            "--limit",
+            help="Cap on new bills scraped. Load and index run unbounded.",
+        ),
+    ] = None,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help="Print progress to stderr throughout all three stages.",
+        ),
+    ] = True,
+) -> None:
+    """Run all three stages for Bills: scrape → load → index."""
+    if not os.environ.get(ENV_API_KEY):
+        typer.echo(
+            f"error: {ENV_API_KEY} is not set; required for `concord scrape bills`",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    parsed_congresses = _parse_congresses(congresses)
+    parsed_types = _parse_bill_types(bill_types)
+
+    typer.echo("→ Stage 0: scrape", err=True)
+    _run_scrape_bills(
+        congresses=parsed_congresses,
+        bill_types=parsed_types,
+        storage_dir=storage_dir,
+        limit=limit,
+        show_progress=show_progress,
+    )
+
+    typer.echo("→ Stage 1: load", err=True)
+    _run_load_bills(storage_dir=storage_dir, db_path=db_path, limit=None)
+
+    typer.echo("→ Stage 2: index", err=True)
+    _run_index_bills(db_path=db_path, limit=None)
 
     typer.echo("✓ Done.", err=True)
 

--- a/src/concord/models.py
+++ b/src/concord/models.py
@@ -512,3 +512,126 @@ def _coerce_int(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+# ---------------------------------------------------------------------------
+# Bill entity (Phase 2a)
+# ---------------------------------------------------------------------------
+
+
+#: Lowercase canonical Bill type codes accepted across the codebase. The
+#: API returns these in mixed case (``HR``, ``HJRES``); :func:`Bill`'s
+#: validator lowercases on the way in so SQL constraints stay simple.
+BILL_TYPES = ("hr", "hres", "hjres", "hconres", "s", "sres", "sjres", "sconres")
+BillType = Literal["hr", "hres", "hjres", "hconres", "s", "sres", "sjres", "sconres"]
+OriginChamber = Literal["House", "Senate"]
+
+
+def bill_id_from_components(congress: int, bill_type: str, bill_number: int) -> str:
+    """Flatten a Bill's natural key into the single string used as the SQL PK.
+
+    Shape: ``"{congress}-{bill_type_lower}-{bill_number}"`` (e.g.
+    ``"119-hr-1234"``). Chosen to match the named ``source_id`` format
+    in [ADR 0008] so Phase 5 chunks linkage is a mechanical join.
+    """
+    return f"{congress}-{bill_type.lower()}-{bill_number}"
+
+
+class Bill(BaseModel):
+    """A piece of legislation introduced in either chamber.
+
+    Identity record only — the mutable political-graph data (cosponsors,
+    actions, subjects, titles, summaries) lives in child tables added in
+    Phase 2b. Fields here are exactly what the loader writes to the
+    ``bills`` SQLite table.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    bill_id: str
+    congress: int
+    bill_type: BillType
+    bill_number: int
+    origin_chamber: OriginChamber
+    title: str
+    introduced_date: str | None = None  # ISO YYYY-MM-DD
+    policy_area: str | None = None
+    sponsor_bioguide_id: str | None = None
+    latest_action_date: str | None = None
+    latest_action_text: str | None = None
+    update_date: str
+
+    @field_validator("bill_type", mode="before")
+    @classmethod
+    def _coerce_bill_type(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+
+class BillSnapshot(BaseModel):
+    """ADR 0006 envelope wrapping one raw ``/bill`` detail API response.
+
+    Each Stage 0 fetch appends one of these to ``data/bills.jsonl``. The
+    Stage 1 loader groups by ``(key["congress"], key["bill_type"],
+    key["bill_number"])`` and keeps the latest ``fetched_at`` per key.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    fetched_at: datetime
+    key: dict[str, str | int]
+    payload: dict[str, Any]
+
+
+def parse_bill(payload: dict[str, Any]) -> Bill:
+    """Project a ``/v3/bill/{c}/{t}/{n}`` detail payload into a :class:`Bill`.
+
+    The detail endpoint nests sponsors / policyArea / latestAction one
+    level deep; this helper flattens them into the columns the loader
+    writes. The first sponsor is taken (Bills have at most one per
+    Congress's rules — the array is the API's convention, not a
+    multi-sponsor signal).
+    """
+    congress = int(payload["congress"])
+    bill_type_raw = payload["type"]
+    bill_number = int(payload["number"])
+
+    sponsors = payload.get("sponsors") or []
+    sponsor_bioguide = None
+    if sponsors:
+        first = sponsors[0]
+        if isinstance(first, dict):
+            sponsor_bioguide = first.get("bioguideId")
+
+    policy_area_raw = payload.get("policyArea")
+    policy_area = policy_area_raw.get("name") if isinstance(policy_area_raw, dict) else None
+
+    latest_action_raw = payload.get("latestAction") or {}
+    latest_action_date = (
+        latest_action_raw.get("actionDate") if isinstance(latest_action_raw, dict) else None
+    )
+    latest_action_text = (
+        latest_action_raw.get("text") if isinstance(latest_action_raw, dict) else None
+    )
+
+    update_date_raw = payload.get("updateDateIncludingText") or payload.get("updateDate")
+    if not update_date_raw:
+        raise ValueError(f"bill payload missing updateDate: {payload!r}")
+
+    bill_type = str(bill_type_raw).lower()
+
+    return Bill(
+        bill_id=bill_id_from_components(congress, bill_type, bill_number),
+        congress=congress,
+        bill_type=bill_type,  # type: ignore[arg-type]
+        bill_number=bill_number,
+        origin_chamber=payload["originChamber"],
+        title=payload["title"],
+        introduced_date=payload.get("introducedDate"),
+        policy_area=policy_area,
+        sponsor_bioguide_id=sponsor_bioguide,
+        latest_action_date=latest_action_date,
+        latest_action_text=latest_action_text,
+        update_date=str(update_date_raw),
+    )

--- a/src/concord/pipeline/index_bills.py
+++ b/src/concord/pipeline/index_bills.py
@@ -1,0 +1,48 @@
+"""Stage 2 — Bills indexer.
+
+Populates the ``bills_fts`` FTS5 virtual table from the ``bills`` table.
+Truncate-then-repopulate keeps the index in lockstep with the current
+projection without triggers.
+
+Bill search is FTS5-only in Phase 2a; embeddings come in Phase 5 when
+the ``chunks`` table generalizes to ``source_type='bill'`` per ADR 0008.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+from ..storage.sqlite import SqliteStorage
+
+
+class IndexStats(NamedTuple):
+    """Outcome of one :func:`index` invocation."""
+
+    indexed_bills: int
+
+
+def index(*, db_path: Path, limit: int | None = None) -> IndexStats:
+    """Repopulate ``bills_fts`` from the current ``bills`` rows."""
+    storage = SqliteStorage(db_path, load_vec=False)
+    try:
+        conn = storage.connection
+        conn.execute("DELETE FROM bills_fts")
+        sql = "SELECT bill_id, bill_type, bill_number, title, policy_area FROM bills"
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+        rows = conn.execute(sql).fetchall()
+        for row in rows:
+            identifier = f"{row['bill_type']} {row['bill_number']}"
+            conn.execute(
+                "INSERT INTO bills_fts (bill_id, identifier, title, policy_area) "
+                "VALUES (?, ?, ?, ?)",
+                (row["bill_id"], identifier, row["title"], row["policy_area"]),
+            )
+        conn.commit()
+        return IndexStats(indexed_bills=len(rows))
+    finally:
+        storage.close()
+
+
+__all__ = ["IndexStats", "index"]

--- a/src/concord/pipeline/load_bills.py
+++ b/src/concord/pipeline/load_bills.py
@@ -1,0 +1,110 @@
+"""Stage 1 — Bills loader.
+
+Projects the ADR 0006 snapshot stream in ``<storage_dir>/bills.jsonl``
+into the ``bills`` SQLite table. The natural key is the composite
+``(congress, bill_type, bill_number)``; the loader keeps the latest
+snapshot per key and UPSERTs one row each.
+
+Re-running the loader over an unchanged JSONL is a no-op. Re-running
+over a JSONL that gained new snapshots converges the SQL projection to
+the latest-snapshot view.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from ..models import parse_bill
+from ..scraper.bills import BILLS_JSONL_NAME
+from ..storage.sqlite import SqliteStorage
+
+_log = logging.getLogger("concord.pipeline.load_bills")
+
+
+class LoadStats(NamedTuple):
+    """Outcome of one :func:`load` invocation."""
+
+    bills_written: int
+    snapshots_read: int
+    malformed: int
+
+
+def load(
+    *,
+    storage_dir: Path,
+    db_path: Path,
+    limit: int | None = None,
+) -> LoadStats:
+    """Project the latest Bill snapshot per key into SQLite.
+
+    Reads ``<storage_dir>/bills.jsonl``. If the file is missing, returns
+    a zeroed :class:`LoadStats` — matching the no-op-on-missing
+    convention set by :mod:`concord.pipeline.load_members`. Stops after
+    ``limit`` bills have been UPSERTed when set.
+    """
+    jsonl_path = storage_dir / BILLS_JSONL_NAME
+    if not jsonl_path.exists():
+        return LoadStats(bills_written=0, snapshots_read=0, malformed=0)
+
+    latest_per_key: dict[tuple[int, str, int], tuple[datetime, dict[str, Any]]] = {}
+    snapshots_read = 0
+    malformed = 0
+
+    with jsonl_path.open("r", encoding="utf-8") as fh:
+        for line_no, raw in enumerate(fh, 1):
+            line = raw.strip()
+            if not line:
+                continue
+            snapshots_read += 1
+            try:
+                envelope = json.loads(line)
+            except json.JSONDecodeError as exc:
+                malformed += 1
+                _log.warning("skipping malformed line %d: %s", line_no, exc)
+                continue
+            try:
+                key = envelope["key"]
+                congress = int(key["congress"])
+                bill_type = str(key["bill_type"]).lower()
+                bill_number = int(key["bill_number"])
+                fetched_at = datetime.fromisoformat(envelope["fetched_at"])
+                payload = envelope["payload"]
+            except (KeyError, TypeError, ValueError) as exc:
+                malformed += 1
+                _log.warning("skipping line %d with bad envelope: %s", line_no, exc)
+                continue
+
+            cell = (congress, bill_type, bill_number)
+            current = latest_per_key.get(cell)
+            if current is None or fetched_at > current[0]:
+                latest_per_key[cell] = (fetched_at, payload)
+
+    bills_written = 0
+    storage = SqliteStorage(db_path, load_vec=False)
+    try:
+        for (_c, _t, _n), (fetched_at, payload) in latest_per_key.items():
+            try:
+                bill = parse_bill(payload)
+            except Exception as exc:
+                malformed += 1
+                _log.warning("skipping bill after parse failure: %s", exc)
+                continue
+            storage.upsert_bill(bill, fetched_at=fetched_at.isoformat())
+            bills_written += 1
+            if limit is not None and bills_written >= limit:
+                break
+    finally:
+        storage.close()
+
+    return LoadStats(
+        bills_written=bills_written,
+        snapshots_read=snapshots_read,
+        malformed=malformed,
+    )
+
+
+__all__ = ["LoadStats", "load"]

--- a/src/concord/scraper/bills.py
+++ b/src/concord/scraper/bills.py
@@ -1,0 +1,152 @@
+"""Stage 0 — Bills scraper.
+
+Walks ``api.congress.gov``'s two Bill endpoints to build the canonical
+identity record per Bill:
+
+1. ``/v3/bill/{congress}/{bill_type}`` — list endpoint. Stubs only;
+   used solely to discover Bill numbers. Not persisted.
+2. ``/v3/bill/{c}/{t}/{n}`` — detail endpoint. One ADR 0006 snapshot
+   envelope per response is appended to ``data/bills.jsonl``.
+
+Per ADR 0009 the bills.jsonl file holds only the Tier 1 identity
+snapshots — Phase 2b will add five sibling JSONL files for the
+sub-endpoints (cosponsors, actions, subjects, titles, summaries) via a
+second entry point ``scrape_enrichment`` added to this same module.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from datetime import datetime
+from pathlib import Path
+from typing import NamedTuple
+
+from ..api import Client
+
+#: Default Bill type codes scraped when the caller doesn't pass
+#: ``bill_types``. Order matches the API documentation; chamber-grouped
+#: so a partial run still covers a recognizable slice.
+DEFAULT_BILL_TYPES: tuple[str, ...] = (
+    "hr",
+    "hres",
+    "hjres",
+    "hconres",
+    "s",
+    "sres",
+    "sjres",
+    "sconres",
+)
+
+#: Canonical filename inside the storage directory.
+BILLS_JSONL_NAME = "bills.jsonl"
+
+
+class ScrapeProgressEvent(NamedTuple):
+    """Emitted by :func:`scrape_basic` once per ``(congress, bill_type)``."""
+
+    congress: int
+    bill_type: str
+    bills_seen: int
+    bills_written: int
+
+
+class ScrapeStats(NamedTuple):
+    """Outcome of one :func:`scrape_basic` invocation."""
+
+    bills_written: int
+    bills_seen: int
+
+
+def scrape_basic(
+    *,
+    client: Client,
+    congresses: Iterable[int],
+    storage_dir: Path,
+    fetched_at: datetime,
+    bill_types: Iterable[str] | None = None,
+    limit: int | None = None,
+    progress: Callable[[ScrapeProgressEvent], None] | None = None,
+) -> ScrapeStats:
+    """Append one detail snapshot per Bill to ``<storage_dir>/bills.jsonl``.
+
+    Behavior:
+
+    * For each ``(congress, bill_type)`` pair, paginate the list endpoint
+      to discover Bill numbers (stubs are not persisted).
+    * For each stub, fetch the detail endpoint and append one ADR 0006
+      envelope keyed by ``(congress, bill_type, bill_number)``.
+    * If ``limit`` is set, stop once ``limit`` detail envelopes have been
+      written across all pairs.
+
+    The output file is opened in append mode; the storage directory is
+    created if missing.
+    """
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    out_path = storage_dir / BILLS_JSONL_NAME
+    iso = fetched_at.isoformat()
+
+    types = tuple(bill_types) if bill_types is not None else DEFAULT_BILL_TYPES
+
+    written = 0
+    seen = 0
+    done = False
+    with out_path.open("a", encoding="utf-8") as fh:
+        for congress in congresses:
+            if done:
+                break
+            for bill_type in types:
+                if done:
+                    break
+                bt = bill_type.lower()
+                pair_seen = 0
+                pair_written = 0
+                for stub in client.list_bills(congress, bt):
+                    pair_seen += 1
+                    seen += 1
+                    number_raw = stub.get("number")
+                    if number_raw is None:
+                        # Defensive: a stub without a number can't be
+                        # promoted to a detail call; skip it.
+                        continue
+                    try:
+                        bill_number = int(number_raw)
+                    except (TypeError, ValueError):
+                        continue
+                    detail = client.get_bill_detail(congress, bt, bill_number)
+                    envelope = {
+                        "fetched_at": iso,
+                        "key": {
+                            "congress": congress,
+                            "bill_type": bt,
+                            "bill_number": bill_number,
+                        },
+                        "payload": detail,
+                    }
+                    fh.write(json.dumps(envelope, ensure_ascii=False))
+                    fh.write("\n")
+                    pair_written += 1
+                    written += 1
+                    if limit is not None and written >= limit:
+                        done = True
+                        break
+                if progress is not None:
+                    progress(
+                        ScrapeProgressEvent(
+                            congress=congress,
+                            bill_type=bt,
+                            bills_seen=pair_seen,
+                            bills_written=pair_written,
+                        )
+                    )
+
+    return ScrapeStats(bills_written=written, bills_seen=seen)
+
+
+__all__ = [
+    "BILLS_JSONL_NAME",
+    "DEFAULT_BILL_TYPES",
+    "ScrapeProgressEvent",
+    "ScrapeStats",
+    "scrape_basic",
+]

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -30,7 +30,7 @@ from typing import Any
 
 import sqlite_vec  # type: ignore[import-untyped]
 
-from ..models import Member, Proceeding, Term
+from ..models import Bill, Member, Proceeding, Term
 
 # Columns in the exact order they appear in the INSERT statement. Keeping
 # this list in one place makes it easy to add a column later: extend here,
@@ -165,6 +165,49 @@ CREATE VIRTUAL TABLE IF NOT EXISTS members_fts USING fts5(
     last_name,
     tokenize = 'porter'
 );
+
+-- Bills (Phase 2a). Identity record per Bill — sponsor goes here too
+-- because Congress's rules cap one Sponsor per Bill. The mutable
+-- political-graph data (cosponsors, actions, subjects, titles,
+-- summaries) is added in Phase 2b as child tables. ``bill_id`` is the
+-- flattened "{congress}-{bill_type}-{bill_number}" PK chosen so Phase 5
+-- chunks linkage matches ADR 0008. The sponsor column is bare TEXT (no
+-- REFERENCES members) so ingest is robust to any Phase 1 gap.
+CREATE TABLE IF NOT EXISTS bills (
+    bill_id              TEXT PRIMARY KEY,
+    congress             INTEGER NOT NULL,
+    bill_type            TEXT NOT NULL
+        CHECK (bill_type IN ('hr', 'hres', 'hjres', 'hconres', 's', 'sres', 'sjres', 'sconres')),
+    bill_number          INTEGER NOT NULL,
+    origin_chamber       TEXT NOT NULL
+        CHECK (origin_chamber IN ('House', 'Senate')),
+    title                TEXT NOT NULL,
+    introduced_date      TEXT,
+    policy_area          TEXT,
+    sponsor_bioguide_id  TEXT,
+    latest_action_date   TEXT,
+    latest_action_text   TEXT,
+    update_date          TEXT NOT NULL,
+    fetched_at           TEXT NOT NULL,
+    UNIQUE (congress, bill_type, bill_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bills_sponsor
+    ON bills (sponsor_bioguide_id);
+CREATE INDEX IF NOT EXISTS idx_bills_latest_action
+    ON bills (latest_action_date DESC);
+CREATE INDEX IF NOT EXISTS idx_bills_policy_area
+    ON bills (policy_area);
+CREATE INDEX IF NOT EXISTS idx_bills_congress
+    ON bills (congress);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS bills_fts USING fts5(
+    bill_id UNINDEXED,
+    identifier,
+    title,
+    policy_area,
+    tokenize = 'porter'
+);
 """
 
 # Column lists for members + member_terms tables. Mirrors the ``_PROCEEDING_COLUMNS``
@@ -209,6 +252,31 @@ _TERM_INSERT_SQL = (
     + ") VALUES ("
     + ", ".join("?" for _ in _TERM_COLUMNS)
     + ")"
+)
+
+_BILL_COLUMNS: tuple[str, ...] = (
+    "bill_id",
+    "congress",
+    "bill_type",
+    "bill_number",
+    "origin_chamber",
+    "title",
+    "introduced_date",
+    "policy_area",
+    "sponsor_bioguide_id",
+    "latest_action_date",
+    "latest_action_text",
+    "update_date",
+    "fetched_at",
+)
+
+_BILL_UPSERT_SQL = (
+    "INSERT INTO bills ("
+    + ", ".join(_BILL_COLUMNS)
+    + ") VALUES ("
+    + ", ".join("?" for _ in _BILL_COLUMNS)
+    + ") ON CONFLICT(bill_id) DO UPDATE SET "
+    + ", ".join(f"{col} = excluded.{col}" for col in _BILL_COLUMNS if col != "bill_id")
 )
 
 # Vec-only schema. Only created when load_vec=True.
@@ -417,6 +485,26 @@ class SqliteStorage:
         )
         return cursor.fetchall()
 
+    # -- Bills (Phase 2a) -------------------------------------------------
+
+    def upsert_bill(self, bill: Bill, *, fetched_at: str) -> None:
+        """UPSERT one Bill row keyed on ``bill_id``.
+
+        Latest snapshot wins per ADR 0006; the loader is responsible for
+        feeding only the latest snapshot per natural key.
+        """
+        row = _row_from_bill(bill, fetched_at=fetched_at)
+        self._conn.execute(_BILL_UPSERT_SQL, row)
+        self._conn.commit()
+
+    def get_bill(self, bill_id: str) -> sqlite3.Row | None:
+        cursor = self._conn.execute(
+            "SELECT * FROM bills WHERE bill_id = ?",
+            (bill_id,),
+        )
+        row: sqlite3.Row | None = cursor.fetchone()
+        return row
+
     # -- introspection ----------------------------------------------------
 
     @property
@@ -475,3 +563,10 @@ def _row_from_term(term: Term) -> tuple[Any, ...]:
     """Project a :class:`Term` into the column tuple expected by SQL."""
     dumped: dict[str, Any] = term.model_dump(mode="json")
     return tuple(dumped[col] for col in _TERM_COLUMNS)
+
+
+def _row_from_bill(bill: Bill, *, fetched_at: str) -> tuple[Any, ...]:
+    """Project a :class:`Bill` into the column tuple expected by SQL."""
+    dumped: dict[str, Any] = bill.model_dump(mode="json")
+    dumped["fetched_at"] = fetched_at
+    return tuple(dumped[col] for col in _BILL_COLUMNS)

--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -20,6 +20,7 @@ Rate limiting (slowapi, in-process per-IP) is applied to ``/search``
 only — the other routes don't call OpenAI and don't need protection.
 """
 
+import re
 import sqlite3
 from collections.abc import Iterator
 from datetime import date
@@ -28,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 import sqlite_vec  # type: ignore[import-untyped]
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
-from fastapi.responses import HTMLResponse, JSONResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from slowapi import Limiter, _rate_limit_exceeded_handler
@@ -51,10 +52,30 @@ SEARCH_PAGE_SIZE = 20
 #: Page size for the ``/members`` browse-only index.
 MEMBERS_PAGE_SIZE = 50
 
+#: Page size for the ``/bills`` browse-only index.
+BILLS_PAGE_SIZE = 50
+
 #: Cap on Member hits surfaced in a federated ``/search``. Members are an
 #: at-most-N peek alongside Proceedings; deeper exploration goes through
 #: ``/members``.
 MEMBER_RESULT_LIMIT = 10
+
+#: Cap on Bill hits surfaced in a federated ``/search``.
+BILL_RESULT_LIMIT = 10
+
+#: Bill type codes accepted in URL paths. Mirrors
+#: :data:`concord.cli.DEFAULT_BILL_TYPES`; kept here too so the web
+#: package doesn't import the CLI module.
+_VALID_BILL_TYPES = frozenset({"hr", "hres", "hjres", "hconres", "s", "sres", "sjres", "sconres"})
+
+#: Regex that matches a bare Bill identifier like ``"HR 1234"`` or
+#: ``"S.47"``. Used to detect "did you mean this Bill?" queries and
+#: redirect to the Bill page when there's exactly one match across the
+#: in-scope Congresses.
+_BARE_BILL_RE = re.compile(
+    r"^\s*(HR|HRES|HJRES|HCONRES|S|SRES|SJRES|SCONRES)\.?\s*(\d+)\s*$",
+    re.IGNORECASE,
+)
 
 _HERE = Path(__file__).parent
 _TEMPLATES_DIR = _HERE / "templates"
@@ -146,6 +167,7 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
         section: str | None = Query(None, description="Senate Section, House Section, etc."),
         page: int = Query(1, ge=1, description="1-based page index."),
         members_on: str = Query("on", alias="members", description="'on' to include Members."),
+        bills_on: str = Query("on", alias="bills", description="'on' to include Bills."),
         proceedings_on: str = Query(
             "on", alias="proceedings", description="'on' to include Proceedings."
         ),
@@ -157,7 +179,29 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
         offset = (page - 1) * SEARCH_PAGE_SIZE
 
         include_members = members_on == "on"
+        include_bills = bills_on == "on"
         include_proceedings = proceedings_on == "on"
+
+        # -- Bare-identifier short-circuit -------------------------------
+        # "HR 1" / "s.47" → redirect to the bill page when there is
+        # exactly one match across in-scope Congresses. Multiple matches
+        # fall through and render via search_bills below; zero matches
+        # also fall through (the FTS section will handle it).
+        bare_match = _BARE_BILL_RE.match(q) if q.strip() else None
+        if bare_match:
+            bill_type_q = bare_match.group(1).lower()
+            bill_number_q = int(bare_match.group(2))
+            rows = db.execute(
+                "SELECT congress FROM bills WHERE bill_type = ? AND bill_number = ? "
+                "ORDER BY congress DESC",
+                (bill_type_q, bill_number_q),
+            ).fetchall()
+            if len(rows) == 1:
+                congress = int(rows[0]["congress"])
+                return RedirectResponse(
+                    url=f"/bills/{congress}/{bill_type_q}/{bill_number_q}",
+                    status_code=307,
+                )
 
         # -- Members section ---------------------------------------------
         member_hits: list[search_mod.MemberHit] = []
@@ -168,6 +212,14 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
                 # FTS5 query syntax errors land here; show no Members
                 # rather than 500 on a malformed query.
                 member_hits = []
+
+        # -- Bills section -----------------------------------------------
+        bill_hits: list[search_mod.BillHit] = []
+        if include_bills and q.strip():
+            try:
+                bill_hits = search_mod.search_bills(db, query=q, limit=BILL_RESULT_LIMIT)
+            except sqlite3.OperationalError:
+                bill_hits = []
 
         # -- Proceedings section -----------------------------------------
         rendered_results: list[dict[str, Any]] = []
@@ -206,7 +258,9 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
             "has_prev": page > 1,
             "sections": _SECTION_OPTIONS,
             "member_hits": member_hits,
+            "bill_hits": bill_hits,
             "include_members": include_members,
+            "include_bills": include_bills,
             "include_proceedings": include_proceedings,
         }
 
@@ -287,10 +341,78 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
             ),
             None,
         )
+        sponsored = search_mod.sponsored_bills_for_member(db, bioguide_id, limit=25)
+        sponsored_total = search_mod.count_sponsored_bills_for_member(db, bioguide_id)
         return templates.TemplateResponse(  # type: ignore[no-any-return]
             request,
             "members/profile.html",
-            {"member": member, "terms": terms, "current_term": current_term},
+            {
+                "member": member,
+                "terms": terms,
+                "current_term": current_term,
+                "sponsored_bills": sponsored,
+                "sponsored_bills_total": sponsored_total,
+            },
+        )
+
+    @app.get("/bills", response_class=HTMLResponse)
+    def bills_index(
+        request: Request,
+        chamber: str | None = Query(None, description="'House', 'Senate', or omitted."),
+        policy_area: str | None = Query(None, description="Filter on CRS policy area."),
+        congress: int | None = Query(None, description="Filter on a Congress number."),
+        sponsor: str | None = Query(None, description="Filter on sponsor Bioguide ID."),
+        page: int = Query(1, ge=1, description="1-based page index."),
+        db: sqlite3.Connection = Depends(get_db),  # noqa: B008 - FastAPI Depends pattern
+    ) -> Response:
+        offset = (page - 1) * BILLS_PAGE_SIZE
+        chamber_filter = chamber if chamber in {"House", "Senate"} else None
+        hits, total = search_mod.list_bills(
+            db,
+            chamber=chamber_filter,
+            policy_area=policy_area or None,
+            congress=congress,
+            sponsor_bioguide_id=sponsor or None,
+            limit=BILLS_PAGE_SIZE,
+            offset=offset,
+        )
+        context = {
+            "bills": hits,
+            "total": total,
+            "page": page,
+            "page_size": BILLS_PAGE_SIZE,
+            "has_next": offset + BILLS_PAGE_SIZE < total,
+            "has_prev": page > 1,
+            "chamber": chamber_filter or "",
+            "policy_area": policy_area or "",
+            "congress": congress,
+            "sponsor": sponsor or "",
+        }
+        return templates.TemplateResponse(  # type: ignore[no-any-return]
+            request, "bills/list.html", context
+        )
+
+    @app.get("/bills/{congress}/{bill_type}/{bill_number}", response_class=HTMLResponse)
+    def bill_profile(
+        request: Request,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+        db: sqlite3.Connection = Depends(get_db),  # noqa: B008 - FastAPI Depends pattern
+    ) -> Response:
+        bt = bill_type.lower()
+        if bt not in _VALID_BILL_TYPES:
+            raise HTTPException(status_code=404, detail=f"unknown bill type: {bill_type}")
+        bill = search_mod.get_bill(db, congress=congress, bill_type=bt, bill_number=bill_number)
+        if bill is None:
+            return templates.TemplateResponse(  # type: ignore[no-any-return]
+                request,
+                "404.html",
+                {"granule_id": f"{congress}/{bt}/{bill_number}"},
+                status_code=404,
+            )
+        return templates.TemplateResponse(  # type: ignore[no-any-return]
+            request, "bills/profile.html", {"bill": bill}
         )
 
     @app.get("/healthz")
@@ -325,6 +447,8 @@ def _parse_optional_date(value: str | None) -> date | None:
 
 
 __all__: list[Any] = [
+    "BILLS_PAGE_SIZE",
+    "BILL_RESULT_LIMIT",
     "MEMBERS_PAGE_SIZE",
     "MEMBER_RESULT_LIMIT",
     "SEARCH_PAGE_SIZE",

--- a/src/concord/web/search.py
+++ b/src/concord/web/search.py
@@ -364,6 +364,219 @@ def terms_for_member(db: sqlite3.Connection, bioguide_id: str) -> list[dict[str,
     return [dict(r) for r in rows]
 
 
+# -- Bills (Phase 2a) -------------------------------------------------------
+
+
+def _row_get(row: sqlite3.Row, name: str) -> Any:
+    """``row[name]`` with a None fallback when the column isn't in the result."""
+    try:
+        return row[name]
+    except IndexError:
+        return None
+
+
+class BillHit(BaseModel):
+    """One row of the federated ``/search`` Bills section."""
+
+    bill_id: str
+    congress: int
+    bill_type: str
+    bill_number: int
+    title: str
+    origin_chamber: str
+    policy_area: str | None
+    latest_action_date: str | None
+    sponsor_bioguide_id: str | None
+    sponsor_display_name: str | None
+
+
+def _bill_hit_from_row(row: sqlite3.Row) -> BillHit:
+    return BillHit(
+        bill_id=row["bill_id"],
+        congress=row["congress"],
+        bill_type=row["bill_type"],
+        bill_number=row["bill_number"],
+        title=row["title"],
+        origin_chamber=row["origin_chamber"],
+        policy_area=row["policy_area"],
+        latest_action_date=row["latest_action_date"],
+        sponsor_bioguide_id=row["sponsor_bioguide_id"],
+        sponsor_display_name=_row_get(row, "sponsor_display_name"),
+    )
+
+
+def search_bills(
+    db: sqlite3.Connection,
+    *,
+    query: str,
+    limit: int = 10,
+) -> list[BillHit]:
+    """FTS5 search over ``bills_fts`` (title + identifier + policy_area).
+
+    Empty / whitespace-only ``query`` short-circuits to ``[]``. Results
+    are joined back to ``bills`` for the card line on the results page,
+    plus the sponsor's display name (when the Member is indexed).
+    """
+    if not query.strip():
+        return []
+    safe = '"' + query.replace('"', '""') + '"'
+    rows = db.execute(
+        """
+        SELECT
+            b.bill_id              AS bill_id,
+            b.congress             AS congress,
+            b.bill_type            AS bill_type,
+            b.bill_number          AS bill_number,
+            b.title                AS title,
+            b.origin_chamber       AS origin_chamber,
+            b.policy_area          AS policy_area,
+            b.latest_action_date   AS latest_action_date,
+            b.sponsor_bioguide_id  AS sponsor_bioguide_id,
+            m.display_name         AS sponsor_display_name
+        FROM bills_fts f
+        JOIN bills b ON b.bill_id = f.bill_id
+        LEFT JOIN members m ON m.bioguide_id = b.sponsor_bioguide_id
+        WHERE f.bills_fts MATCH ?
+        ORDER BY b.latest_action_date DESC
+        LIMIT ?
+        """,
+        (safe, limit),
+    ).fetchall()
+    return [_bill_hit_from_row(r) for r in rows]
+
+
+def list_bills(
+    db: sqlite3.Connection,
+    *,
+    chamber: str | None = None,
+    policy_area: str | None = None,
+    congress: int | None = None,
+    sponsor_bioguide_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[BillHit], int]:
+    """Return ``(rows, total)`` for the browse-only ``/bills`` index.
+
+    Default sort is ``latest_action_date DESC NULLS LAST``. Filters AND
+    together; an absent filter is a wildcard.
+    """
+    where: list[str] = []
+    params: list[Any] = []
+    if chamber in {"House", "Senate"}:
+        where.append("b.origin_chamber = ?")
+        params.append(chamber)
+    if policy_area:
+        where.append("b.policy_area = ?")
+        params.append(policy_area)
+    if congress is not None:
+        where.append("b.congress = ?")
+        params.append(congress)
+    if sponsor_bioguide_id:
+        where.append("b.sponsor_bioguide_id = ?")
+        params.append(sponsor_bioguide_id)
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+
+    (total,) = db.execute(
+        f"SELECT COUNT(*) FROM bills b{where_sql}",
+        params,
+    ).fetchone()
+
+    rows = db.execute(
+        f"""
+        SELECT
+            b.bill_id              AS bill_id,
+            b.congress             AS congress,
+            b.bill_type            AS bill_type,
+            b.bill_number          AS bill_number,
+            b.title                AS title,
+            b.origin_chamber       AS origin_chamber,
+            b.policy_area          AS policy_area,
+            b.latest_action_date   AS latest_action_date,
+            b.sponsor_bioguide_id  AS sponsor_bioguide_id,
+            m.display_name         AS sponsor_display_name
+        FROM bills b
+        LEFT JOIN members m ON m.bioguide_id = b.sponsor_bioguide_id
+        {where_sql}
+        ORDER BY (b.latest_action_date IS NULL), b.latest_action_date DESC,
+                 b.congress DESC, b.bill_number ASC
+        LIMIT ? OFFSET ?
+        """,
+        [*params, limit, offset],
+    ).fetchall()
+    return [_bill_hit_from_row(r) for r in rows], int(total)
+
+
+def get_bill(
+    db: sqlite3.Connection,
+    *,
+    congress: int,
+    bill_type: str,
+    bill_number: int,
+) -> dict[str, Any] | None:
+    """Fetch one Bill row (joined with the sponsor's display name)."""
+    row = db.execute(
+        """
+        SELECT
+            b.*,
+            m.display_name AS sponsor_display_name
+        FROM bills b
+        LEFT JOIN members m ON m.bioguide_id = b.sponsor_bioguide_id
+        WHERE b.congress = ? AND b.bill_type = ? AND b.bill_number = ?
+        """,
+        (congress, bill_type.lower(), bill_number),
+    ).fetchone()
+    if row is None:
+        return None
+    return dict(row)
+
+
+def sponsored_bills_for_member(
+    db: sqlite3.Connection,
+    bioguide_id: str,
+    *,
+    limit: int = 25,
+) -> list[BillHit]:
+    """Return Bills the Member sponsored, newest introduced first.
+
+    Used by the Member profile's "Sponsored bills" cross-link. The
+    ``bills.sponsor_bioguide_id`` column is indexed (idx_bills_sponsor),
+    so this is sub-millisecond at v1 scale.
+    """
+    rows = db.execute(
+        """
+        SELECT
+            b.bill_id              AS bill_id,
+            b.congress             AS congress,
+            b.bill_type            AS bill_type,
+            b.bill_number          AS bill_number,
+            b.title                AS title,
+            b.origin_chamber       AS origin_chamber,
+            b.policy_area          AS policy_area,
+            b.latest_action_date   AS latest_action_date,
+            b.sponsor_bioguide_id  AS sponsor_bioguide_id,
+            NULL                   AS sponsor_display_name
+        FROM bills b
+        WHERE b.sponsor_bioguide_id = ?
+        ORDER BY (b.introduced_date IS NULL), b.introduced_date DESC,
+                 b.congress DESC, b.bill_number ASC
+        LIMIT ?
+        """,
+        (bioguide_id, limit),
+    ).fetchall()
+    return [_bill_hit_from_row(r) for r in rows]
+
+
+def count_sponsored_bills_for_member(
+    db: sqlite3.Connection,
+    bioguide_id: str,
+) -> int:
+    (count,) = db.execute(
+        "SELECT COUNT(*) FROM bills WHERE sponsor_bioguide_id = ?",
+        (bioguide_id,),
+    ).fetchone()
+    return int(count)
+
+
 def list_current_members(
     db: sqlite3.Connection,
     *,

--- a/src/concord/web/templates/_results.html
+++ b/src/concord/web/templates/_results.html
@@ -5,7 +5,7 @@
         type="checkbox" name="members" value="on"
         form=""
         {% if include_members %}checked{% endif %}
-        hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&members={% if include_members %}{% else %}on{% endif %}&proceedings={% if include_proceedings %}on{% endif %}"
+        hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&members={% if include_members %}{% else %}on{% endif %}&bills={% if include_bills %}on{% endif %}&proceedings={% if include_proceedings %}on{% endif %}"
         hx-target="main"
         hx-push-url="true"
       >
@@ -13,10 +13,21 @@
     </label>
     <label class="flex items-center gap-1">
       <input
+        type="checkbox" name="bills" value="on"
+        form=""
+        {% if include_bills %}checked{% endif %}
+        hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&members={% if include_members %}on{% endif %}&bills={% if include_bills %}{% else %}on{% endif %}&proceedings={% if include_proceedings %}on{% endif %}"
+        hx-target="main"
+        hx-push-url="true"
+      >
+      <span>Bills</span>
+    </label>
+    <label class="flex items-center gap-1">
+      <input
         type="checkbox" name="proceedings" value="on"
         form=""
         {% if include_proceedings %}checked{% endif %}
-        hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&members={% if include_members %}on{% endif %}&proceedings={% if include_proceedings %}{% else %}on{% endif %}"
+        hx-get="/search?q={{ query|urlencode }}&from={{ from_date }}&to={{ to_date }}&section={{ section }}&members={% if include_members %}on{% endif %}&bills={% if include_bills %}on{% endif %}&proceedings={% if include_proceedings %}{% else %}on{% endif %}"
         hx-target="main"
         hx-push-url="true"
       >
@@ -67,6 +78,49 @@
       {% else %}
         <p class="text-stone-500 text-sm">
           No Members match <span class="font-mono">&ldquo;{{ query }}&rdquo;</span>.
+        </p>
+      {% endif %}
+    </section>
+  {% endif %}
+
+  {% if include_bills %}
+    <section class="mb-8">
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-3">
+        Bills ({{ bill_hits|length }})
+      </h2>
+      {% if bill_hits %}
+        <ul class="space-y-2">
+          {% for b in bill_hits %}
+            <li class="border border-stone-200 rounded p-3 bg-white">
+              <div class="flex items-baseline gap-2 mb-1">
+                <span class="text-xs uppercase tracking-wide px-2 py-0.5 rounded
+                  {% if b.origin_chamber == 'House' %}bg-blue-50 text-blue-800{% else %}bg-amber-50 text-amber-800{% endif %}">
+                  {{ b.origin_chamber }}
+                </span>
+                <a
+                  href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+                  class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
+                >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
+                <span class="text-xs text-stone-400">· {{ b.congress }}th</span>
+              </div>
+              <a
+                href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+                class="block text-stone-800 hover:text-stone-600"
+              >{{ b.title|truncate(120) }}</a>
+              <div class="text-xs text-stone-500 mt-1 flex flex-wrap gap-x-3">
+                {% if b.sponsor_display_name %}
+                  <span>Sponsor: {{ b.sponsor_display_name }}</span>
+                {% endif %}
+                {% if b.latest_action_date %}
+                  <span>Latest action: {{ b.latest_action_date }}</span>
+                {% endif %}
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="text-stone-500 text-sm">
+          No Bills match <span class="font-mono">&ldquo;{{ query }}&rdquo;</span>.
         </p>
       {% endif %}
     </section>

--- a/src/concord/web/templates/base.html
+++ b/src/concord/web/templates/base.html
@@ -19,6 +19,7 @@
         <nav class="ml-auto text-sm flex gap-3">
           <a href="/" class="text-stone-600 hover:text-stone-900">Search</a>
           <a href="/members" class="text-stone-600 hover:text-stone-900">Members</a>
+          <a href="/bills" class="text-stone-600 hover:text-stone-900">Bills</a>
         </nav>
       </div>
       <form

--- a/src/concord/web/templates/bills/list.html
+++ b/src/concord/web/templates/bills/list.html
@@ -1,0 +1,111 @@
+{% extends "base.html" %}
+{% block title %}Bills — Concord{% endblock %}
+{% block content %}
+<div>
+  <div class="flex items-baseline justify-between mb-4">
+    <h1 class="text-2xl font-serif font-semibold text-stone-900">Bills</h1>
+    <span class="text-sm text-stone-500">{{ total }} matching</span>
+  </div>
+
+  <form method="get" action="/bills" class="mb-6 flex flex-wrap gap-4 text-sm text-stone-600">
+    <fieldset class="flex flex-wrap gap-3">
+      <legend class="text-stone-500 uppercase tracking-wide text-xs mr-2">Chamber</legend>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="chamber" value="" {% if not chamber %}checked{% endif %}>
+        <span>All</span>
+      </label>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="chamber" value="House" {% if chamber == "House" %}checked{% endif %}>
+        <span>House</span>
+      </label>
+      <label class="flex items-center gap-1">
+        <input type="radio" name="chamber" value="Senate" {% if chamber == "Senate" %}checked{% endif %}>
+        <span>Senate</span>
+      </label>
+    </fieldset>
+    <label class="flex items-center gap-1">
+      <span class="text-stone-500 uppercase tracking-wide text-xs">Congress</span>
+      <input
+        type="number" name="congress" value="{{ congress or '' }}"
+        min="1" max="999"
+        class="w-20 rounded border border-stone-300 px-2 py-1 text-sm"
+      >
+    </label>
+    <label class="flex items-center gap-1">
+      <span class="text-stone-500 uppercase tracking-wide text-xs">Policy area</span>
+      <input
+        type="text" name="policy_area" value="{{ policy_area }}"
+        class="rounded border border-stone-300 px-2 py-1 text-sm"
+      >
+    </label>
+    <label class="flex items-center gap-1">
+      <span class="text-stone-500 uppercase tracking-wide text-xs">Sponsor</span>
+      <input
+        type="text" name="sponsor" value="{{ sponsor }}" placeholder="Bioguide ID"
+        class="rounded border border-stone-300 px-2 py-1 text-sm"
+      >
+    </label>
+    <button
+      type="submit"
+      class="rounded bg-stone-900 px-3 py-1 text-white text-xs font-medium hover:bg-stone-700"
+    >Apply</button>
+  </form>
+
+  {% if bills %}
+    <ul class="space-y-3">
+      {% for b in bills %}
+        <li class="border border-stone-200 rounded p-3 bg-white">
+          <div class="flex items-baseline gap-2 mb-1">
+            <span class="text-xs uppercase tracking-wide px-2 py-0.5 rounded
+              {% if b.origin_chamber == 'House' %}bg-blue-50 text-blue-800{% else %}bg-amber-50 text-amber-800{% endif %}">
+              {{ b.origin_chamber }}
+            </span>
+            <a
+              href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+              class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
+            >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
+            <span class="text-xs text-stone-400">· {{ b.congress }}th Congress</span>
+          </div>
+          <a
+            href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+            class="block text-stone-800 hover:text-stone-600"
+          >{{ b.title|truncate(120) }}</a>
+          <div class="text-xs text-stone-500 mt-1 flex flex-wrap gap-x-3">
+            {% if b.policy_area %}<span>{{ b.policy_area }}</span>{% endif %}
+            {% if b.sponsor_bioguide_id %}
+              <span>
+                Sponsor:
+                <a href="/members/{{ b.sponsor_bioguide_id }}" class="underline hover:text-stone-700">
+                  {{ b.sponsor_display_name or b.sponsor_bioguide_id }}
+                </a>
+              </span>
+            {% endif %}
+            {% if b.latest_action_date %}
+              <span>Latest action: {{ b.latest_action_date }}</span>
+            {% endif %}
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+
+    {% if has_prev or has_next %}
+      <nav class="mt-8 flex justify-between text-sm">
+        {% if has_prev %}
+          <a
+            class="text-stone-600 hover:text-stone-900 underline"
+            href="/bills?chamber={{ chamber }}&policy_area={{ policy_area|urlencode }}&congress={{ congress or '' }}&sponsor={{ sponsor }}&page={{ page - 1 }}"
+          >&larr; Previous</a>
+        {% else %}<span></span>{% endif %}
+        {% if has_next %}
+          <a
+            class="text-stone-600 hover:text-stone-900 underline"
+            href="/bills?chamber={{ chamber }}&policy_area={{ policy_area|urlencode }}&congress={{ congress or '' }}&sponsor={{ sponsor }}&page={{ page + 1 }}"
+          >Next &rarr;</a>
+        {% else %}<span></span>{% endif %}
+      </nav>
+    {% endif %}
+  {% else %}
+    <p class="text-stone-600">No Bills match the current filters.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/concord/web/templates/bills/profile.html
+++ b/src/concord/web/templates/bills/profile.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+{% block title %}{{ bill.bill_type|upper }} {{ bill.bill_number }} — Concord{% endblock %}
+{% block content %}
+<article class="grid grid-cols-1 md:grid-cols-4 gap-6">
+  <aside class="md:col-span-1 text-sm text-stone-600 space-y-3">
+    <div>
+      <div class="uppercase text-xs tracking-wide text-stone-400">Chamber</div>
+      <div>{{ bill.origin_chamber }}</div>
+    </div>
+    <div>
+      <div class="uppercase text-xs tracking-wide text-stone-400">Congress</div>
+      <div>{{ bill.congress }}th</div>
+    </div>
+    {% if bill.introduced_date %}
+      <div>
+        <div class="uppercase text-xs tracking-wide text-stone-400">Introduced</div>
+        <div>{{ bill.introduced_date }}</div>
+      </div>
+    {% endif %}
+    {% if bill.policy_area %}
+      <div>
+        <div class="uppercase text-xs tracking-wide text-stone-400">Policy area</div>
+        <div>{{ bill.policy_area }}</div>
+      </div>
+    {% endif %}
+    <div class="text-xs text-stone-400">
+      Updated: {{ bill.fetched_at }}
+    </div>
+  </aside>
+
+  <div class="md:col-span-3 space-y-8">
+    <header>
+      <div class="font-mono text-sm text-stone-500 mb-1">
+        {{ bill.bill_type|upper }} {{ bill.bill_number }} · {{ bill.congress }}th Congress
+      </div>
+      <h1 class="text-2xl font-serif font-semibold leading-snug">{{ bill.title }}</h1>
+    </header>
+
+    {% if bill.latest_action_date or bill.latest_action_text %}
+      <section>
+        <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Latest action</h2>
+        <p class="text-stone-800">
+          {% if bill.latest_action_date %}
+            <span class="font-medium">{{ bill.latest_action_date }}</span> —
+          {% endif %}
+          {{ bill.latest_action_text or "—" }}
+        </p>
+      </section>
+    {% endif %}
+
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Sponsor</h2>
+      {% if bill.sponsor_bioguide_id %}
+        {% if bill.sponsor_display_name %}
+          <a
+            href="/members/{{ bill.sponsor_bioguide_id }}"
+            class="text-stone-900 hover:text-stone-700 underline"
+          >{{ bill.sponsor_display_name }}</a>
+        {% else %}
+          <span class="text-stone-700">
+            Bioguide
+            <span class="font-mono">{{ bill.sponsor_bioguide_id }}</span>
+            <span class="text-stone-400 text-xs">(not indexed)</span>
+          </span>
+        {% endif %}
+      {% else %}
+        <span class="text-stone-500">No sponsor recorded.</span>
+      {% endif %}
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-sm uppercase tracking-wide text-stone-500">Coming in later phases</h2>
+
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Cosponsors (Phase 2b)</div>
+        <div class="text-xs">Members who signed on after introduction will appear here.</div>
+      </div>
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Action history (Phase 2b)</div>
+        <div class="text-xs">Full chronological action list will appear here.</div>
+      </div>
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Subjects (Phase 2b)</div>
+        <div class="text-xs">CRS-assigned subject tags will appear here.</div>
+      </div>
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Titles (Phase 2b)</div>
+        <div class="text-xs">Short, popular, and official titles will appear here.</div>
+      </div>
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Summaries (Phase 2b)</div>
+        <div class="text-xs">CRS summaries will appear here as the bill progresses.</div>
+      </div>
+
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Vote history (Phase 3)</div>
+        <div class="text-xs">Roll-call votes referencing this bill will appear here.</div>
+      </div>
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Committee path (Phase 4)</div>
+        <div class="text-xs">Committee referrals and reports will appear here.</div>
+      </div>
+      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+        <div class="font-medium text-stone-600">Search within this bill (Phase 5)</div>
+        <div class="text-xs">Bill text will become searchable here.</div>
+      </div>
+    </section>
+  </div>
+</article>
+{% endblock %}

--- a/src/concord/web/templates/members/profile.html
+++ b/src/concord/web/templates/members/profile.html
@@ -91,11 +91,43 @@
       {% endif %}
     </section>
 
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Sponsored bills</h2>
+      {% if sponsored_bills %}
+        <ul class="space-y-2">
+          {% for b in sponsored_bills %}
+            <li class="border border-stone-200 rounded p-3 bg-white">
+              <div class="flex items-baseline gap-2 mb-1">
+                <a
+                  href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+                  class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
+                >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
+                <span class="text-xs text-stone-400">· {{ b.congress }}th</span>
+              </div>
+              <a
+                href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+                class="block text-sm text-stone-800 hover:text-stone-600"
+              >{{ b.title|truncate(120) }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+        {% if sponsored_bills_total > sponsored_bills|length %}
+          <p class="mt-2 text-sm">
+            <a href="/bills?sponsor={{ member.bioguide_id }}" class="text-stone-600 hover:text-stone-900 underline">
+              View all {{ sponsored_bills_total }} &rarr;
+            </a>
+          </p>
+        {% endif %}
+      {% else %}
+        <p class="text-stone-500 text-sm">No sponsored bills indexed for this Member.</p>
+      {% endif %}
+    </section>
+
     <section class="space-y-3">
       <h2 class="text-sm uppercase tracking-wide text-stone-500">Coming in later phases</h2>
       <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
-        <div class="font-medium text-stone-600">Sponsored bills (Phase 2)</div>
-        <div class="text-xs">Bills this Member introduced or cosponsored will appear here.</div>
+        <div class="font-medium text-stone-600">Cosponsored bills (Phase 2b)</div>
+        <div class="text-xs">Bills this Member signed on to after introduction will appear here.</div>
       </div>
       <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
         <div class="font-medium text-stone-600">Recent votes (Phase 3)</div>

--- a/tests/fixtures/api/bills/detail_119_hr_1.json
+++ b/tests/fixtures/api/bills/detail_119_hr_1.json
@@ -1,0 +1,48 @@
+{
+  "bill": {
+    "congress": 119,
+    "type": "HR",
+    "number": "1",
+    "title": "Lower Energy Costs Act",
+    "originChamber": "House",
+    "originChamberCode": "H",
+    "introducedDate": "2025-01-09",
+    "updateDate": "2026-04-01",
+    "updateDateIncludingText": "2026-04-01T12:34:56Z",
+    "policyArea": {
+      "name": "Energy"
+    },
+    "sponsors": [
+      {
+        "bioguideId": "S001176",
+        "firstName": "Steve",
+        "lastName": "Scalise",
+        "middleName": null,
+        "fullName": "Rep. Scalise, Steve [R-LA-1]",
+        "party": "R",
+        "state": "LA",
+        "district": 1,
+        "isByRequest": "N",
+        "url": "https://api.congress.gov/v3/member/S001176?format=json"
+      }
+    ],
+    "latestAction": {
+      "actionDate": "2026-03-30",
+      "text": "Became Public Law No: 119-1."
+    },
+    "laws": [
+      {
+        "type": "Public Law",
+        "number": "119-1"
+      }
+    ]
+  },
+  "request": {
+    "billNumber": "1",
+    "billType": "hr",
+    "billUrl": "https://api.congress.gov/v3/bill/119/hr/1?format=json",
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/fixtures/api/bills/detail_119_hr_22.json
+++ b/tests/fixtures/api/bills/detail_119_hr_22.json
@@ -1,0 +1,42 @@
+{
+  "bill": {
+    "congress": 119,
+    "type": "HR",
+    "number": "22",
+    "title": "Safeguard American Voter Eligibility Act",
+    "originChamber": "House",
+    "originChamberCode": "H",
+    "introducedDate": "2025-01-03",
+    "updateDate": "2026-04-10",
+    "updateDateIncludingText": "2026-04-10T08:00:00Z",
+    "policyArea": {
+      "name": "Government Operations and Politics"
+    },
+    "sponsors": [
+      {
+        "bioguideId": "R000614",
+        "firstName": "Chip",
+        "lastName": "Roy",
+        "middleName": null,
+        "fullName": "Rep. Roy, Chip [R-TX-21]",
+        "party": "R",
+        "state": "TX",
+        "district": 21,
+        "isByRequest": "N",
+        "url": "https://api.congress.gov/v3/member/R000614?format=json"
+      }
+    ],
+    "latestAction": {
+      "actionDate": "2026-04-10",
+      "text": "Received in the Senate and Read twice and referred to the Committee on Rules and Administration."
+    }
+  },
+  "request": {
+    "billNumber": "22",
+    "billType": "hr",
+    "billUrl": "https://api.congress.gov/v3/bill/119/hr/22?format=json",
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/fixtures/api/bills/list_hr_119.json
+++ b/tests/fixtures/api/bills/list_hr_119.json
@@ -1,0 +1,43 @@
+{
+  "bills": [
+    {
+      "congress": 119,
+      "type": "HR",
+      "number": "1",
+      "title": "Lower Energy Costs Act",
+      "originChamber": "House",
+      "originChamberCode": "H",
+      "updateDate": "2026-04-01",
+      "updateDateIncludingText": "2026-04-01T12:34:56Z",
+      "latestAction": {
+        "actionDate": "2026-03-30",
+        "text": "Became Public Law No: 119-1."
+      },
+      "url": "https://api.congress.gov/v3/bill/119/hr/1?format=json"
+    },
+    {
+      "congress": 119,
+      "type": "HR",
+      "number": "22",
+      "title": "SAVE Act",
+      "originChamber": "House",
+      "originChamberCode": "H",
+      "updateDate": "2026-04-10",
+      "updateDateIncludingText": "2026-04-10T08:00:00Z",
+      "latestAction": {
+        "actionDate": "2026-04-10",
+        "text": "Received in the Senate and Read twice and referred to the Committee on Rules and Administration."
+      },
+      "url": "https://api.congress.gov/v3/bill/119/hr/22?format=json"
+    }
+  ],
+  "pagination": {
+    "count": 2
+  },
+  "request": {
+    "congress": "119",
+    "billType": "hr",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -471,3 +471,78 @@ class TestListMembers:
         with client:
             list(client.list_members(congress=118))
         assert captured == ["/v3/member/congress/118"]
+
+
+# -- list_bills --------------------------------------------------------------
+
+
+class TestListBills:
+    def test_iterates_single_page(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/list_hr_119.json").read_text())
+        client = _make_client(lambda r: _json_response(payload))
+        with client:
+            bills = list(client.list_bills(congress=119, bill_type="hr"))
+        assert [b["number"] for b in bills] == ["1", "22"]
+
+    def test_paginates_until_no_next(self, fixtures_dir: Path) -> None:
+        page1 = json.loads((fixtures_dir / "api/bills/list_hr_119.json").read_text())
+        page1["pagination"] = {"next": "https://example.invalid/next", "count": 4}
+        page2 = {
+            "bills": [
+                {"congress": 119, "type": "HR", "number": "47"},
+                {"congress": 119, "type": "HR", "number": "88"},
+            ],
+            "pagination": {"count": 4},
+        }
+        responses = iter([page1, page2])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response(next(responses))
+
+        client = _make_client(handler)
+        with client:
+            bills = list(client.list_bills(congress=119, bill_type="hr"))
+        assert [b["number"] for b in bills] == ["1", "22", "47", "88"]
+
+    def test_canonicalizes_bill_type_to_lowercase(self) -> None:
+        captured: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request.url.path)
+            return _json_response({"bills": [], "pagination": {"count": 0}})
+
+        client = _make_client(handler)
+        with client:
+            list(client.list_bills(congress=119, bill_type="HR"))
+        assert captured == ["/v3/bill/119/hr"]
+
+
+# -- get_bill_detail ---------------------------------------------------------
+
+
+class TestGetBillDetail:
+    def test_parses_detail_payload(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/detail_119_hr_1.json").read_text())
+        client = _make_client(lambda r: _json_response(payload))
+        with client:
+            bill = client.get_bill_detail(congress=119, bill_type="hr", bill_number=1)
+        assert bill["number"] == "1"
+        assert bill["sponsors"][0]["bioguideId"] == "S001176"
+        assert bill["policyArea"]["name"] == "Energy"
+
+    def test_canonicalizes_bill_type_in_path(self) -> None:
+        captured: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request.url.path)
+            return _json_response({"bill": {"number": "1"}})
+
+        client = _make_client(handler)
+        with client:
+            client.get_bill_detail(congress=119, bill_type="HR", bill_number=1)
+        assert captured == ["/v3/bill/119/hr/1"]
+
+    def test_missing_bill_object_raises(self) -> None:
+        client = _make_client(lambda r: _json_response({"notBill": {}}))
+        with client, pytest.raises(ApiError, match="expected 'bill' object"):
+            client.get_bill_detail(congress=119, bill_type="hr", bill_number=1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1042,3 +1042,169 @@ class TestLoadMembersCommand:
         plain = _strip(result.output)
         assert "No input file" in plain
         assert "scrape members" in plain
+
+
+# -- `concord scrape bills` --------------------------------------------------
+
+
+def _bills_fixture(name: str) -> dict[str, Any]:
+    import json as _json
+
+    here = Path(__file__).parent / "fixtures" / "api" / "bills"
+    return _json.loads((here / name).read_text())
+
+
+def _bills_handler(call_log: list[str] | None = None):
+    """Return an httpx handler that answers list + detail for the bills fixtures."""
+    import json as _json
+
+    import httpx
+
+    list_payload = _bills_fixture("list_hr_119.json")
+    details = {
+        1: _bills_fixture("detail_119_hr_1.json"),
+        22: _bills_fixture("detail_119_hr_22.json"),
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if call_log is not None:
+            call_log.append(request.url.path)
+        parts = request.url.path.rstrip("/").split("/")
+        if len(parts) == 5:
+            body = list_payload
+        elif len(parts) == 6:
+            number = int(parts[-1])
+            body = details[number]
+        else:
+            return httpx.Response(404)
+        return httpx.Response(
+            200,
+            content=_json.dumps(body),
+            headers={"content-type": "application/json"},
+        )
+
+    return handler
+
+
+class TestBillsHelp:
+    def test_scrape_bills_help_lists_flags(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli_module.app, ["scrape", "bills", "--help"])
+        assert result.exit_code == 0
+        plain = _strip(result.output)
+        for flag in ["--congresses", "--bill-types", "--storage-dir", "--limit"]:
+            assert flag in plain
+
+    def test_load_bills_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli_module.app, ["load", "bills", "--help"])
+        assert result.exit_code == 0
+        plain = _strip(result.output)
+        for flag in ["--storage-dir", "--db", "--limit"]:
+            assert flag in plain
+
+    def test_index_bills_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli_module.app, ["index", "bills", "--help"])
+        assert result.exit_code == 0
+        plain = _strip(result.output)
+        for flag in ["--db", "--limit"]:
+            assert flag in plain
+
+    def test_run_bills_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli_module.app, ["run", "bills", "--help"])
+        assert result.exit_code == 0
+        plain = _strip(result.output)
+        for flag in ["--congresses", "--bill-types", "--storage-dir", "--db", "--limit"]:
+            assert flag in plain
+
+
+class TestScrapeBillsCommand:
+    def test_scrapes_with_limit(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import httpx
+
+        from concord.api import Client as ApiClient
+
+        handler = _bills_handler()
+
+        # Monkey-patch the Client to inject the mock transport while still
+        # exercising the real CLI wiring.
+        original_init = ApiClient.__init__
+
+        def patched_init(self, **kwargs):
+            kwargs.setdefault("transport", httpx.MockTransport(handler))
+            kwargs.setdefault("sleep", lambda _s: None)
+            original_init(self, **kwargs)
+
+        monkeypatch.setattr(ApiClient, "__init__", patched_init)
+
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "--congresses",
+                "119",
+                "--bill-types",
+                "hr",
+                "--storage-dir",
+                str(tmp_path),
+                "--limit",
+                "2",
+                "--no-progress",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        out = tmp_path / "bills.jsonl"
+        assert out.exists()
+        lines = out.read_text().splitlines()
+        assert len(lines) == 2
+
+    def test_rejects_unknown_bill_type(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "--congresses",
+                "119",
+                "--bill-types",
+                "xxx",
+                "--storage-dir",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code != 0
+        plain = _strip(result.output) + _strip(result.stderr or "")
+        assert "unknown bill type" in plain.lower()
+
+
+class TestLoadBillsCommand:
+    def test_missing_file_is_a_no_op(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "load",
+                "bills",
+                "--storage-dir",
+                str(tmp_path / "no_such_dir"),
+                "--db",
+                str(tmp_path / "out.db"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        plain = _strip(result.output)
+        assert "No input file" in plain
+        assert "scrape bills" in plain

--- a/tests/test_models_bills.py
+++ b/tests/test_models_bills.py
@@ -1,0 +1,122 @@
+"""Tests for Bill and BillSnapshot models (Phase 2a)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from concord.models import (
+    Bill,
+    BillSnapshot,
+    bill_id_from_components,
+    parse_bill,
+)
+
+from ._snapshots import wrap_snapshot
+
+FIXED_FETCHED_AT = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC)
+
+
+class TestBillIdFromComponents:
+    def test_round_trip(self) -> None:
+        assert bill_id_from_components(119, "hr", 1234) == "119-hr-1234"
+
+    def test_lowercases_bill_type(self) -> None:
+        assert bill_id_from_components(118, "HRES", 5) == "118-hres-5"
+
+
+class TestBillModel:
+    def test_validator_lowercases_bill_type(self) -> None:
+        bill = Bill(
+            bill_id="119-hr-1",
+            congress=119,
+            bill_type="HR",  # type: ignore[arg-type]
+            bill_number=1,
+            origin_chamber="House",
+            title="Lower Energy Costs Act",
+            update_date="2026-04-01",
+        )
+        assert bill.bill_type == "hr"
+
+    def test_rejects_unknown_bill_type(self) -> None:
+        with pytest.raises(ValidationError):
+            Bill(
+                bill_id="119-xxx-1",
+                congress=119,
+                bill_type="xxx",  # type: ignore[arg-type]
+                bill_number=1,
+                origin_chamber="House",
+                title="x",
+                update_date="2026-04-01",
+            )
+
+    def test_rejects_unknown_origin_chamber(self) -> None:
+        with pytest.raises(ValidationError):
+            Bill(
+                bill_id="119-hr-1",
+                congress=119,
+                bill_type="hr",
+                bill_number=1,
+                origin_chamber="House of Cards",  # type: ignore[arg-type]
+                title="x",
+                update_date="2026-04-01",
+            )
+
+
+class TestParseBill:
+    def test_parses_hr_1_fixture(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/detail_119_hr_1.json").read_text())
+        bill = parse_bill(payload["bill"])
+        assert bill.bill_id == "119-hr-1"
+        assert bill.congress == 119
+        assert bill.bill_type == "hr"
+        assert bill.bill_number == 1
+        assert bill.origin_chamber == "House"
+        assert bill.title == "Lower Energy Costs Act"
+        assert bill.introduced_date == "2025-01-09"
+        assert bill.policy_area == "Energy"
+        assert bill.sponsor_bioguide_id == "S001176"
+        assert bill.latest_action_date == "2026-03-30"
+        assert bill.latest_action_text == "Became Public Law No: 119-1."
+        # update_date prefers updateDateIncludingText when present.
+        assert bill.update_date == "2026-04-01T12:34:56Z"
+
+    def test_parses_hr_22_fixture(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/detail_119_hr_22.json").read_text())
+        bill = parse_bill(payload["bill"])
+        assert bill.bill_id == "119-hr-22"
+        assert bill.sponsor_bioguide_id == "R000614"
+        assert bill.policy_area == "Government Operations and Politics"
+
+    def test_missing_sponsor_is_ok(self) -> None:
+        payload = {
+            "congress": 119,
+            "type": "HR",
+            "number": "9999",
+            "originChamber": "House",
+            "title": "Sponsorless Bill Act",
+            "updateDate": "2026-04-01",
+        }
+        bill = parse_bill(payload)
+        assert bill.sponsor_bioguide_id is None
+        assert bill.policy_area is None
+        assert bill.latest_action_date is None
+
+
+class TestBillSnapshot:
+    def test_envelope_round_trip(self) -> None:
+        env = wrap_snapshot(
+            {"congress": 119, "type": "HR", "number": "1"},
+            fetched_at=FIXED_FETCHED_AT,
+            key={"congress": 119, "bill_type": "hr", "bill_number": 1},
+        )
+        # Round-trip through JSON to mirror how the loader reads it.
+        raw = json.dumps(env)
+        snap = BillSnapshot.model_validate(json.loads(raw))
+        assert snap.key == {"congress": 119, "bill_type": "hr", "bill_number": 1}
+        assert snap.payload["number"] == "1"
+        assert snap.fetched_at == FIXED_FETCHED_AT

--- a/tests/test_pipeline_bills.py
+++ b/tests/test_pipeline_bills.py
@@ -1,0 +1,181 @@
+"""Tests for the Bills Stage 1 (load) and Stage 2 (index) pipelines."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from concord.pipeline.index_bills import index as index_bills
+from concord.pipeline.load_bills import load as load_bills
+from concord.scraper.bills import BILLS_JSONL_NAME
+from concord.storage.sqlite import SqliteStorage
+
+from ._snapshots import wrap_snapshot
+
+FIXED_FETCHED_AT = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC)
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    here = Path(__file__).parent / "fixtures" / "api" / "bills"
+    return json.loads((here / name).read_text())
+
+
+def _detail_payload(name: str) -> dict[str, Any]:
+    """Return just the unwrapped ``bill`` object the scraper persists."""
+    return _fixture(name)["bill"]
+
+
+def _envelope_for(
+    payload: dict[str, Any],
+    *,
+    fetched_at: datetime = FIXED_FETCHED_AT,
+) -> dict[str, Any]:
+    return wrap_snapshot(
+        payload,
+        fetched_at=fetched_at,
+        key={
+            "congress": int(payload["congress"]),
+            "bill_type": str(payload["type"]).lower(),
+            "bill_number": int(payload["number"]),
+        },
+    )
+
+
+def _write_jsonl(storage_dir: Path, envelopes: list[dict[str, Any]]) -> None:
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    (storage_dir / BILLS_JSONL_NAME).write_text(
+        "\n".join(json.dumps(e) for e in envelopes) + "\n",
+        encoding="utf-8",
+    )
+
+
+class TestLoadBills:
+    def test_basic_load(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        _write_jsonl(
+            storage_dir,
+            [
+                _envelope_for(_detail_payload("detail_119_hr_1.json")),
+                _envelope_for(_detail_payload("detail_119_hr_22.json")),
+            ],
+        )
+
+        stats = load_bills(storage_dir=storage_dir, db_path=db)
+        assert stats.bills_written == 2
+        assert stats.snapshots_read == 2
+        assert stats.malformed == 0
+
+        with SqliteStorage(db, load_vec=False) as storage:
+            row = storage.get_bill("119-hr-1")
+            assert row is not None
+            assert row["title"] == "Lower Energy Costs Act"
+            assert row["sponsor_bioguide_id"] == "S001176"
+            assert row["policy_area"] == "Energy"
+
+    def test_latest_snapshot_wins(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        early = _detail_payload("detail_119_hr_1.json")
+        late = {**early, "title": "Renamed Bill"}
+        _write_jsonl(
+            storage_dir,
+            [
+                _envelope_for(early, fetched_at=FIXED_FETCHED_AT),
+                _envelope_for(late, fetched_at=FIXED_FETCHED_AT + timedelta(hours=1)),
+            ],
+        )
+        load_bills(storage_dir=storage_dir, db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            row = storage.get_bill("119-hr-1")
+            assert row is not None
+            assert row["title"] == "Renamed Bill"
+
+    def test_limit_caps_writes(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        _write_jsonl(
+            storage_dir,
+            [
+                _envelope_for(_detail_payload("detail_119_hr_1.json")),
+                _envelope_for(_detail_payload("detail_119_hr_22.json")),
+            ],
+        )
+        stats = load_bills(storage_dir=storage_dir, db_path=db, limit=1)
+        assert stats.bills_written == 1
+
+    def test_missing_file_is_noop(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "no_such_dir"
+        db = tmp_path / "test.db"
+        stats = load_bills(storage_dir=storage_dir, db_path=db)
+        assert stats == (0, 0, 0)
+
+    def test_idempotent_rerun(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        _write_jsonl(
+            storage_dir,
+            [_envelope_for(_detail_payload("detail_119_hr_1.json"))],
+        )
+        load_bills(storage_dir=storage_dir, db_path=db)
+        load_bills(storage_dir=storage_dir, db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            count = storage.connection.execute("SELECT COUNT(*) FROM bills").fetchone()[0]
+            assert count == 1
+
+
+class TestIndexBills:
+    def test_repopulates_fts(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        _write_jsonl(
+            storage_dir,
+            [
+                _envelope_for(_detail_payload("detail_119_hr_1.json")),
+                _envelope_for(_detail_payload("detail_119_hr_22.json")),
+            ],
+        )
+        load_bills(storage_dir=storage_dir, db_path=db)
+        stats = index_bills(db_path=db)
+        assert stats.indexed_bills == 2
+        with SqliteStorage(db, load_vec=False) as storage:
+            rows = storage.connection.execute(
+                "SELECT bill_id, identifier FROM bills_fts ORDER BY bill_id"
+            ).fetchall()
+            assert [r["bill_id"] for r in rows] == ["119-hr-1", "119-hr-22"]
+            assert rows[0]["identifier"] == "hr 1"
+
+    def test_index_is_idempotent(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        _write_jsonl(
+            storage_dir,
+            [_envelope_for(_detail_payload("detail_119_hr_1.json"))],
+        )
+        load_bills(storage_dir=storage_dir, db_path=db)
+        index_bills(db_path=db)
+        index_bills(db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            (count,) = storage.connection.execute("SELECT COUNT(*) FROM bills_fts").fetchone()
+            assert count == 1
+
+    def test_fts_matches_title_and_policy_area(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        _write_jsonl(
+            storage_dir,
+            [
+                _envelope_for(_detail_payload("detail_119_hr_1.json")),
+                _envelope_for(_detail_payload("detail_119_hr_22.json")),
+            ],
+        )
+        load_bills(storage_dir=storage_dir, db_path=db)
+        index_bills(db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            rows = storage.connection.execute(
+                "SELECT bill_id FROM bills_fts WHERE bills_fts MATCH ?",
+                ("energy",),
+            ).fetchall()
+            assert [r["bill_id"] for r in rows] == ["119-hr-1"]

--- a/tests/test_scraper_bills.py
+++ b/tests/test_scraper_bills.py
@@ -1,0 +1,189 @@
+"""Integration tests for the Bills Stage 0 scraper."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from concord.api import Client
+from concord.scraper.bills import BILLS_JSONL_NAME, ScrapeProgressEvent, scrape_basic
+
+FIXED_FETCHED_AT = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC)
+
+
+def _fixture(name: str) -> dict[str, Any]:
+    here = Path(__file__).parent / "fixtures" / "api" / "bills"
+    return json.loads((here / name).read_text())
+
+
+def _client_serving(
+    list_payload: dict[str, Any],
+    details_by_number: dict[int, dict[str, Any]],
+) -> Client:
+    """Return a Client whose handler answers list + detail calls.
+
+    The list response is served for any list-endpoint request; detail
+    responses are looked up by the bill number in the path.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        parts = request.url.path.rstrip("/").split("/")
+        # path is /v3/bill/{congress}/{type} (list) or
+        # /v3/bill/{congress}/{type}/{number} (detail).
+        if len(parts) == 5:  # ["", "v3", "bill", "{c}", "{t}"]
+            body = list_payload
+        elif len(parts) == 6:  # detail
+            number = int(parts[-1])
+            body = details_by_number[number]
+        else:
+            return httpx.Response(404)
+        return httpx.Response(
+            200,
+            content=json.dumps(body),
+            headers={"content-type": "application/json"},
+        )
+
+    return Client(
+        api_key="test-key",
+        transport=httpx.MockTransport(handler),
+        sleep=lambda _s: None,
+    )
+
+
+class TestScrapeBasic:
+    def test_writes_one_envelope_per_detail(self, tmp_path: Path) -> None:
+        client = _client_serving(
+            _fixture("list_hr_119.json"),
+            {
+                1: _fixture("detail_119_hr_1.json"),
+                22: _fixture("detail_119_hr_22.json"),
+            },
+        )
+
+        with client:
+            stats = scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+            )
+
+        assert stats.bills_written == 2
+        out = tmp_path / BILLS_JSONL_NAME
+        lines = out.read_text().splitlines()
+        assert len(lines) == 2
+        envelopes = [json.loads(line) for line in lines]
+        assert envelopes[0]["fetched_at"] == FIXED_FETCHED_AT.isoformat()
+        # bill_type in key is lowercased.
+        assert envelopes[0]["key"] == {"congress": 119, "bill_type": "hr", "bill_number": 1}
+        assert envelopes[1]["key"]["bill_number"] == 22
+        # Payload is the unwrapped ``bill`` object.
+        assert envelopes[0]["payload"]["number"] == "1"
+
+    def test_only_writes_bills_jsonl(self, tmp_path: Path) -> None:
+        client = _client_serving(
+            _fixture("list_hr_119.json"),
+            {
+                1: _fixture("detail_119_hr_1.json"),
+                22: _fixture("detail_119_hr_22.json"),
+            },
+        )
+        with client:
+            scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+            )
+        files = {p.name for p in tmp_path.iterdir()}
+        assert files == {BILLS_JSONL_NAME}
+
+    def test_limit_caps_writes(self, tmp_path: Path) -> None:
+        client = _client_serving(
+            _fixture("list_hr_119.json"),
+            {
+                1: _fixture("detail_119_hr_1.json"),
+                22: _fixture("detail_119_hr_22.json"),
+            },
+        )
+        with client:
+            stats = scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+                limit=1,
+            )
+        assert stats.bills_written == 1
+        lines = (tmp_path / BILLS_JSONL_NAME).read_text().splitlines()
+        assert len(lines) == 1
+
+    def test_canonicalizes_uppercase_bill_type(self, tmp_path: Path) -> None:
+        client = _client_serving(
+            _fixture("list_hr_119.json"),
+            {
+                1: _fixture("detail_119_hr_1.json"),
+                22: _fixture("detail_119_hr_22.json"),
+            },
+        )
+        with client:
+            scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["HR"],
+            )
+        envelopes = [
+            json.loads(line) for line in (tmp_path / BILLS_JSONL_NAME).read_text().splitlines()
+        ]
+        assert all(e["key"]["bill_type"] == "hr" for e in envelopes)
+
+    def test_progress_emits_per_pair(self, tmp_path: Path) -> None:
+        events: list[ScrapeProgressEvent] = []
+        client = _client_serving(
+            _fixture("list_hr_119.json"),
+            {
+                1: _fixture("detail_119_hr_1.json"),
+                22: _fixture("detail_119_hr_22.json"),
+            },
+        )
+        with client:
+            scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+                progress=events.append,
+            )
+        assert len(events) == 1
+        assert events[0].congress == 119
+        assert events[0].bill_type == "hr"
+        assert events[0].bills_written == 2
+
+    def test_creates_storage_dir(self, tmp_path: Path) -> None:
+        nested = tmp_path / "nested" / "data"
+        client = _client_serving(
+            _fixture("list_hr_119.json"),
+            {
+                1: _fixture("detail_119_hr_1.json"),
+                22: _fixture("detail_119_hr_22.json"),
+            },
+        )
+        with client:
+            scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=nested,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+            )
+        assert (nested / BILLS_JSONL_NAME).exists()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -105,3 +105,73 @@ def test_members_end_to_end(tmp_path: Path) -> None:
     assert resp.status_code == 200
     assert "Members" in resp.text
     assert "Sanders" in resp.text
+
+
+def test_bills_end_to_end(tmp_path: Path) -> None:
+    """Stage 1 → Stage 2 → web smoke for Bills (Phase 2a).
+
+    Skips Stage 0 (network) — writes a hand-built bills.jsonl, then runs
+    load + index and pokes the FastAPI app at the four routes named in
+    the plan's verification section.
+    """
+    from fastapi.testclient import TestClient
+
+    from concord.embedding import EMBEDDING_DIM, Embedder
+    from concord.pipeline.index_bills import index as index_bills
+    from concord.pipeline.load_bills import load as load_bills
+    from concord.scraper.bills import BILLS_JSONL_NAME
+    from concord.storage.sqlite import SqliteStorage as _SqliteStorage
+    from concord.web.app import create_app
+
+    storage_dir = tmp_path / "data"
+    storage_dir.mkdir()
+    fetched_at = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC).isoformat()
+    bill_payload = json.loads(
+        (Path(__file__).parent / "fixtures" / "api" / "bills" / "detail_119_hr_1.json").read_text()
+    )["bill"]
+    (storage_dir / BILLS_JSONL_NAME).write_text(
+        json.dumps(
+            {
+                "fetched_at": fetched_at,
+                "key": {"congress": 119, "bill_type": "hr", "bill_number": 1},
+                "payload": bill_payload,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    db = tmp_path / "test.db"
+    _SqliteStorage(db).close()
+
+    load_stats = load_bills(storage_dir=storage_dir, db_path=db)
+    assert load_stats.bills_written == 1
+    index_stats = index_bills(db_path=db)
+    assert index_stats.indexed_bills == 1
+
+    class _StubResp:
+        def __init__(self, vectors: list[list[float]]) -> None:
+            self.data = [type("D", (), {"embedding": v})() for v in vectors]
+
+    class _StubEmb:
+        def create(self, *, model: str, input: list[str]) -> _StubResp:
+            return _StubResp([[0.5] * EMBEDDING_DIM for _ in input])
+
+    class _Stub:
+        embeddings = _StubEmb()
+
+    app = create_app(db, embedder=Embedder(_Stub()))
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/bills")
+    assert resp.status_code == 200
+    assert "Lower Energy Costs Act" in resp.text
+
+    resp = client.get("/bills/119/hr/1")
+    assert resp.status_code == 200
+    assert "Cosponsors (Phase 2b)" in resp.text
+
+    # Bare-identifier query: with only one Bill in scope, this redirects.
+    resp = client.get("/search?q=HR+1", follow_redirects=False)
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/bills/119/hr/1"

--- a/tests/test_storage_bills_sqlite.py
+++ b/tests/test_storage_bills_sqlite.py
@@ -1,0 +1,114 @@
+"""Tests for the Bills SQLite storage layer (Phase 2a)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from concord.models import Bill
+from concord.storage.sqlite import SqliteStorage
+
+
+def _bill(
+    bill_id: str = "119-hr-1",
+    *,
+    congress: int = 119,
+    bill_type: str = "hr",
+    bill_number: int = 1,
+    origin_chamber: str = "House",
+    title: str = "Lower Energy Costs Act",
+    sponsor_bioguide_id: str | None = "S001176",
+    policy_area: str | None = "Energy",
+    latest_action_date: str | None = "2026-03-30",
+    latest_action_text: str | None = "Became Public Law No: 119-1.",
+    introduced_date: str | None = "2025-01-09",
+    update_date: str = "2026-04-01T12:34:56Z",
+) -> Bill:
+    return Bill(
+        bill_id=bill_id,
+        congress=congress,
+        bill_type=bill_type,  # type: ignore[arg-type]
+        bill_number=bill_number,
+        origin_chamber=origin_chamber,  # type: ignore[arg-type]
+        title=title,
+        introduced_date=introduced_date,
+        policy_area=policy_area,
+        sponsor_bioguide_id=sponsor_bioguide_id,
+        latest_action_date=latest_action_date,
+        latest_action_text=latest_action_text,
+        update_date=update_date,
+    )
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> SqliteStorage:
+    s = SqliteStorage(tmp_path / "test.db", load_vec=False)
+    yield s
+    s.close()
+
+
+class TestUpsertBill:
+    def test_inserts_and_reads(self, storage: SqliteStorage) -> None:
+        storage.upsert_bill(_bill(), fetched_at="2026-05-25T14:02:11+00:00")
+        row = storage.get_bill("119-hr-1")
+        assert row is not None
+        assert row["title"] == "Lower Energy Costs Act"
+        assert row["sponsor_bioguide_id"] == "S001176"
+        assert row["policy_area"] == "Energy"
+        assert row["latest_action_date"] == "2026-03-30"
+        assert row["fetched_at"] == "2026-05-25T14:02:11+00:00"
+
+    def test_upsert_replaces_row(self, storage: SqliteStorage) -> None:
+        storage.upsert_bill(
+            _bill(title="Original Title"),
+            fetched_at="2026-01-01T00:00:00+00:00",
+        )
+        storage.upsert_bill(
+            _bill(title="Updated Title", latest_action_date="2026-04-15"),
+            fetched_at="2026-05-25T00:00:00+00:00",
+        )
+        row = storage.get_bill("119-hr-1")
+        assert row is not None
+        assert row["title"] == "Updated Title"
+        assert row["latest_action_date"] == "2026-04-15"
+        assert row["fetched_at"] == "2026-05-25T00:00:00+00:00"
+
+    def test_get_missing_returns_none(self, storage: SqliteStorage) -> None:
+        assert storage.get_bill("119-hr-9999") is None
+
+
+class TestSchemaConstraints:
+    def test_bill_type_check_rejects_unknown(self, storage: SqliteStorage) -> None:
+        with pytest.raises(sqlite3.IntegrityError):
+            storage.connection.execute(
+                "INSERT INTO bills "
+                "(bill_id, congress, bill_type, bill_number, origin_chamber, "
+                "title, update_date, fetched_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                ("119-xx-1", 119, "xx", 1, "House", "x", "2026-04-01", "2026-05-25T00:00:00Z"),
+            )
+
+    def test_origin_chamber_check_rejects_unknown(self, storage: SqliteStorage) -> None:
+        with pytest.raises(sqlite3.IntegrityError):
+            storage.connection.execute(
+                "INSERT INTO bills "
+                "(bill_id, congress, bill_type, bill_number, origin_chamber, "
+                "title, update_date, fetched_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                ("119-hr-9", 119, "hr", 9, "Lords", "x", "2026-04-01", "2026-05-25T00:00:00Z"),
+            )
+
+
+class TestBillsFtsTable:
+    def test_table_exists_and_is_queryable(self, storage: SqliteStorage) -> None:
+        storage.connection.execute(
+            "INSERT INTO bills_fts (bill_id, identifier, title, policy_area) VALUES (?, ?, ?, ?)",
+            ("119-hr-1", "hr 1", "Lower Energy Costs Act", "Energy"),
+        )
+        rows = storage.connection.execute(
+            "SELECT bill_id FROM bills_fts WHERE bills_fts MATCH ?",
+            ("energy",),
+        ).fetchall()
+        assert [r["bill_id"] for r in rows] == ["119-hr-1"]

--- a/tests/test_web_bills.py
+++ b/tests/test_web_bills.py
@@ -1,0 +1,256 @@
+"""Integration tests for the Bills web routes (Phase 2a)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from concord.embedding import EMBEDDING_DIM, Embedder
+from concord.models import Bill, Member, Term
+from concord.pipeline.index_bills import index as index_bills
+from concord.storage.sqlite import SqliteStorage
+from concord.web.app import create_app
+
+
+class _StubData:
+    def __init__(self, vec: list[float]) -> None:
+        self.embedding = vec
+
+
+class _StubResponse:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self.data = [_StubData(v) for v in vectors]
+
+
+class _StubEmbeddings:
+    def create(self, *, model: str, input: list[str]) -> _StubResponse:
+        return _StubResponse([[0.5] * EMBEDDING_DIM for _ in input])
+
+
+class _StubOpenAI:
+    embeddings = _StubEmbeddings()
+
+
+def _bill(
+    bill_id: str,
+    *,
+    congress: int,
+    bill_type: str,
+    bill_number: int,
+    title: str,
+    sponsor_bioguide_id: str | None,
+    origin_chamber: str = "House",
+    policy_area: str | None = "Energy",
+    introduced_date: str | None = "2025-01-09",
+    latest_action_date: str | None = "2026-03-30",
+    latest_action_text: str | None = "Became Public Law.",
+) -> Bill:
+    return Bill(
+        bill_id=bill_id,
+        congress=congress,
+        bill_type=bill_type,  # type: ignore[arg-type]
+        bill_number=bill_number,
+        origin_chamber=origin_chamber,  # type: ignore[arg-type]
+        title=title,
+        introduced_date=introduced_date,
+        policy_area=policy_area,
+        sponsor_bioguide_id=sponsor_bioguide_id,
+        latest_action_date=latest_action_date,
+        latest_action_text=latest_action_text,
+        update_date="2026-04-01",
+    )
+
+
+def _seed(storage: SqliteStorage) -> None:
+    # Sponsor Member so the join produces a real name on the bill page.
+    storage.upsert_member(
+        Member(
+            bioguide_id="S001176",
+            first_name="Steve",
+            last_name="Scalise",
+            display_name="Steve Scalise",
+        ),
+        [
+            Term(
+                bioguide_id="S001176",
+                congress=119,
+                chamber="house",
+                state="LA",
+                district=1,
+                party="Republican",
+                start_date="2025-01-01",
+            ),
+        ],
+        fetched_at="2026-05-25T00:00:00+00:00",
+    )
+
+    # Three bills: 119-hr-1 sponsored by Scalise; 119-hr-22 sponsored by
+    # a Member not in the table (cross-link should degrade gracefully);
+    # 118-s-47 to exercise the chamber filter and a duplicate identifier
+    # across Congresses (alongside 119-hr-1, both will match query "hr 1"
+    # only — 's 47' will be unique).
+    storage.upsert_bill(
+        _bill(
+            "119-hr-1",
+            congress=119,
+            bill_type="hr",
+            bill_number=1,
+            title="Lower Energy Costs Act",
+            sponsor_bioguide_id="S001176",
+        ),
+        fetched_at="2026-05-25T00:00:00+00:00",
+    )
+    storage.upsert_bill(
+        _bill(
+            "119-hr-22",
+            congress=119,
+            bill_type="hr",
+            bill_number=22,
+            title="Safeguard American Voter Eligibility Act",
+            sponsor_bioguide_id="R000614",  # not in members table
+            policy_area="Government Operations and Politics",
+            latest_action_date="2026-04-10",
+        ),
+        fetched_at="2026-05-25T00:00:00+00:00",
+    )
+    storage.upsert_bill(
+        _bill(
+            "118-s-47",
+            congress=118,
+            bill_type="s",
+            bill_number=47,
+            title="An Unrelated Senate Bill",
+            sponsor_bioguide_id=None,
+            origin_chamber="Senate",
+            policy_area="Health",
+            latest_action_date="2024-09-01",
+        ),
+        fetched_at="2026-05-25T00:00:00+00:00",
+    )
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db_path = tmp_path / "test.db"
+    storage = SqliteStorage(db_path)
+    _seed(storage)
+    storage.close()
+    index_bills(db_path=db_path)
+    app = create_app(db_path, embedder=Embedder(_StubOpenAI()))
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestBillsIndex:
+    def test_lists_all(self, client: TestClient) -> None:
+        resp = client.get("/bills")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Lower Energy Costs Act" in body
+        assert "Safeguard American Voter Eligibility Act" in body
+        assert "An Unrelated Senate Bill" in body
+
+    def test_chamber_filter(self, client: TestClient) -> None:
+        resp = client.get("/bills?chamber=Senate")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "An Unrelated Senate Bill" in body
+        assert "Lower Energy Costs Act" not in body
+
+    def test_congress_filter(self, client: TestClient) -> None:
+        resp = client.get("/bills?congress=118")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "An Unrelated Senate Bill" in body
+        assert "Lower Energy Costs Act" not in body
+
+    def test_policy_area_filter(self, client: TestClient) -> None:
+        resp = client.get("/bills?policy_area=Energy")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Lower Energy Costs Act" in body
+        assert "Safeguard American Voter Eligibility Act" not in body
+
+    def test_sponsor_filter(self, client: TestClient) -> None:
+        resp = client.get("/bills?sponsor=S001176")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Lower Energy Costs Act" in body
+        assert "Safeguard American Voter Eligibility Act" not in body
+
+
+class TestBillProfile:
+    def test_renders_known_bill(self, client: TestClient) -> None:
+        resp = client.get("/bills/119/hr/1")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Lower Energy Costs Act" in body
+        # Sponsor link present (Member in table).
+        assert "Steve Scalise" in body
+        assert "/members/S001176" in body
+        # Phase 2b placeholders visible.
+        assert "Cosponsors (Phase 2b)" in body
+        assert "Action history (Phase 2b)" in body
+        # Phase 3/4/5 placeholders.
+        assert "Vote history (Phase 3)" in body
+        assert "Committee path (Phase 4)" in body
+        assert "Search within this bill (Phase 5)" in body
+
+    def test_unknown_bill_number_404(self, client: TestClient) -> None:
+        resp = client.get("/bills/119/hr/9999")
+        assert resp.status_code == 404
+
+    def test_invalid_bill_type_404(self, client: TestClient) -> None:
+        resp = client.get("/bills/119/xyz/1")
+        assert resp.status_code == 404
+
+    def test_sponsor_not_in_members_table_degrades(self, client: TestClient) -> None:
+        """The Member isn't indexed; show the bioguide id with a hint, no link."""
+        resp = client.get("/bills/119/hr/22")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "R000614" in body
+        assert "(not indexed)" in body
+
+
+class TestFederatedBillsSearch:
+    def test_search_includes_bills_section(self, client: TestClient) -> None:
+        resp = client.get("/search?q=energy")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Bills" in body
+        assert "Lower Energy Costs Act" in body
+
+    def test_bills_off_suppresses_section(self, client: TestClient) -> None:
+        resp = client.get("/search?q=energy&members=on&proceedings=on&bills=")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Lower Energy Costs Act" not in body
+
+    def test_bare_identifier_redirects_when_unique(self, client: TestClient) -> None:
+        # Only 118-s-47 exists; bare "S 47" should redirect there.
+        resp = client.get("/search?q=S+47", follow_redirects=False)
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/bills/118/s/47"
+
+    def test_bare_identifier_with_period_redirects(self, client: TestClient) -> None:
+        resp = client.get("/search?q=s.47", follow_redirects=False)
+        assert resp.status_code == 307
+
+    def test_bare_identifier_with_only_one_congress_match(self, client: TestClient) -> None:
+        # HR 1 only exists in 119 in our seed; should redirect.
+        resp = client.get("/search?q=HR+1", follow_redirects=False)
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/bills/119/hr/1"
+
+
+class TestMemberProfileSponsoredCrossLink:
+    def test_sponsored_section_lists_bill(self, client: TestClient) -> None:
+        resp = client.get("/members/S001176")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Sponsored bills" in body
+        assert "Lower Energy Costs Act" in body
+        # Cosponsored placeholder still visible, but relabeled for 2b.
+        assert "Cosponsored bills (Phase 2b)" in body


### PR DESCRIPTION
Implements [docs/plans/phase-2a-bills-basic.md](docs/plans/phase-2a-bills-basic.md). After this lands a journalist can browse every Bill in 117–119, find them by title or identifier, and click through from a Member's profile to the bills they introduced.

## Summary
- **Stage 0** — `concord scrape bills` paginates `/v3/bill/{c}/{t}` for discovery, fetches `/v3/bill/{c}/{t}/{n}` per stub, and appends one ADR-0006 envelope per detail to `data/bills.jsonl`. Tier-1 only; the five sub-endpoints land in Phase 2b.
- **Stage 1** — `concord load bills` projects latest-snapshot-per-key into a new `bills` table (PK `"{congress}-{type}-{number}"` per ADR 0008; `sponsor_bioguide_id` bare TEXT so ingest is robust to Phase 1 gaps).
- **Stage 2** — `concord index bills` truncates + repopulates `bills_fts` over `(identifier, title, policy_area)`.
- **Web** — `GET /bills` (chamber/policy_area/congress/sponsor filters) and `GET /bills/{c}/{t}/{n}` (sponsor block + five `(Phase 2b)` placeholder boxes + Phase 3/4/5 placeholders). Nav link added.
- **Federation** — `/search` gains a Bills section + checkbox; bare-identifier queries (`HR 1`, `s.47`) parse via regex and 307 to the matching Bill when a single Congress has it.
- **Member cross-link** — Sponsored bills section is now live (top 25 by introduced date, with "View all →"). Cosponsored stays as a `(Phase 2b)` placeholder so the seam is honest.

Every command takes `--limit N`. `--storage-dir` (not `--storage`) because Phase 2b will add five sibling JSONL files in the same directory per ADR 0009.

## Test plan
- [x] `pytest` — 373 tests pass (Phase 1 regressions clean).
- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean.
- [x] `uv run mypy src/concord` clean.
- [x] New tests cover models, sqlite schema/constraints, scraper (limit, lowercasing, dir creation), loader (latest-wins, idempotent, no-op-on-missing), indexer (FTS5 row count, match), web routes (filters, 404s on bad type/number, sponsor degradation when Member not indexed, Bills section, bare-id redirect), CLI (help + smoke + unknown-type rejection), and a new bills end-to-end smoke in `tests/test_smoke.py`.
- [x] Manual: with `CONGRESS_API_KEY`, run `concord run bills --congresses 119 --bill-types hr --limit 50` and click through `/bills`, a profile, `/search?q=…`, and a sponsor's `/members/{id}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)