### PR TITLE
Add pre-commit hook with expanded ruff rule set

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff-format
+      - id: ruff
+        args: [--fix]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+## Setup
+
+```sh
+uv sync
+uv run pre-commit install   # one-time per clone
+```
+
+The pre-commit hook runs `ruff format` and `ruff check --fix` on every `git commit`, so most style issues land fixed before they reach review.
+
+## Style highlights
+
+- **Line length: 100.** Enforced by `ruff format` (black-compatible).
+- **Top-level imports.** No lazy imports inside functions unless there is a *real* circular-dependency or optional-dependency reason. If there is, add `# noqa: PLC0415 — <one-phrase reason>`.
+- **Absolute imports only.** Use `from concord.foo import bar`, not `from .foo import bar`. Ruff will autofix this for you.
+- **Type-hint everything in `src/`.** `mypy --strict` runs in CI on `src/concord/` (tests are looser).
+- **No magic numbers in `src/`.** Pull them into a module-level `_FOO = N` constant. HTTP status codes are in `concord.api.HTTP_*`. Tests are exempt.
+- **`pytest.mark.parametrize` takes a tuple of names**, not a comma-separated string: `("url", "expected")`, not `"url,expected"`.
+- **One assertion per `assert`.** Split `assert a and b` into two lines so failure messages identify the culprit.
+- **Use `pytest.raises(...)`**, not try/except/else with assertions on the exception.
+- **`# noqa` requires an inline reason.** Format: `# noqa: RULE — short reason`. A bare `# noqa` will be flagged in review.
+- **Reach for per-file-ignores in `pyproject.toml` over scattering noqas** when a rule consistently misfires on a whole module (e.g., the storage layer's intentional SQL-string construction).
+
+## Linter philosophy
+
+The ruff config in [pyproject.toml](pyproject.toml) is intentionally broad — it pulls in most pylint checks (`PL`), security (`S`), complexity (`C90`), naming (`N`), pytest style (`PT`), and more. The goal isn't perfectionism: it's to catch *unintentional* drift early, so the codebase stays uniform without anyone having to remember the rules.
+
+When a rule fires on code that's genuinely right as written — a FastAPI route handler that has eleven query params, a pipeline orchestrator that's long *because* it orchestrates — prefer an inline `# noqa: RULE — reason` over rewriting the code to dodge the linter. The reason text matters: it's the documentation a future reader needs to understand why the rule was waived. If the same rule keeps misfiring across many files in one module, prefer a `per-file-ignores` entry in `pyproject.toml` with a comment explaining the pattern.

--- a/README.md
+++ b/README.md
@@ -177,13 +177,14 @@ See [docs/rebuild-plan.md](docs/rebuild-plan.md) for the rebuild rationale, [doc
 
 ```sh
 uv sync
+uv run pre-commit install   # one-time, wires up the local commit hook
 uv run ruff check
 uv run ruff format --check
 uv run mypy src
 uv run pytest
 ```
 
-CI runs all four on every PR.
+The `pre-commit` hook runs `ruff format` and `ruff check --fix` on every commit; CI runs all four checks above plus `pytest`.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ concord = "concord.cli:main"
 dev = [
     "mongomock>=4.1",
     "mypy>=1.11",
+    "pre-commit>=4.0",
     "pytest>=8.0",
     "ruff>=0.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,14 +48,57 @@ src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = [
-    "E",    # pycodestyle errors
-    "F",    # pyflakes
-    "I",    # isort
-    "UP",   # pyupgrade
-    "B",    # flake8-bugbear
-    "SIM",  # flake8-simplify
-    "RUF",  # ruff-specific
+    "E", "F", "W",   # pycodestyle + pyflakes
+    "I",             # isort
+    "UP",            # pyupgrade
+    "B",             # flake8-bugbear
+    "SIM",           # flake8-simplify
+    "RUF",           # ruff-specific
+    "PL",            # pylint (PLC/PLE/PLR/PLW)
+    "N",             # pep8-naming
+    "C90",           # mccabe complexity
+    "S",             # bandit (security)
+    "A",             # shadowing builtins
+    "ARG",           # unused arguments
+    "RET",           # return statement issues
+    "TRY",           # try/except antipatterns
+    "PTH",           # use pathlib
+    "ERA",           # commented-out code
+    "TID",           # tidy imports
+    "PT",            # pytest style
+    "C4",            # comprehensions
+    "PIE",
+    "ISC",
+    "G",             # logging format
 ]
+ignore = [
+    "TRY003",  # long exception messages — too noisy
+    "ISC001",  # conflicts with formatter
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "S101",     # asserts are the whole point in tests
+    "ARG",      # fixtures often look unused
+    "PLR2004",  # magic numbers are fine in tests
+    "S105", "S106",  # hardcoded passwords in test data
+    "A002",     # OpenAI-API-shaped stubs use `input=` kwarg
+    "S608",     # dynamic SQL built from `?` placeholders only
+    "PLR0913",  # test factory fixtures take many kwargs
+]
+# cli.py defers heavy subcommand imports (openai, uvicorn, pipeline modules)
+# so `concord --help` stays fast.
+"src/concord/cli.py" = ["PLC0415"]
+# SQL built from module-level column tuples + `?` placeholders; no user input.
+"src/concord/storage/sqlite.py" = ["S608"]
+"src/concord/web/search.py" = ["S608"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pylint]
+max-args = 8
+max-branches = 12
 
 [tool.mypy]
 python_version = "3.12"

--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -64,6 +64,11 @@ MAX_5XX_RETRIES = 5
 #: Exponential schedule for transient backoff: 1s, 2s, 4s, 8s, 16s (capped).
 _BACKOFF_BASE = 2.0
 
+#: HTTP status codes we treat specially.
+HTTP_TOO_MANY_REQUESTS = 429
+HTTP_SERVER_ERROR_MIN = 500
+HTTP_SERVER_ERROR_MAX = 600  # exclusive upper bound
+
 _log = logging.getLogger("concord.api")
 
 
@@ -280,7 +285,7 @@ class Client:
 
             status = response.status_code
 
-            if status == 429:
+            if status == HTTP_TOO_MANY_REQUESTS:
                 delay = _retry_after_seconds(response) or _backoff_seconds(transient_attempts)
                 _log.warning("429 from %s; backing off %.1fs before retry", path, delay)
                 self._sleep(delay)
@@ -288,7 +293,7 @@ class Client:
                 # is a wait condition, not a fault. We could be 429'd for hours.
                 continue
 
-            if 500 <= status < 600:
+            if HTTP_SERVER_ERROR_MIN <= status < HTTP_SERVER_ERROR_MAX:
                 if transient_attempts >= MAX_5XX_RETRIES:
                     raise ApiError(
                         f"{status} {response.reason_phrase} from {path} "

--- a/src/concord/embedding.py
+++ b/src/concord/embedding.py
@@ -67,7 +67,7 @@ class _EmbeddingsAPI(Protocol):
     needing to construct a real ``openai.OpenAI`` instance.
     """
 
-    def create(self, *, model: str, input: list[str]) -> Any: ...
+    def create(self, *, model: str, input: list[str]) -> Any: ...  # noqa: A002 — matches openai SDK kwarg name
 
 
 class _OpenAILike(Protocol):
@@ -146,7 +146,7 @@ class Embedder:
         # to need it on the import path. The Exception type comparison
         # below falls back to class-name matching when openai isn't loaded.
         try:
-            import openai
+            import openai  # noqa: PLC0415 — guarded so test stubs don't need openai installed
 
             rate_limit_exc: type[BaseException] = openai.RateLimitError
         except ImportError:  # pragma: no cover - openai is a hard dep in prod

--- a/src/concord/models.py
+++ b/src/concord/models.py
@@ -253,12 +253,15 @@ _STATE_NAME_TO_CODE = {
 }
 
 
+_STATE_CODE_LEN = 2
+
+
 def normalize_state(value: str | None) -> str | None:
     """Map the API's full state name to a two-letter code; pass through codes."""
     if value is None:
         return None
     stripped = value.strip()
-    if len(stripped) == 2 and stripped.isupper():
+    if len(stripped) == _STATE_CODE_LEN and stripped.isupper():
         return stripped
     return _STATE_NAME_TO_CODE.get(stripped.lower(), stripped)
 
@@ -388,7 +391,7 @@ def parse_member_identity(payload: dict[str, Any]) -> Member:
     )
 
 
-def parse_member_term(payload: dict[str, Any], *, congress: int) -> Term | None:
+def parse_member_term(payload: dict[str, Any], *, congress: int) -> Term | None:  # noqa: C901 — one branch per optional payload field
     """Project a raw ``/member`` payload + queried Congress into one :class:`Term`.
 
     The ``/v3/member/congress/{n}`` list endpoint omits ``congress`` from

--- a/src/concord/pipeline/index_bills.py
+++ b/src/concord/pipeline/index_bills.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import NamedTuple
 
-from ..storage.sqlite import SqliteStorage
+from concord.storage.sqlite import SqliteStorage
 
 
 class IndexStats(NamedTuple):

--- a/src/concord/pipeline/index_members.py
+++ b/src/concord/pipeline/index_members.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import NamedTuple
 
-from ..storage.sqlite import SqliteStorage
+from concord.storage.sqlite import SqliteStorage
 
 
 class IndexStats(NamedTuple):

--- a/src/concord/pipeline/index_proceedings.py
+++ b/src/concord/pipeline/index_proceedings.py
@@ -18,10 +18,10 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import NamedTuple
 
-from ..chunking import Chunk, Chunker
-from ..embedding import Embedder
-from ..models import Proceeding
-from ..storage.sqlite import SqliteStorage
+from concord.chunking import Chunk, Chunker
+from concord.embedding import Embedder
+from concord.models import Proceeding
+from concord.storage.sqlite import SqliteStorage
 
 
 class IndexResult(NamedTuple):

--- a/src/concord/pipeline/load_bills.py
+++ b/src/concord/pipeline/load_bills.py
@@ -18,9 +18,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, NamedTuple
 
-from ..models import parse_bill
-from ..scraper.bills import BILLS_JSONL_NAME
-from ..storage.sqlite import SqliteStorage
+from concord.models import parse_bill
+from concord.scraper.bills import BILLS_JSONL_NAME
+from concord.storage.sqlite import SqliteStorage
 
 _log = logging.getLogger("concord.pipeline.load_bills")
 

--- a/src/concord/pipeline/load_members.py
+++ b/src/concord/pipeline/load_members.py
@@ -34,8 +34,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, NamedTuple
 
-from ..models import Term, parse_member_identity, parse_member_term
-from ..storage.sqlite import SqliteStorage
+from concord.models import Term, parse_member_identity, parse_member_term
+from concord.storage.sqlite import SqliteStorage
 
 _log = logging.getLogger("concord.pipeline.load_members")
 
@@ -49,7 +49,7 @@ class LoadStats(NamedTuple):
     malformed: int
 
 
-def load(*, jsonl_path: Path, db_path: Path) -> LoadStats:
+def load(*, jsonl_path: Path, db_path: Path) -> LoadStats:  # noqa: C901, PLR0915 — pipeline orchestrator
     """Load the JSONL snapshot stream into SQLite.
 
     Returns the count of Members and Terms written plus diagnostics.

--- a/src/concord/pipeline/load_proceedings.py
+++ b/src/concord/pipeline/load_proceedings.py
@@ -28,10 +28,10 @@ from collections.abc import Callable
 from datetime import UTC, date, datetime
 from typing import NamedTuple
 
-from ..api import Client
-from ..models import Issue, Proceeding
-from ..storage.base import Storage
-from ..text import TextFetchError
+from concord.api import Client
+from concord.models import Issue, Proceeding
+from concord.storage.base import Storage
+from concord.text import TextFetchError
 
 _log = logging.getLogger("concord.pipeline")
 
@@ -69,7 +69,7 @@ class ProgressEvent(NamedTuple):
     total_failed: int
 
 
-def pull(
+def pull(  # noqa: C901 — pipeline orchestrator
     start: date,
     end: date,
     *,

--- a/src/concord/scraper/bills.py
+++ b/src/concord/scraper/bills.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import NamedTuple
 
-from ..api import Client
+from concord.api import Client
 
 #: Default Bill type codes scraped when the caller doesn't pass
 #: ``bill_types``. Order matches the API documentation; chamber-grouped

--- a/src/concord/scraper/members.py
+++ b/src/concord/scraper/members.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import NamedTuple
 
-from ..api import Client
+from concord.api import Client
 
 
 class ScrapeProgressEvent(NamedTuple):

--- a/src/concord/scraper/proceedings.py
+++ b/src/concord/scraper/proceedings.py
@@ -14,10 +14,10 @@ from datetime import date
 import httpx
 import typer
 
-from ..api import ApiError, Client
-from ..pipeline.load_proceedings import ProgressEvent, PullResult, pull
-from ..storage.base import Storage
-from ..text import fetch_text
+from concord.api import ApiError, Client
+from concord.pipeline.load_proceedings import ProgressEvent, PullResult, pull
+from concord.storage.base import Storage
+from concord.text import fetch_text
 
 #: Per-request timeout (seconds) for fetching article text from congress.gov.
 #: The default httpx timeout (5s) is too aggressive for occasional slow
@@ -41,8 +41,7 @@ def scrape(
     the article-text fetch. Errors that prevent any work (missing API key,
     failed client construction) exit with code 2 via :class:`typer.Exit`.
     """
-    # Local import to avoid a circular dep on the CLI's Progress helper.
-    from ..cli import Progress
+    from concord.cli import Progress  # noqa: PLC0415 — circular dep: cli imports this module
 
     try:
         api_client = Client()

--- a/src/concord/storage/base.py
+++ b/src/concord/storage/base.py
@@ -9,7 +9,7 @@ over articles without ever checking — though it's still expected to call
 
 from typing import Protocol
 
-from ..models import Proceeding
+from concord.models import Proceeding
 
 
 class Storage(Protocol):

--- a/src/concord/storage/jsonl.py
+++ b/src/concord/storage/jsonl.py
@@ -13,7 +13,7 @@ ability to resume the whole thing.
 import json
 from pathlib import Path
 
-from ..models import Proceeding
+from concord.models import Proceeding
 
 
 class JsonlStorage:

--- a/src/concord/storage/mongo.py
+++ b/src/concord/storage/mongo.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..models import Proceeding
+from concord.models import Proceeding
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     pass
@@ -60,7 +60,7 @@ class MongoStorage:
         install hint if the optional dependency isn't installed.
         """
         try:
-            from pymongo import MongoClient  # type: ignore[import-not-found]
+            from pymongo import MongoClient  # type: ignore[import-not-found]  # noqa: PLC0415
         except ImportError as exc:  # pragma: no cover - exercised via install hint
             raise ImportError(
                 "MongoDB support requires pymongo. Install with "

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -30,7 +30,7 @@ from typing import Any
 
 import sqlite_vec  # type: ignore[import-untyped]
 
-from ..models import Bill, Member, Proceeding, Term
+from concord.models import Bill, Member, Proceeding, Term
 
 # Columns in the exact order they appear in the INSERT statement. Keeping
 # this list in one place makes it easy to add a column later: extend here,

--- a/src/concord/text.py
+++ b/src/concord/text.py
@@ -33,6 +33,8 @@ from html.parser import HTMLParser
 
 import httpx
 
+from concord.api import HTTP_SERVER_ERROR_MAX, HTTP_SERVER_ERROR_MIN, HTTP_TOO_MANY_REQUESTS
+
 #: Cap on a single backoff delay, in seconds. Applied to both the exponential
 #: schedule and Retry-After values so a server-suggested 1-hour wait can't
 #: silently stall the pipeline.
@@ -73,7 +75,7 @@ class _PreExtractor(HTMLParser):
         self._depth = 0
         self._chunks: list[str] = []
 
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # noqa: ARG002 — HTMLParser override
         if tag == "pre":
             self._depth += 1
 
@@ -143,7 +145,7 @@ def _get_with_retry(
 
         status = response.status_code
 
-        if status == 429:
+        if status == HTTP_TOO_MANY_REQUESTS:
             delay = _retry_after_seconds(response) or _backoff_seconds(transient_attempts)
             _log.warning("429 from %s; backing off %.1fs before retry", url, delay)
             sleep(delay)
@@ -151,7 +153,7 @@ def _get_with_retry(
             # is a wait condition, not a fault.
             continue
 
-        if 500 <= status < 600:
+        if HTTP_SERVER_ERROR_MIN <= status < HTTP_SERVER_ERROR_MAX:
             if transient_attempts >= MAX_5XX_RETRIES:
                 raise TextFetchError(
                     f"{status} {response.reason_phrase} fetching {url} "

--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -36,7 +36,8 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
-from ..embedding import Embedder
+from concord.embedding import Embedder
+
 from . import search as search_mod
 from .snippets import keyword_snippet, semantic_snippet
 
@@ -101,9 +102,7 @@ def create_app(
     db_path = Path(db_path)
 
     if embedder is None:
-        # Lazy import so the module is importable when openai isn't
-        # available (tests inject their own embedder).
-        import openai
+        import openai  # noqa: PLC0415 — guarded so tests can import this module without openai
 
         embedder = Embedder(openai.OpenAI())
 
@@ -133,7 +132,7 @@ def create_app(
 # -- routes ----------------------------------------------------------------
 
 
-def _register_routes(app: FastAPI, limiter: Limiter) -> None:
+def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR0915 — FastAPI route declarations
     templates = app.state.templates
 
     def get_db(request: Request) -> Iterator[sqlite3.Connection]:
@@ -159,7 +158,7 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:
 
     @app.get("/search", response_class=HTMLResponse)
     @limiter.limit(SEARCH_RATE_LIMIT)
-    def search_endpoint(
+    def search_endpoint(  # noqa: C901, PLR0913 — one arg per FastAPI query param
         request: Request,
         q: str = Query("", description="Search query."),
         date_from: str | None = Query(None, alias="from", description="YYYY-MM-DD"),

--- a/src/concord/web/search.py
+++ b/src/concord/web/search.py
@@ -18,7 +18,7 @@ from typing import Any
 import sqlite_vec  # type: ignore[import-untyped]
 from pydantic import BaseModel
 
-from ..embedding import EMBEDDING_DIM, Embedder
+from concord.embedding import EMBEDDING_DIM, Embedder
 
 #: Per-signal retrieval cap. We pull 200 chunks from each index then let
 #: RRF + group-by reduce to the final result page. Larger than any

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,18 +6,27 @@ itself is covered by tests/test_pipeline.py — here we stub it out and verify
 the CLI does the right thing around it.
 """
 
+import io
+import json
 import re
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
+import httpx
+import mongomock
+import openai
 import pytest
+import uvicorn
 from typer.testing import CliRunner
 
 import concord.cli as cli_module
 import concord.scraper.proceedings as scraper_proceedings_module
-from concord.api import ENV_API_KEY, ApiError
+from concord.api import ENV_API_KEY, ApiError, Client
+from concord.models import Article, Issue, Proceeding
+from concord.pipeline.index_proceedings import IndexResult
 from concord.pipeline.load_proceedings import PullResult
+from concord.storage import MongoStorage, SqliteStorage
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -336,15 +345,11 @@ class TestMongoBackend:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """With --mongo-uri, the CLI calls MongoStorage.from_uri instead of JsonlStorage."""
-        from concord.storage import MongoStorage
-
         calls: list[dict[str, Any]] = []
 
         def fake_from_uri(uri: str, *, db: str, collection: str) -> MongoStorage:
             calls.append({"uri": uri, "db": db, "collection": collection})
             # Return a stand-in that satisfies the Storage protocol.
-            import mongomock
-
             return MongoStorage(collection=mongomock.MongoClient()[db][collection])
 
         monkeypatch.setattr(cli_module.MongoStorage, "from_uri", staticmethod(fake_from_uri))
@@ -451,8 +456,6 @@ class TestLoadCommand:
         assert str(db) in plain
 
         # Verify the rows actually landed.
-        from concord.storage import SqliteStorage
-
         with SqliteStorage(db) as storage:
             assert len(storage) == 2
 
@@ -498,8 +501,6 @@ class TestLoadCommand:
         assert result.exit_code == 0, result.output
         plain = _strip(result.output)
         assert "Loaded 2 new proceedings" in plain
-
-        from concord.storage import SqliteStorage
 
         with SqliteStorage(db) as storage:
             assert len(storage) == 2
@@ -579,11 +580,6 @@ class TestLoadCommand:
 
 def _seed_db_for_index(db_path: Path, granule_ids: list[str]) -> None:
     """Pre-populate a SQLite DB with proceedings so `concord index` has work to do."""
-    from datetime import UTC, datetime
-
-    from concord.models import Article, Issue, Proceeding
-    from concord.storage import SqliteStorage
-
     with SqliteStorage(db_path) as storage:
         for gid in granule_ids:
             text_url = f"https://www.congress.gov/119/crec/2026/05/22/172/88/modified/{gid}.htm"
@@ -684,8 +680,6 @@ class TestIndexCommand:
         _seed_db_for_index(db, ["CREC-2026-05-22-pt1-PgD551-1", "CREC-2026-05-22-pt1-PgD551-2"])
 
         # Patch openai.OpenAI inside the CLI to return our fake.
-        import openai
-
         monkeypatch.setattr(openai, "OpenAI", lambda *a, **kw: _FakeOpenAIClient())
 
         result = runner.invoke(cli_module.app, ["index", "proceedings", "--db", str(db)])
@@ -696,8 +690,6 @@ class TestIndexCommand:
         assert "embedded" in plain
 
         # Verify state on disk: chunks_vec has rows.
-        from concord.storage import SqliteStorage
-
         with SqliteStorage(db) as storage:
             count = storage.connection.execute("SELECT COUNT(*) FROM chunks_vec").fetchone()[0]
             assert count > 0
@@ -733,8 +725,6 @@ class TestServeCommand:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from concord.storage import SqliteStorage
-
         monkeypatch.delenv(cli_module.ENV_OPENAI_API_KEY, raising=False)
         db = tmp_path / "out.db"
         SqliteStorage(db).close()
@@ -751,8 +741,6 @@ class TestServeCommand:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Verify the CLI's wiring up to ``uvicorn.run`` without actually starting a server."""
-        from concord.storage import SqliteStorage
-
         monkeypatch.setenv(cli_module.ENV_OPENAI_API_KEY, "sk-test")
         db = tmp_path / "out.db"
         SqliteStorage(db).close()
@@ -760,8 +748,6 @@ class TestServeCommand:
         captured: dict[str, Any] = {}
 
         # Stub uvicorn so the test doesn't actually bind a port.
-        import uvicorn
-
         def fake_run(app: Any, **kwargs: Any) -> None:
             captured["app"] = app
             captured["kwargs"] = kwargs
@@ -770,10 +756,8 @@ class TestServeCommand:
 
         # Stub openai.OpenAI so the embedder construction inside create_app
         # doesn't need a real API key.
-        import openai
-
         class _Fake:
-            class embeddings:
+            class embeddings:  # noqa: N801 — mirrors openai SDK attribute name
                 @staticmethod
                 def create(*, model: str, input: list[str]) -> Any:
                     raise AssertionError("should not be called during serve startup")
@@ -782,10 +766,10 @@ class TestServeCommand:
 
         result = runner.invoke(
             cli_module.app,
-            ["serve", "--db", str(db), "--host", "0.0.0.0", "--port", "8123"],
+            ["serve", "--db", str(db), "--host", "0.0.0.0", "--port", "8123"],  # noqa: S104 — verifying CLI passes --host through
         )
         assert result.exit_code == 0, result.output
-        assert captured["kwargs"]["host"] == "0.0.0.0"
+        assert captured["kwargs"]["host"] == "0.0.0.0"  # noqa: S104 — asserting wiring, not deploying
         assert captured["kwargs"]["port"] == 8123
         assert captured["kwargs"]["reload"] is False
 
@@ -801,8 +785,6 @@ class TestDefaults:
         stub_pull: list[dict[str, Any]],
         tmp_path: Path,
     ) -> None:
-        from datetime import UTC, datetime
-
         result = runner.invoke(
             cli_module.app,
             [
@@ -839,9 +821,6 @@ class TestRunCommand:
         tmp_path: Path,
     ) -> None:
         """`concord run` should call _run_pull, _run_load, _run_index in order."""
-        from concord.pipeline.index_proceedings import IndexResult
-        from concord.pipeline.load_proceedings import PullResult
-
         monkeypatch.setenv(cli_module.ENV_OPENAI_API_KEY, "sk-test")
         calls: list[str] = []
 
@@ -885,7 +864,9 @@ class TestRunCommand:
         assert result.exit_code == 0, result.output
         assert calls == ["pull", "load", "index"]
         plain = _strip(result.output)
-        assert "Stage 0" in plain and "Stage 1" in plain and "Stage 2" in plain
+        assert "Stage 0" in plain
+        assert "Stage 1" in plain
+        assert "Stage 2" in plain
 
     def test_run_fails_fast_on_missing_congress_key(
         self,
@@ -941,8 +922,6 @@ class _FakeTTY:
     """StringIO that pretends to be a TTY for isatty()."""
 
     def __init__(self) -> None:
-        import io
-
         self._buf = io.StringIO()
         self.write = self._buf.write
         self.flush = self._buf.flush
@@ -958,8 +937,6 @@ class _FakeNonTTY:
     """StringIO that pretends to be a pipe / file."""
 
     def __init__(self) -> None:
-        import io
-
         self._buf = io.StringIO()
         self.write = self._buf.write
         self.flush = self._buf.flush
@@ -1048,18 +1025,12 @@ class TestLoadMembersCommand:
 
 
 def _bills_fixture(name: str) -> dict[str, Any]:
-    import json as _json
-
     here = Path(__file__).parent / "fixtures" / "api" / "bills"
-    return _json.loads((here / name).read_text())
+    return json.loads((here / name).read_text())
 
 
 def _bills_handler(call_log: list[str] | None = None):
     """Return an httpx handler that answers list + detail for the bills fixtures."""
-    import json as _json
-
-    import httpx
-
     list_payload = _bills_fixture("list_hr_119.json")
     details = {
         1: _bills_fixture("detail_119_hr_1.json"),
@@ -1079,7 +1050,7 @@ def _bills_handler(call_log: list[str] | None = None):
             return httpx.Response(404)
         return httpx.Response(
             200,
-            content=_json.dumps(body),
+            content=json.dumps(body),
             headers={"content-type": "application/json"},
         )
 
@@ -1124,22 +1095,18 @@ class TestScrapeBillsCommand:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        import httpx
-
-        from concord.api import Client as ApiClient
-
         handler = _bills_handler()
 
         # Monkey-patch the Client to inject the mock transport while still
         # exercising the real CLI wiring.
-        original_init = ApiClient.__init__
+        original_init = Client.__init__
 
         def patched_init(self, **kwargs):
             kwargs.setdefault("transport", httpx.MockTransport(handler))
             kwargs.setdefault("sleep", lambda _s: None)
             original_init(self, **kwargs)
 
-        monkeypatch.setattr(ApiClient, "__init__", patched_init)
+        monkeypatch.setattr(Client, "__init__", patched_init)
 
         result = runner.invoke(
             cli_module.app,

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -5,7 +5,13 @@ from typing import Any
 
 import pytest
 
-from concord.embedding import DEFAULT_MODEL, EMBEDDING_DIM, Embedder, EmbeddingError
+from concord.embedding import (
+    DEFAULT_MODEL,
+    EMBEDDING_DIM,
+    MAX_RATE_LIMIT_WAIT,
+    Embedder,
+    EmbeddingError,
+)
 
 
 class _FakeData:
@@ -229,8 +235,6 @@ class TestRateLimitRetry:
         assert waits == [pytest.approx(1.5)]
 
     def test_caps_unreasonable_wait_at_max(self) -> None:
-        from concord.embedding import MAX_RATE_LIMIT_WAIT
-
         waits: list[float] = []
         # Server (hypothetically) suggests an hour. Cap to MAX_RATE_LIMIT_WAIT.
         api = _RateLimitedThenOk(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ SAMPLE_GRANULE = "CREC-2026-05-22-pt1-PgD551-6"
 
 class TestParseGranuleId:
     @pytest.mark.parametrize(
-        "url,expected",
+        ("url", "expected"),
         [
             (SAMPLE_TEXT_URL, SAMPLE_GRANULE),
             (SAMPLE_PDF_URL, SAMPLE_GRANULE),

--- a/tests/test_models_members.py
+++ b/tests/test_models_members.py
@@ -35,7 +35,7 @@ FIXED_FETCHED_AT = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC)
 
 class TestNormalization:
     @pytest.mark.parametrize(
-        "input_, expected",
+        ("input_", "expected"),
         [
             ("Vermont", "VT"),
             ("New York", "NY"),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,7 +19,7 @@ from concord.api import Client
 from concord.models import Article, Issue, Proceeding
 from concord.pipeline.load_proceedings import pull
 from concord.storage import JsonlStorage
-from concord.text import fetch_text
+from concord.text import TextFetchError, fetch_text
 
 FIXED_NOW = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
 
@@ -202,8 +202,6 @@ class TestDedup:
 
 class TestFetchFailures:
     def test_single_fetch_failure_does_not_abort_run(self) -> None:
-        from concord.text import TextFetchError
-
         issue = _issue("2026-05-22", issue_number=88)
         articles = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(3)]
         client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})
@@ -229,8 +227,6 @@ class TestFetchFailures:
         assert all(p.granule_id != articles[1].granule_id for p in storage.writes)
 
     def test_failed_count_in_progress_event(self) -> None:
-        from concord.text import TextFetchError
-
         issue = _issue("2026-05-22", issue_number=88)
         articles = [_article(f"CREC-2026-05-22-pt1-PgS{n:04d}") for n in range(3)]
         client = _StubClient(pages=[[issue]], articles_by_issue={(172, 88): articles})

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -6,7 +6,17 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+from fastapi.testclient import TestClient
+
 import concord
+from concord.embedding import EMBEDDING_DIM, Embedder
+from concord.pipeline.index_bills import index as index_bills
+from concord.pipeline.index_members import index as index_members
+from concord.pipeline.load_bills import load as load_bills
+from concord.pipeline.load_members import load as load_members
+from concord.scraper.bills import BILLS_JSONL_NAME
+from concord.storage.sqlite import SqliteStorage
+from concord.web.app import create_app
 
 
 def test_package_importable() -> None:
@@ -25,13 +35,6 @@ def test_members_end_to_end(tmp_path: Path) -> None:
     three snapshots, then loads + indexes + queries the FastAPI app.
     Asserts the acceptance-criteria HTTP routes all return 200.
     """
-    from fastapi.testclient import TestClient
-
-    from concord.embedding import EMBEDDING_DIM, Embedder
-    from concord.pipeline.index_members import index as index_members
-    from concord.pipeline.load_members import load as load_members
-    from concord.web.app import create_app
-
     here = Path(__file__).parent / "fixtures" / "api" / "members"
     payloads = [
         json.loads((here / "current_house.json").read_text())["members"][0],
@@ -67,9 +70,7 @@ def test_members_end_to_end(tmp_path: Path) -> None:
     # Touch the DB with load_vec=True so the chunks_vec virtual table
     # exists. /search would 500 trying to query it otherwise — a real
     # deployment would have run `concord run proceedings` first.
-    from concord.storage.sqlite import SqliteStorage as _SqliteStorage
-
-    _SqliteStorage(db).close()
+    SqliteStorage(db).close()
 
     load_stats = load_members(jsonl_path=jsonl, db_path=db)
     assert load_stats.members_written == 3
@@ -114,15 +115,6 @@ def test_bills_end_to_end(tmp_path: Path) -> None:
     load + index and pokes the FastAPI app at the four routes named in
     the plan's verification section.
     """
-    from fastapi.testclient import TestClient
-
-    from concord.embedding import EMBEDDING_DIM, Embedder
-    from concord.pipeline.index_bills import index as index_bills
-    from concord.pipeline.load_bills import load as load_bills
-    from concord.scraper.bills import BILLS_JSONL_NAME
-    from concord.storage.sqlite import SqliteStorage as _SqliteStorage
-    from concord.web.app import create_app
-
     storage_dir = tmp_path / "data"
     storage_dir.mkdir()
     fetched_at = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC).isoformat()
@@ -142,7 +134,7 @@ def test_bills_end_to_end(tmp_path: Path) -> None:
     )
 
     db = tmp_path / "test.db"
-    _SqliteStorage(db).close()
+    SqliteStorage(db).close()
 
     load_stats = load_bills(storage_dir=storage_dir, db_path=db)
     assert load_stats.bills_written == 1

--- a/tests/test_storage_members_sqlite.py
+++ b/tests/test_storage_members_sqlite.py
@@ -7,6 +7,7 @@ contract that keeps the SQL state consistent with the latest snapshot.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -16,14 +17,14 @@ from concord.storage.sqlite import SqliteStorage
 
 
 def _member(bioguide_id: str = "O000172", **overrides: object) -> Member:
-    defaults = dict(
-        bioguide_id=bioguide_id,
-        first_name="Alexandria",
-        last_name="Ocasio-Cortez",
-        display_name="Alexandria Ocasio-Cortez",
-        photo_url="https://example.invalid/o000172.jpg",
-        birth_year=1989,
-    )
+    defaults: dict[str, object] = {
+        "bioguide_id": bioguide_id,
+        "first_name": "Alexandria",
+        "last_name": "Ocasio-Cortez",
+        "display_name": "Alexandria Ocasio-Cortez",
+        "photo_url": "https://example.invalid/o000172.jpg",
+        "birth_year": 1989,
+    }
     defaults.update(overrides)
     return Member(**defaults)  # type: ignore[arg-type]
 
@@ -129,8 +130,6 @@ class TestUpsertMember:
         Bypasses the pydantic validator (which would normalize ``"foo"``)
         by writing the bad value via raw SQL.
         """
-        import sqlite3
-
         storage.connection.execute(
             "INSERT INTO members (bioguide_id, first_name, last_name, display_name, fetched_at) "
             "VALUES (?, ?, ?, ?, ?)",

--- a/tests/test_storage_mongo.py
+++ b/tests/test_storage_mongo.py
@@ -7,6 +7,7 @@ without a real Mongo server.
 from datetime import UTC, datetime
 
 import mongomock
+import pytest
 
 from concord.models import Article, Issue, Proceeding
 from concord.storage import MongoStorage, Storage
@@ -160,9 +161,5 @@ class TestErrorPropagation:
                 raise RuntimeError("disk full")
 
         storage = MongoStorage(collection=_BrokenCollection())
-        try:
+        with pytest.raises(RuntimeError, match="disk full"):
             storage.write(_sample_proceeding())
-        except RuntimeError as exc:
-            assert "disk full" in str(exc)
-        else:
-            raise AssertionError("expected RuntimeError to propagate")

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -4,6 +4,8 @@ import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from concord.models import Article, Issue, Proceeding
 from concord.storage import SqliteStorage, Storage
 
@@ -429,8 +431,6 @@ class TestStage2EmbeddingHelpers:
             assert storage.bulk_insert_embeddings([]) == 0
 
     def test_embedding_helpers_require_load_vec(self, tmp_path: Path) -> None:
-        import pytest
-
         with SqliteStorage(tmp_path / "out.db", load_vec=False) as storage:
             with pytest.raises(RuntimeError, match="load_vec=True"):
                 list(storage.chunks_without_embeddings())

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-from concord.text import TextFetchError, fetch_text
+from concord.text import MAX_BACKOFF, TextFetchError, fetch_text
 
 
 def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
@@ -172,8 +172,6 @@ class TestFetchTextRateLimit:
         assert slept == [7.0]
 
     def test_429_retry_after_clamped_to_max_backoff(self) -> None:
-        from concord.text import MAX_BACKOFF
-
         responses = iter(
             [
                 httpx.Response(429, headers={"retry-after": "99999"}),

--- a/tests/test_web_members.py
+++ b/tests/test_web_members.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 
 from concord.embedding import EMBEDDING_DIM, Embedder
 from concord.models import Member, Term
+from concord.pipeline.index_members import index as index_members
 from concord.storage.sqlite import SqliteStorage
 from concord.web.app import create_app
 
@@ -105,8 +106,6 @@ def _seed_members(storage: SqliteStorage) -> None:
     )
 
     # Populate the FTS index the same way `concord index members` would.
-    from concord.pipeline.index_members import index as index_members
-
     storage.close()
     index_members(db_path=storage.path)
 

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -324,7 +324,8 @@ class TestSnippets:
             ("CREC-2026-05-22-pt1-PgS001-1",),
         ).fetchone()[0]
         snip = keyword_snippet(seeded_db.connection, chunk_id, "banking")
-        assert "<mark>" in snip and "</mark>" in snip
+        assert "<mark>" in snip
+        assert "</mark>" in snip
         assert "banking" in snip.lower()
 
     def test_keyword_snippet_empty_for_non_matching_chunk(self, seeded_db: SqliteStorage) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -206,6 +215,7 @@ mongo = [
 dev = [
     { name = "mongomock" },
     { name = "mypy" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -230,6 +240,7 @@ provides-extras = ["mongo"]
 dev = [
     { name = "mongomock", specifier = ">=4.1" },
     { name = "mypy", specifier = ">=1.11" },
+    { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.6" },
 ]
@@ -244,6 +255,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
 
 [[package]]
@@ -278,6 +298,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -344,6 +373,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -674,6 +712,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -711,12 +758,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -883,6 +955,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
 ]
 
 [[package]]
@@ -1312,6 +1397,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Wires up the [pre-commit framework](https://pre-commit.com/) so `git commit` runs `ruff format` + `ruff check --fix` on staged files locally.
- Expands `[tool.ruff.lint].select` from 7 narrow rule families to ~22 covering most pylint checks (`PL`), security (`S`), complexity (`C90`), naming (`N`), pytest style (`PT`), and more.
- Cleans up all 155 violations the expanded rule set surfaced in existing code, split between real fixes, per-file-ignores, and inline `# noqa` with one-phrase reasons.

## What's in each commit
1. **`c57760a` Add pre-commit framework** — `.pre-commit-config.yaml`, `pre-commit` dev dep, README setup line. No rule changes, so CI stays green at this commit.
2. **`3385bee` Expand ruff rule set and clean up** — the substantive change. `pyproject.toml` rule expansion + per-file-ignores + cap tweaks (max-complexity 10, max-args 8), plus all the resulting code cleanups bundled so each commit is independently green.

Notable real changes in commit 2:
- All 44 lazy imports in `tests/` moved to module top (PLC0415). `src/concord/cli.py` keeps its lazy imports via per-file-ignore — they defer `openai` / `uvicorn` / pipeline modules so `concord --help` stays fast.
- All 39 relative imports across `src/` converted to absolute (TID252, via ruff's autofix).
- HTTP status codes 429 / 500 / 600 extracted as `HTTP_TOO_MANY_REQUESTS` / `HTTP_SERVER_ERROR_MIN` / `HTTP_SERVER_ERROR_MAX` in [api.py](src/concord/api.py), reused in [text.py](src/concord/text.py).
- `_STATE_CODE_LEN = 2` in [models.py](src/concord/models.py).
- Misc trivials: `dict()` → `{}`, parametrize names string → tuple, composite asserts split, try/except/else → `pytest.raises`.

Inline `# noqa` with reason for cases where the rule fires but the code is correct as written: `_EmbeddingsAPI` Protocol mirrors the openai SDK kwarg name (A002); `HTMLParser` overrides have fixed signatures (ARG002); FastAPI declarative route registration is inherently wide (C901, PLR0915, PLR0913 on `_register_routes` + `search_endpoint`); pipeline orchestrators `pull()` and `load()` are *meant* to be long.

## Test plan
- [x] `uv run ruff check` — passes
- [x] `uv run ruff format --check` — passes
- [x] `uv run mypy src` — passes
- [x] `uv run pytest` — 373/373 pass
- [ ] After merge, contributors run `uv run pre-commit install` once per clone to wire up the local hook
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)