### PR TITLE
Phase 2b — Bills enrichment ingest + web surface

### DIFF
--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -52,6 +52,12 @@ MEMBERS_PAGE_SIZE = 250
 #: Congress.
 BILLS_PAGE_SIZE = 250
 
+#: Per-page size when walking a Bill sub-endpoint (cosponsors, actions,
+#: subjects, titles, summaries). Same 250 cap as the parent list
+#: endpoint; minimizes round trips on bills with hundreds of cosponsors
+#: or actions.
+BILL_SUB_PAGE_SIZE = 250
+
 #: Cap on a single backoff delay, in seconds. Applied to both the exponential
 #: schedule and Retry-After values so a server-suggested 1-hour wait can't
 #: silently stall the pipeline.
@@ -257,6 +263,135 @@ class Client:
                 f"{congress}/{bt}/{bill_number}; got {type(bill).__name__}"
             )
         return bill
+
+    def get_bill_cosponsors(
+        self,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+    ) -> dict[str, Any]:
+        """Fetch every cosponsor of one Bill, paginating to completion.
+
+        Returns the sub-endpoint response with the ``cosponsors`` array
+        concatenated across all pages. Other top-level keys (``pagination``,
+        ``request``) come from the final page.
+        """
+        return self._paginate_sub_endpoint(
+            congress, bill_type, bill_number, "cosponsors", array_key="cosponsors"
+        )
+
+    def get_bill_actions(
+        self,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+    ) -> dict[str, Any]:
+        """Fetch every action in one Bill's legislative history, paginating to completion."""
+        return self._paginate_sub_endpoint(
+            congress, bill_type, bill_number, "actions", array_key="actions"
+        )
+
+    def get_bill_subjects(
+        self,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+    ) -> dict[str, Any]:
+        """Fetch every CRS-assigned subject for one Bill, paginating to completion.
+
+        The subjects endpoint nests its array one level deep
+        (``subjects.legislativeSubjects``); pagination concatenates that
+        inner list across pages while preserving the outer ``policyArea``
+        sibling from the final page.
+        """
+        bt = bill_type.lower()
+        path = f"/bill/{congress}/{bt}/{bill_number}/subjects"
+        offset = 0
+        merged: dict[str, Any] = {}
+        merged_legislative: list[Any] = []
+        while True:
+            payload = self._get(path, params={"limit": BILL_SUB_PAGE_SIZE, "offset": offset})
+            subjects_obj = payload.get("subjects") or {}
+            page_legislative = (
+                subjects_obj.get("legislativeSubjects", [])
+                if isinstance(subjects_obj, dict)
+                else []
+            )
+            merged_legislative.extend(page_legislative)
+            merged = payload
+            if "next" not in payload.get("pagination", {}):
+                break
+            if not page_legislative:
+                break
+            offset += BILL_SUB_PAGE_SIZE
+        # Overwrite the final-page legislativeSubjects with the concatenated list.
+        outer = merged.get("subjects")
+        if isinstance(outer, dict):
+            outer = {**outer, "legislativeSubjects": merged_legislative}
+            merged = {**merged, "subjects": outer}
+        return merged
+
+    def get_bill_titles(
+        self,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+    ) -> dict[str, Any]:
+        """Fetch every title variant for one Bill.
+
+        The titles endpoint advertises pagination but in practice every
+        bill's full set of titles fits on one page; the implementation
+        still walks ``pagination.next`` defensively.
+        """
+        return self._paginate_sub_endpoint(
+            congress, bill_type, bill_number, "titles", array_key="titles"
+        )
+
+    def get_bill_summaries(
+        self,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+    ) -> dict[str, Any]:
+        """Fetch every CRS-written summary version for one Bill."""
+        return self._paginate_sub_endpoint(
+            congress, bill_type, bill_number, "summaries", array_key="summaries"
+        )
+
+    def _paginate_sub_endpoint(
+        self,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+        sub_path: str,
+        *,
+        array_key: str,
+    ) -> dict[str, Any]:
+        """Walk one Bill sub-endpoint until ``pagination.next`` is absent.
+
+        Returns the final page's payload with ``payload[array_key]``
+        replaced by the concatenation of every page's array. The path is
+        ``/v3/bill/{c}/{t}/{n}/{sub_path}`` with ``bill_type`` canonicalized
+        to lowercase.
+        """
+        bt = bill_type.lower()
+        path = f"/bill/{congress}/{bt}/{bill_number}/{sub_path}"
+        offset = 0
+        merged_array: list[Any] = []
+        merged: dict[str, Any] = {}
+        while True:
+            payload = self._get(path, params={"limit": BILL_SUB_PAGE_SIZE, "offset": offset})
+            page = payload.get(array_key, [])
+            if isinstance(page, list):
+                merged_array.extend(page)
+            merged = payload
+            if "next" not in payload.get("pagination", {}):
+                break
+            if not isinstance(page, list) or not page:
+                # Defensive: server claims "next" but page is empty/wrong shape.
+                break
+            offset += BILL_SUB_PAGE_SIZE
+        return {**merged, array_key: merged_array}
 
     # -- internals -----------------------------------------------------------
 

--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -1189,7 +1189,10 @@ def scrape_bills_enrich_command(
         int,
         typer.Option(
             "--limit",
-            help="Cap on bills enriched. With --db (no --bill-ids), required.",
+            help=(
+                "Cap on bills enriched. Defaults to 25 in --db auto-select mode; "
+                "applied to --bill-ids count when given."
+            ),
         ),
     ] = DEFAULT_ENRICH_AUTO_LIMIT,
     show_progress: Annotated[
@@ -1229,7 +1232,7 @@ def scrape_bills_enrich_command(
         bill_keys=keys,
         sections=parsed_sections,
         storage_dir=storage_dir,
-        limit=limit if bill_ids is None else None,
+        limit=limit,
         show_progress=show_progress,
     )
 

--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -82,6 +82,16 @@ DEFAULT_BILL_CONGRESSES = (117, 118, 119)
 #: for the ``/bills/{...}/{bill_type}/...`` URL segment.
 DEFAULT_BILL_TYPES = ("hr", "hres", "hjres", "hconres", "s", "sres", "sjres", "sconres")
 
+#: Tier-2 sub-endpoint names that ``concord scrape bills enrich`` defaults to.
+DEFAULT_BILL_SECTIONS = ("cosponsors", "actions", "subjects", "titles", "summaries")
+
+#: Default cap on the auto-selected enrichment batch when --bill-ids is
+#: not given. Operators tweak via ``--limit N``.
+DEFAULT_ENRICH_AUTO_LIMIT = 25
+
+#: Expected number of dash-separated parts in a ``--bill-ids`` token.
+_BILL_ID_PART_COUNT = 3
+
 
 class Progress:
     """Progress lines that overwrite themselves on a TTY.
@@ -525,6 +535,83 @@ def _run_scrape_bills(
     return stats.bills_written
 
 
+def _autoselect_unenriched_bills(
+    db_path: Path,
+    *,
+    limit: int,
+) -> list[tuple[int, str, int]]:
+    """Return ``[(congress, bill_type, bill_number)]`` for un-enriched bills, newest first."""
+    if not db_path.exists():
+        typer.echo(f"error: database not found: {db_path}", err=True)
+        raise typer.Exit(code=2)
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.execute(
+            "SELECT congress, bill_type, bill_number FROM bills "
+            "WHERE cosponsors_fetched_at IS NULL "
+            "ORDER BY (introduced_date IS NULL), introduced_date DESC, "
+            "         congress DESC, bill_number ASC "
+            "LIMIT ?",
+            (limit,),
+        )
+        return [(int(c), str(t), int(n)) for c, t, n in cursor.fetchall()]
+    finally:
+        conn.close()
+
+
+def _run_scrape_bills_enrich(
+    *,
+    bill_keys: list[tuple[int, str, int]],
+    sections: list[str],
+    storage_dir: Path,
+    limit: int | None,
+    show_progress: bool,
+) -> int:
+    from .api import ApiError
+    from .scraper import bills as bills_scraper
+
+    try:
+        api_client = Client()
+    except ApiError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    progress = Progress(enabled=show_progress)
+
+    def _on_progress(event: bills_scraper.EnrichProgressEvent) -> None:
+        c, t, n = event.bill_key
+        suffix = ""
+        if event.partial_failures:
+            suffix = f" (failed: {', '.join(event.partial_failures)})"
+        progress.update(
+            f"  {c}-{t}-{n}  +{event.sections_written}/{len(sections)} sections{suffix}"
+        )
+
+    try:
+        with api_client:
+            stats = bills_scraper.scrape_enrichment(
+                client=api_client,
+                bill_keys=bill_keys,
+                storage_dir=storage_dir,
+                fetched_at=datetime.now(UTC),
+                sections=sections,
+                limit=limit,
+                progress=_on_progress if show_progress else None,
+            )
+    finally:
+        progress.commit()
+
+    typer.echo(
+        f"Enriched {stats.bills_enriched} bill(s); "
+        f"wrote {stats.snapshots_written} snapshot(s) to {storage_dir}"
+        + (f" ({stats.section_failures} section failure(s))" if stats.section_failures else "")
+        + "."
+    )
+    return stats.snapshots_written
+
+
 def _run_load_bills(
     *,
     storage_dir: Path,
@@ -945,8 +1032,65 @@ def run_members_command(
 # ---------------------------------------------------------------------------
 
 
-@scrape_app.command("bills")
+scrape_bills_app = typer.Typer(
+    no_args_is_help=False,
+    add_completion=False,
+    pretty_exceptions_enable=False,
+    help=(
+        "Stage 0 — scrape Bills. Without a sub-command, snapshots Bill identity "
+        "records into bills.jsonl. Use `enrich` for tier-2 sub-endpoints."
+    ),
+    invoke_without_command=True,
+)
+scrape_app.add_typer(scrape_bills_app, name="bills")
+
+
+def _parse_bill_ids(raw: str) -> list[tuple[int, str, int]]:
+    """Parse ``--bill-ids 119-hr-1,119-hr-22`` into ``[(119,"hr",1), ...]``."""
+    out: list[tuple[int, str, int]] = []
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        bits = token.split("-")
+        if len(bits) != _BILL_ID_PART_COUNT:
+            raise typer.BadParameter(
+                f"bad --bill-ids token {token!r}; expected '<congress>-<type>-<number>'"
+            )
+        try:
+            congress = int(bits[0])
+            bill_type = bits[1].lower()
+            bill_number = int(bits[2])
+        except ValueError as exc:
+            raise typer.BadParameter(f"bad --bill-ids token {token!r}: {exc}") from exc
+        if bill_type not in DEFAULT_BILL_TYPES:
+            raise typer.BadParameter(
+                f"unknown bill type in {token!r}: {bill_type}. Valid: "
+                + ", ".join(DEFAULT_BILL_TYPES)
+            )
+        out.append((congress, bill_type, bill_number))
+    if not out:
+        raise typer.BadParameter(f"no values parsed from --bill-ids {raw!r}")
+    return out
+
+
+def _parse_sections(raw: str) -> list[str]:
+    """Parse ``--sections cosponsors,actions`` into a validated list."""
+    from .scraper.bills import BILL_ENRICHMENT_SECTIONS
+
+    parsed = _parse_csv(raw, name="sections", coerce=str.lower)
+    unknown = [s for s in parsed if s not in BILL_ENRICHMENT_SECTIONS]
+    if unknown:
+        raise typer.BadParameter(
+            f"unknown section(s): {', '.join(unknown)}. "
+            f"Valid: {', '.join(BILL_ENRICHMENT_SECTIONS)}"
+        )
+    return parsed
+
+
+@scrape_bills_app.callback(invoke_without_command=True)
 def scrape_bills_command(
+    ctx: typer.Context,
     congresses: Annotated[
         str,
         typer.Option(
@@ -991,6 +1135,10 @@ def scrape_bills_command(
     Re-running appends new snapshots; the Stage 1 loader projects the
     latest per key into SQLite.
     """
+    # When the user invoked a sub-command (e.g. `scrape bills enrich`),
+    # let the sub-command run instead of the basic scrape.
+    if ctx.invoked_subcommand is not None:
+        return
     parsed_congresses = _parse_congresses(congresses)
     parsed_types = _parse_bill_types(bill_types)
     _run_scrape_bills(
@@ -998,6 +1146,90 @@ def scrape_bills_command(
         bill_types=parsed_types,
         storage_dir=storage_dir,
         limit=limit,
+        show_progress=show_progress,
+    )
+
+
+@scrape_bills_app.command("enrich")
+def scrape_bills_enrich_command(
+    bill_ids: Annotated[
+        str | None,
+        typer.Option(
+            "--bill-ids",
+            help=(
+                "Comma-separated bill IDs like '119-hr-1,119-hr-22'. "
+                "Required when --db is not provided."
+            ),
+        ),
+    ] = None,
+    sections: Annotated[
+        str,
+        typer.Option(
+            "--sections",
+            help="Comma-separated sub-endpoint sections to fetch.",
+        ),
+    ] = ",".join(DEFAULT_BILL_SECTIONS),
+    storage_dir: Annotated[
+        Path,
+        typer.Option(
+            "--storage-dir",
+            help="Directory holding the bill_<section>.jsonl files.",
+        ),
+    ] = DEFAULT_BILLS_STORAGE_DIR,
+    db_path: Annotated[
+        Path | None,
+        typer.Option(
+            "--db",
+            help=(
+                "SQLite DB used to auto-select un-enriched bills when --bill-ids is not provided."
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option(
+            "--limit",
+            help="Cap on bills enriched. With --db (no --bill-ids), required.",
+        ),
+    ] = DEFAULT_ENRICH_AUTO_LIMIT,
+    show_progress: Annotated[
+        bool,
+        typer.Option(
+            "--progress/--no-progress",
+            help="Print a stderr line per bill enriched.",
+        ),
+    ] = True,
+) -> None:
+    """Fetch tier-2 sub-endpoints for selected Bills.
+
+    Either pass ``--bill-ids`` (explicit selection) or ``--db`` (auto-
+    selects bills with ``cosponsors_fetched_at IS NULL`` ordered by
+    ``introduced_date DESC``, capped by ``--limit``).
+    """
+    parsed_sections = _parse_sections(sections)
+    if bill_ids is None and db_path is None:
+        typer.echo(
+            "error: provide --bill-ids or --db (or both); neither was set",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    if bill_ids is not None:
+        keys = _parse_bill_ids(bill_ids)
+    elif db_path is not None:
+        keys = _autoselect_unenriched_bills(db_path, limit=limit)
+        if not keys:
+            typer.echo(f"No un-enriched bills found in {db_path}; nothing to do.")
+            return
+    else:
+        # Unreachable: the earlier guard already exited with code 2.
+        return
+
+    _run_scrape_bills_enrich(
+        bill_keys=keys,
+        sections=parsed_sections,
+        storage_dir=storage_dir,
+        limit=limit if bill_ids is None else None,
         show_progress=show_progress,
     )
 

--- a/src/concord/models.py
+++ b/src/concord/models.py
@@ -587,6 +587,151 @@ class BillSnapshot(BaseModel):
     payload: dict[str, Any]
 
 
+# ---------------------------------------------------------------------------
+# Bill tier-2 entities (Phase 2b)
+# ---------------------------------------------------------------------------
+
+
+class Cosponsor(BaseModel):
+    """One Member's M:N edge to a Bill, as recorded on the Bill's cosponsors list.
+
+    ``sponsorship_withdrawn_date`` is non-NULL for Members who removed
+    their name after signing on. ``is_original_cosponsor`` is True for
+    cosponsors recorded on the day of introduction.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    bioguide_id: str
+    sponsorship_date: str | None = None
+    sponsorship_withdrawn_date: str | None = None
+    is_original_cosponsor: bool = False
+
+
+class BillAction(BaseModel):
+    """One event in a Bill's legislative history."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    action_date: str
+    action_text: str
+    action_code: str | None = None
+    source_system: str | None = None
+
+
+class BillSubject(BaseModel):
+    """One CRS-assigned legislative subject for a Bill.
+
+    A thin wrapper around a single string — modeled so the loader and
+    storage layer can speak the same noun for the row.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    name: str
+
+
+class BillTitle(BaseModel):
+    """One title variant for a Bill (display, official, short, popular)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    title_type: str
+    title_text: str
+    chamber: str | None = None
+
+
+class BillSummary(BaseModel):
+    """One CRS-written summary version for a Bill."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    version_code: str
+    action_date: str | None = None
+    action_desc: str | None = None
+    summary_text: str
+
+
+def parse_cosponsor(payload: dict[str, Any]) -> Cosponsor | None:
+    """Project one ``/cosponsors`` row into a :class:`Cosponsor`.
+
+    Returns ``None`` for rows without a Bioguide ID — the cosponsor row
+    can't be linked without one, and the API has been known to emit
+    placeholder entries for unfilled vacancies.
+    """
+    bioguide = payload.get("bioguideId")
+    if not isinstance(bioguide, str) or not bioguide:
+        return None
+    raw_original = payload.get("isOriginalCosponsor")
+    if isinstance(raw_original, bool):
+        is_original = raw_original
+    elif isinstance(raw_original, str):
+        is_original = raw_original.lower() in {"true", "y", "yes", "1"}
+    else:
+        is_original = False
+    return Cosponsor(
+        bioguide_id=bioguide,
+        sponsorship_date=payload.get("sponsorshipDate"),
+        sponsorship_withdrawn_date=payload.get("sponsorshipWithdrawnDate"),
+        is_original_cosponsor=is_original,
+    )
+
+
+def parse_bill_action(payload: dict[str, Any]) -> BillAction | None:
+    """Project one ``/actions`` row into a :class:`BillAction`.
+
+    Returns ``None`` if the row lacks an ``actionDate`` or ``text`` — both
+    are non-nullable on the column.
+    """
+    action_date = payload.get("actionDate")
+    text = payload.get("text")
+    if not action_date or not text:
+        return None
+    source_raw = payload.get("sourceSystem")
+    source_system = source_raw.get("name") if isinstance(source_raw, dict) else None
+    return BillAction(
+        action_date=str(action_date),
+        action_text=str(text),
+        action_code=payload.get("actionCode"),
+        source_system=source_system,
+    )
+
+
+def parse_bill_subject(payload: dict[str, Any]) -> BillSubject | None:
+    """Project one ``legislativeSubjects`` row into a :class:`BillSubject`."""
+    name = payload.get("name")
+    if not isinstance(name, str) or not name:
+        return None
+    return BillSubject(name=name)
+
+
+def parse_bill_title(payload: dict[str, Any]) -> BillTitle | None:
+    """Project one ``/titles`` row into a :class:`BillTitle`."""
+    title_type = payload.get("titleType")
+    title_text = payload.get("title")
+    if not title_type or not title_text:
+        return None
+    return BillTitle(
+        title_type=str(title_type),
+        title_text=str(title_text),
+        chamber=payload.get("chamberName") or payload.get("chamberCode") or None,
+    )
+
+
+def parse_bill_summary(payload: dict[str, Any]) -> BillSummary | None:
+    """Project one ``/summaries`` row into a :class:`BillSummary`."""
+    version_code = payload.get("versionCode")
+    text = payload.get("text")
+    if not version_code or text is None:
+        return None
+    return BillSummary(
+        version_code=str(version_code),
+        action_date=payload.get("actionDate"),
+        action_desc=payload.get("actionDesc"),
+        summary_text=str(text),
+    )
+
+
 def parse_bill(payload: dict[str, Any]) -> Bill:
     """Project a ``/v3/bill/{c}/{t}/{n}`` detail payload into a :class:`Bill`.
 

--- a/src/concord/pipeline/index_bills.py
+++ b/src/concord/pipeline/index_bills.py
@@ -4,7 +4,13 @@ Populates the ``bills_fts`` FTS5 virtual table from the ``bills`` table.
 Truncate-then-repopulate keeps the index in lockstep with the current
 projection without triggers.
 
-Bill search is FTS5-only in Phase 2a; embeddings come in Phase 5 when
+Per Phase 2b, the indexer also pulls a bill's first short title from
+``bill_titles`` and its CRS subjects from ``bill_subjects`` so federated
+search matches on short-title and subject text once enrichment has run.
+Tier-1-only bills are still indexed; their short_title/subjects columns
+are simply empty.
+
+Bill search is FTS5-only in Phase 2a/2b; embeddings come in Phase 5 when
 the ``chunks`` table generalizes to ``source_type='bill'`` per ADR 0008.
 """
 
@@ -34,10 +40,31 @@ def index(*, db_path: Path, limit: int | None = None) -> IndexStats:
         rows = conn.execute(sql).fetchall()
         for row in rows:
             identifier = f"{row['bill_type']} {row['bill_number']}"
+            short_title_row = conn.execute(
+                "SELECT title_text FROM bill_titles "
+                "WHERE bill_id = ? AND title_type LIKE 'Short Title%' "
+                "ORDER BY ord LIMIT 1",
+                (row["bill_id"],),
+            ).fetchone()
+            short_title = short_title_row["title_text"] if short_title_row else ""
+            subjects_row = conn.execute(
+                "SELECT GROUP_CONCAT(subject, ' | ') AS joined "
+                "FROM bill_subjects WHERE bill_id = ?",
+                (row["bill_id"],),
+            ).fetchone()
+            subjects = (subjects_row["joined"] if subjects_row else None) or ""
             conn.execute(
-                "INSERT INTO bills_fts (bill_id, identifier, title, policy_area) "
-                "VALUES (?, ?, ?, ?)",
-                (row["bill_id"], identifier, row["title"], row["policy_area"]),
+                "INSERT INTO bills_fts "
+                "(bill_id, identifier, title, policy_area, short_title, subjects) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    row["bill_id"],
+                    identifier,
+                    row["title"],
+                    row["policy_area"],
+                    short_title,
+                    subjects,
+                ),
             )
         conn.commit()
         return IndexStats(indexed_bills=len(rows))

--- a/src/concord/pipeline/index_bills.py
+++ b/src/concord/pipeline/index_bills.py
@@ -47,9 +47,13 @@ def index(*, db_path: Path, limit: int | None = None) -> IndexStats:
                 (row["bill_id"],),
             ).fetchone()
             short_title = short_title_row["title_text"] if short_title_row else ""
+            # GROUP_CONCAT row order is not guaranteed without an inner
+            # ORDER BY — fix it to alphabetical so a re-index produces
+            # byte-identical bills_fts.subjects content across runs.
             subjects_row = conn.execute(
                 "SELECT GROUP_CONCAT(subject, ' | ') AS joined "
-                "FROM bill_subjects WHERE bill_id = ?",
+                "FROM (SELECT subject FROM bill_subjects WHERE bill_id = ? "
+                "      ORDER BY subject ASC)",
                 (row["bill_id"],),
             ).fetchone()
             subjects = (subjects_row["joined"] if subjects_row else None) or ""

--- a/src/concord/pipeline/load_bills.py
+++ b/src/concord/pipeline/load_bills.py
@@ -5,6 +5,12 @@ into the ``bills`` SQLite table. The natural key is the composite
 ``(congress, bill_type, bill_number)``; the loader keeps the latest
 snapshot per key and UPSERTs one row each.
 
+Phase 2b adds five sibling tier-2 JSONL files (per ADR 0009) — the
+loader reads each when present and projects to its child table,
+stamping the corresponding ``bills.<section>_fetched_at`` column. A
+Bill present in tier-2 snapshots but absent from ``bills.jsonl`` is
+counted as a tier-2 orphan and skipped (it would violate the FK).
+
 Re-running the loader over an unchanged JSONL is a no-op. Re-running
 over a JSONL that gained new snapshots converges the SQL projection to
 the latest-snapshot view.
@@ -14,12 +20,29 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any, NamedTuple
 
-from concord.models import parse_bill
-from concord.scraper.bills import BILLS_JSONL_NAME
+from concord.models import (
+    BillAction,
+    BillSubject,
+    BillSummary,
+    BillTitle,
+    Cosponsor,
+    parse_bill,
+    parse_bill_action,
+    parse_bill_subject,
+    parse_bill_summary,
+    parse_bill_title,
+    parse_cosponsor,
+)
+from concord.scraper.bills import (
+    BILL_ENRICHMENT_SECTIONS,
+    BILLS_JSONL_NAME,
+    enrichment_jsonl_name,
+)
 from concord.storage.sqlite import SqliteStorage
 
 _log = logging.getLogger("concord.pipeline.load_bills")
@@ -31,6 +54,9 @@ class LoadStats(NamedTuple):
     bills_written: int
     snapshots_read: int
     malformed: int
+    tier2_snapshots_read: int = 0
+    tier2_bills_updated: int = 0
+    tier2_orphans_skipped: int = 0
 
 
 def load(
@@ -41,19 +67,64 @@ def load(
 ) -> LoadStats:
     """Project the latest Bill snapshot per key into SQLite.
 
-    Reads ``<storage_dir>/bills.jsonl``. If the file is missing, returns
-    a zeroed :class:`LoadStats` — matching the no-op-on-missing
-    convention set by :mod:`concord.pipeline.load_members`. Stops after
-    ``limit`` bills have been UPSERTed when set.
+    Reads ``<storage_dir>/bills.jsonl`` plus the five tier-2 sibling
+    files when present. If the directory has no files, returns a
+    zeroed :class:`LoadStats`. Stops after ``limit`` bills have been
+    UPSERTed when set — note that ``limit`` applies to the tier-1
+    projection; tier-2 projection runs against every bill present.
     """
-    jsonl_path = storage_dir / BILLS_JSONL_NAME
-    if not jsonl_path.exists():
-        return LoadStats(bills_written=0, snapshots_read=0, malformed=0)
-
-    latest_per_key: dict[tuple[int, str, int], tuple[datetime, dict[str, Any]]] = {}
+    bills_written = 0
     snapshots_read = 0
     malformed = 0
 
+    jsonl_path = storage_dir / BILLS_JSONL_NAME
+    latest_per_key: dict[tuple[int, str, int], tuple[datetime, dict[str, Any]]] = {}
+    if jsonl_path.exists():
+        snapshots_read, malformed = _ingest_tier1(jsonl_path, latest_per_key)
+
+    storage = SqliteStorage(db_path, load_vec=False)
+    try:
+        for (_c, _t, _n), (fetched_at, payload) in latest_per_key.items():
+            try:
+                bill = parse_bill(payload)
+            except Exception as exc:
+                malformed += 1
+                _log.warning("skipping bill after parse failure: %s", exc)
+                continue
+            storage.upsert_bill(bill, fetched_at=fetched_at.isoformat())
+            bills_written += 1
+            if limit is not None and bills_written >= limit:
+                break
+
+        tier2_snapshots_read = 0
+        tier2_bills_updated = 0
+        tier2_orphans_skipped = 0
+        for section in BILL_ENRICHMENT_SECTIONS:
+            t2 = _load_tier2_section(storage_dir, section, storage)
+            tier2_snapshots_read += t2["snapshots_read"]
+            tier2_bills_updated += t2["bills_updated"]
+            tier2_orphans_skipped += t2["orphans_skipped"]
+            malformed += t2["malformed"]
+    finally:
+        storage.close()
+
+    return LoadStats(
+        bills_written=bills_written,
+        snapshots_read=snapshots_read,
+        malformed=malformed,
+        tier2_snapshots_read=tier2_snapshots_read,
+        tier2_bills_updated=tier2_bills_updated,
+        tier2_orphans_skipped=tier2_orphans_skipped,
+    )
+
+
+def _ingest_tier1(
+    jsonl_path: Path,
+    latest_per_key: dict[tuple[int, str, int], tuple[datetime, dict[str, Any]]],
+) -> tuple[int, int]:
+    """Read bills.jsonl, populate ``latest_per_key`` in place. Return (read, malformed)."""
+    snapshots_read = 0
+    malformed = 0
     with jsonl_path.open("r", encoding="utf-8") as fh:
         for line_no, raw in enumerate(fh, 1):
             line = raw.strip()
@@ -77,34 +148,168 @@ def load(
                 malformed += 1
                 _log.warning("skipping line %d with bad envelope: %s", line_no, exc)
                 continue
-
             cell = (congress, bill_type, bill_number)
             current = latest_per_key.get(cell)
             if current is None or fetched_at > current[0]:
                 latest_per_key[cell] = (fetched_at, payload)
+    return snapshots_read, malformed
 
-    bills_written = 0
-    storage = SqliteStorage(db_path, load_vec=False)
-    try:
-        for (_c, _t, _n), (fetched_at, payload) in latest_per_key.items():
-            try:
-                bill = parse_bill(payload)
-            except Exception as exc:
-                malformed += 1
-                _log.warning("skipping bill after parse failure: %s", exc)
+
+def _load_tier2_section(
+    storage_dir: Path,
+    section: str,
+    storage: SqliteStorage,
+) -> dict[str, int]:
+    """Project one tier-2 JSONL file into its child table.
+
+    Returns a counters dict with ``snapshots_read``, ``bills_updated``,
+    ``orphans_skipped``, ``malformed``. A missing file is a no-op.
+    """
+    counters = {
+        "snapshots_read": 0,
+        "bills_updated": 0,
+        "orphans_skipped": 0,
+        "malformed": 0,
+    }
+    path = storage_dir / enrichment_jsonl_name(section)
+    if not path.exists():
+        return counters
+
+    latest: dict[str, tuple[datetime, dict[str, Any]]] = {}
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, raw in enumerate(fh, 1):
+            line = raw.strip()
+            if not line:
                 continue
-            storage.upsert_bill(bill, fetched_at=fetched_at.isoformat())
-            bills_written += 1
-            if limit is not None and bills_written >= limit:
-                break
-    finally:
-        storage.close()
+            counters["snapshots_read"] += 1
+            try:
+                envelope = json.loads(line)
+                key = envelope["key"]
+                congress = int(key["congress"])
+                bill_type = str(key["bill_type"]).lower()
+                bill_number = int(key["bill_number"])
+                fetched_at = datetime.fromisoformat(envelope["fetched_at"])
+                payload = envelope["payload"]
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                counters["malformed"] += 1
+                _log.warning("skipping malformed %s line %d: %s", path.name, line_no, exc)
+                continue
+            bill_id = f"{congress}-{bill_type}-{bill_number}"
+            current = latest.get(bill_id)
+            if current is None or fetched_at > current[0]:
+                latest[bill_id] = (fetched_at, payload)
 
-    return LoadStats(
-        bills_written=bills_written,
-        snapshots_read=snapshots_read,
-        malformed=malformed,
-    )
+    for bill_id, (fetched_at, payload) in latest.items():
+        if storage.get_bill(bill_id) is None:
+            counters["orphans_skipped"] += 1
+            _log.info(
+                "tier-2 orphan: %s in %s but no parent bill row; skipping",
+                bill_id,
+                section,
+            )
+            continue
+        _project_section(storage, section, bill_id, payload, fetched_at.isoformat())
+        counters["bills_updated"] += 1
+    return counters
+
+
+# Per-section projection: extract the array from the payload, parse each
+# row via the model layer, and call the matching storage method.
+def _project_section(
+    storage: SqliteStorage,
+    section: str,
+    bill_id: str,
+    payload: dict[str, Any],
+    fetched_at: str,
+) -> None:
+    _SECTION_PROJECTORS[section](storage, bill_id, payload, fetched_at)
+
+
+def _project_cosponsors(
+    storage: SqliteStorage, bill_id: str, payload: dict[str, Any], fetched_at: str
+) -> None:
+    raw = payload.get("cosponsors") or []
+    cosponsors: list[Cosponsor] = []
+    seen_bioguides: set[str] = set()
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        parsed = parse_cosponsor(row)
+        if parsed is None or parsed.bioguide_id in seen_bioguides:
+            continue
+        seen_bioguides.add(parsed.bioguide_id)
+        cosponsors.append(parsed)
+    storage.replace_bill_cosponsors(bill_id, cosponsors, fetched_at=fetched_at)
+
+
+def _project_actions(
+    storage: SqliteStorage, bill_id: str, payload: dict[str, Any], fetched_at: str
+) -> None:
+    raw = payload.get("actions") or []
+    actions: list[BillAction] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        parsed = parse_bill_action(row)
+        if parsed is None:
+            continue
+        actions.append(parsed)
+    storage.replace_bill_actions(bill_id, actions, fetched_at=fetched_at)
+
+
+def _project_subjects(
+    storage: SqliteStorage, bill_id: str, payload: dict[str, Any], fetched_at: str
+) -> None:
+    subjects_obj = payload.get("subjects") or {}
+    raw = subjects_obj.get("legislativeSubjects", []) if isinstance(subjects_obj, dict) else []
+    subjects: list[BillSubject] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        parsed = parse_bill_subject(row)
+        if parsed is None:
+            continue
+        subjects.append(parsed)
+    storage.replace_bill_subjects(bill_id, subjects, fetched_at=fetched_at)
+
+
+def _project_titles(
+    storage: SqliteStorage, bill_id: str, payload: dict[str, Any], fetched_at: str
+) -> None:
+    raw = payload.get("titles") or []
+    titles: list[BillTitle] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        parsed = parse_bill_title(row)
+        if parsed is None:
+            continue
+        titles.append(parsed)
+    storage.replace_bill_titles(bill_id, titles, fetched_at=fetched_at)
+
+
+def _project_summaries(
+    storage: SqliteStorage, bill_id: str, payload: dict[str, Any], fetched_at: str
+) -> None:
+    raw = payload.get("summaries") or []
+    summaries: list[BillSummary] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        parsed = parse_bill_summary(row)
+        if parsed is None:
+            continue
+        summaries.append(parsed)
+    storage.replace_bill_summaries(bill_id, summaries, fetched_at=fetched_at)
+
+
+_SECTION_PROJECTORS: dict[str, Callable[[SqliteStorage, str, dict[str, Any], str], None]] = {
+    "cosponsors": _project_cosponsors,
+    "actions": _project_actions,
+    "subjects": _project_subjects,
+    "titles": _project_titles,
+    "summaries": _project_summaries,
+}
 
 
 __all__ = ["LoadStats", "load"]

--- a/src/concord/scraper/bills.py
+++ b/src/concord/scraper/bills.py
@@ -1,28 +1,30 @@
 """Stage 0 — Bills scraper.
 
-Walks ``api.congress.gov``'s two Bill endpoints to build the canonical
-identity record per Bill:
+Walks ``api.congress.gov``'s seven Bill endpoints to build the canonical
+identity record per Bill plus the five tier-2 enrichment streams:
 
 1. ``/v3/bill/{congress}/{bill_type}`` — list endpoint. Stubs only;
    used solely to discover Bill numbers. Not persisted.
 2. ``/v3/bill/{c}/{t}/{n}`` — detail endpoint. One ADR 0006 snapshot
    envelope per response is appended to ``data/bills.jsonl``.
-
-Per ADR 0009 the bills.jsonl file holds only the Tier 1 identity
-snapshots — Phase 2b will add five sibling JSONL files for the
-sub-endpoints (cosponsors, actions, subjects, titles, summaries) via a
-second entry point ``scrape_enrichment`` added to this same module.
+3. ``/v3/bill/{c}/{t}/{n}/{section}`` for each of cosponsors, actions,
+   subjects, titles, summaries — one envelope per (bill, section) is
+   appended to the corresponding ``data/bill_<section>.jsonl`` file
+   per ADR 0009.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable, Iterable
 from datetime import datetime
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 from concord.api import Client
+
+_log = logging.getLogger("concord.scraper.bills")
 
 #: Default Bill type codes scraped when the caller doesn't pass
 #: ``bill_types``. Order matches the API documentation; chamber-grouped
@@ -40,6 +42,21 @@ DEFAULT_BILL_TYPES: tuple[str, ...] = (
 
 #: Canonical filename inside the storage directory.
 BILLS_JSONL_NAME = "bills.jsonl"
+
+#: Tier-2 sub-endpoint names. Each maps to its own ``bill_<section>.jsonl``
+#: under the storage directory per ADR 0009.
+BILL_ENRICHMENT_SECTIONS: tuple[str, ...] = (
+    "cosponsors",
+    "actions",
+    "subjects",
+    "titles",
+    "summaries",
+)
+
+
+def enrichment_jsonl_name(section: str) -> str:
+    """Return the canonical JSONL filename for one tier-2 section."""
+    return f"bill_{section}.jsonl"
 
 
 class ScrapeProgressEvent(NamedTuple):
@@ -143,10 +160,147 @@ def scrape_basic(
     return ScrapeStats(bills_written=written, bills_seen=seen)
 
 
+class EnrichProgressEvent(NamedTuple):
+    """Emitted by :func:`scrape_enrichment` once per Bill.
+
+    ``sections_written`` is the count of sub-endpoints that wrote a
+    snapshot successfully; ``partial_failures`` records the sections
+    that raised. A run-level catastrophic failure surfaces as an
+    exception, not a progress event.
+    """
+
+    bill_key: tuple[int, str, int]
+    sections_written: int
+    partial_failures: tuple[str, ...]
+
+
+class EnrichStats(NamedTuple):
+    """Outcome of one :func:`scrape_enrichment` invocation."""
+
+    bills_enriched: int
+    snapshots_written: int
+    section_failures: int
+
+
+_ENRICHMENT_FETCHERS: dict[str, str] = {
+    "cosponsors": "get_bill_cosponsors",
+    "actions": "get_bill_actions",
+    "subjects": "get_bill_subjects",
+    "titles": "get_bill_titles",
+    "summaries": "get_bill_summaries",
+}
+
+
+def scrape_enrichment(
+    *,
+    client: Client,
+    bill_keys: Iterable[tuple[int, str, int]],
+    storage_dir: Path,
+    fetched_at: datetime,
+    sections: Iterable[str] | None = None,
+    limit: int | None = None,
+    progress: Callable[[EnrichProgressEvent], None] | None = None,
+) -> EnrichStats:
+    """Append one ADR 0006 envelope per (bill, section) to ``data/bill_<section>.jsonl``.
+
+    For each bill in ``bill_keys``, fetch each requested ``section`` from
+    its dedicated sub-endpoint and write one envelope per (bill, section)
+    pair. Per ADR 0009, each section has its own JSONL file under
+    ``storage_dir``; failures in one section don't prevent the others
+    from being written.
+
+    The output files are opened in append mode; the storage directory is
+    created if missing. Re-running over the same bills appends new
+    snapshots — the loader projects the latest per (bill_id, section)
+    into SQLite.
+    """
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    requested_sections = tuple(sections) if sections is not None else BILL_ENRICHMENT_SECTIONS
+    for s in requested_sections:
+        if s not in _ENRICHMENT_FETCHERS:
+            raise ValueError(
+                f"unknown enrichment section {s!r}; "
+                f"expected one of {', '.join(BILL_ENRICHMENT_SECTIONS)}"
+            )
+
+    iso = fetched_at.isoformat()
+    # Open every requested section's file once; the per-bill loop writes
+    # to whichever it just fetched.
+    handles: dict[str, Any] = {}
+    try:
+        for section in requested_sections:
+            handles[section] = (storage_dir / enrichment_jsonl_name(section)).open(
+                "a", encoding="utf-8"
+            )
+
+        bills_enriched = 0
+        snapshots_written = 0
+        section_failures = 0
+        for bill_key in bill_keys:
+            congress, bill_type, bill_number = bill_key
+            bt = bill_type.lower()
+            sections_written = 0
+            partial: list[str] = []
+            for section in requested_sections:
+                method = getattr(client, _ENRICHMENT_FETCHERS[section])
+                try:
+                    payload = method(congress, bt, bill_number)
+                except Exception as exc:
+                    _log.warning(
+                        "enrichment fetch failed for %s/%s/%s/%s: %s",
+                        congress,
+                        bt,
+                        bill_number,
+                        section,
+                        exc,
+                    )
+                    partial.append(section)
+                    section_failures += 1
+                    continue
+                envelope = {
+                    "fetched_at": iso,
+                    "key": {
+                        "congress": congress,
+                        "bill_type": bt,
+                        "bill_number": bill_number,
+                    },
+                    "payload": payload,
+                }
+                handles[section].write(json.dumps(envelope, ensure_ascii=False))
+                handles[section].write("\n")
+                snapshots_written += 1
+                sections_written += 1
+            bills_enriched += 1
+            if progress is not None:
+                progress(
+                    EnrichProgressEvent(
+                        bill_key=(congress, bt, bill_number),
+                        sections_written=sections_written,
+                        partial_failures=tuple(partial),
+                    )
+                )
+            if limit is not None and bills_enriched >= limit:
+                break
+    finally:
+        for fh in handles.values():
+            fh.close()
+
+    return EnrichStats(
+        bills_enriched=bills_enriched,
+        snapshots_written=snapshots_written,
+        section_failures=section_failures,
+    )
+
+
 __all__ = [
     "BILLS_JSONL_NAME",
+    "BILL_ENRICHMENT_SECTIONS",
     "DEFAULT_BILL_TYPES",
+    "EnrichProgressEvent",
+    "EnrichStats",
     "ScrapeProgressEvent",
     "ScrapeStats",
+    "enrichment_jsonl_name",
     "scrape_basic",
+    "scrape_enrichment",
 ]

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -30,7 +30,17 @@ from typing import Any
 
 import sqlite_vec  # type: ignore[import-untyped]
 
-from concord.models import Bill, Member, Proceeding, Term
+from concord.models import (
+    Bill,
+    BillAction,
+    BillSubject,
+    BillSummary,
+    BillTitle,
+    Cosponsor,
+    Member,
+    Proceeding,
+    Term,
+)
 
 # Columns in the exact order they appear in the INSERT statement. Keeping
 # this list in one place makes it easy to add a column later: extend here,
@@ -189,6 +199,11 @@ CREATE TABLE IF NOT EXISTS bills (
     latest_action_text   TEXT,
     update_date          TEXT NOT NULL,
     fetched_at           TEXT NOT NULL,
+    cosponsors_fetched_at TEXT,
+    actions_fetched_at    TEXT,
+    subjects_fetched_at   TEXT,
+    titles_fetched_at     TEXT,
+    summaries_fetched_at  TEXT,
     UNIQUE (congress, bill_type, bill_number)
 );
 
@@ -201,11 +216,65 @@ CREATE INDEX IF NOT EXISTS idx_bills_policy_area
 CREATE INDEX IF NOT EXISTS idx_bills_congress
     ON bills (congress);
 
+-- Tier-2 child tables (Phase 2b). Each row points back to bills via
+-- bill_id with ON DELETE CASCADE so wiping a Bill takes its enrichment
+-- with it. bioguide_id on bill_cosponsors is bare TEXT (no FK) so the
+-- table doesn't depend on Phase 1 having indexed every cosponsoring
+-- Member.
+CREATE TABLE IF NOT EXISTS bill_cosponsors (
+    bill_id                     TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
+    bioguide_id                 TEXT NOT NULL,
+    sponsorship_date            TEXT,
+    sponsorship_withdrawn_date  TEXT,
+    is_original_cosponsor       INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (bill_id, bioguide_id)
+);
+CREATE INDEX IF NOT EXISTS idx_bill_cosponsors_bioguide
+    ON bill_cosponsors (bioguide_id);
+
+CREATE TABLE IF NOT EXISTS bill_actions (
+    bill_id        TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
+    ord            INTEGER NOT NULL,
+    action_date    TEXT NOT NULL,
+    action_text    TEXT NOT NULL,
+    action_code    TEXT,
+    source_system  TEXT,
+    PRIMARY KEY (bill_id, ord)
+);
+CREATE INDEX IF NOT EXISTS idx_bill_actions_date
+    ON bill_actions (action_date DESC);
+
+CREATE TABLE IF NOT EXISTS bill_subjects (
+    bill_id  TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
+    subject  TEXT NOT NULL,
+    PRIMARY KEY (bill_id, subject)
+);
+
+CREATE TABLE IF NOT EXISTS bill_titles (
+    bill_id     TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
+    ord         INTEGER NOT NULL,
+    title_type  TEXT NOT NULL,
+    title_text  TEXT NOT NULL,
+    chamber     TEXT,
+    PRIMARY KEY (bill_id, ord)
+);
+
+CREATE TABLE IF NOT EXISTS bill_summaries (
+    bill_id        TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
+    version_code   TEXT NOT NULL,
+    action_date    TEXT,
+    action_desc    TEXT,
+    summary_text   TEXT NOT NULL,
+    PRIMARY KEY (bill_id, version_code)
+);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS bills_fts USING fts5(
     bill_id UNINDEXED,
     identifier,
     title,
     policy_area,
+    short_title,
+    subjects,
     tokenize = 'porter'
 );
 """
@@ -270,6 +339,21 @@ _BILL_COLUMNS: tuple[str, ...] = (
     "fetched_at",
 )
 
+# The five *_fetched_at columns are upserted only when their tier-2
+# loader has new snapshots to flush; the parent bills row uses the
+# columns above. Listed for use by per-section UPDATE statements.
+BILL_TIER2_SECTIONS: tuple[str, ...] = (
+    "cosponsors",
+    "actions",
+    "subjects",
+    "titles",
+    "summaries",
+)
+
+# UPSERT on the parent row. The five *_fetched_at columns are *not*
+# touched here — they're owned by the tier-2 loaders, and clobbering
+# them on every tier-1 upsert would reset the "enriched" state every
+# time `concord load bills` runs. Keep them under per-section UPDATEs.
 _BILL_UPSERT_SQL = (
     "INSERT INTO bills ("
     + ", ".join(_BILL_COLUMNS)
@@ -278,6 +362,60 @@ _BILL_UPSERT_SQL = (
     + ") ON CONFLICT(bill_id) DO UPDATE SET "
     + ", ".join(f"{col} = excluded.{col}" for col in _BILL_COLUMNS if col != "bill_id")
 )
+
+# Per-child column tuples — used to generate INSERT SQL and to project
+# pydantic models into row tuples.
+_COSPONSOR_COLUMNS: tuple[str, ...] = (
+    "bill_id",
+    "bioguide_id",
+    "sponsorship_date",
+    "sponsorship_withdrawn_date",
+    "is_original_cosponsor",
+)
+
+_ACTION_COLUMNS: tuple[str, ...] = (
+    "bill_id",
+    "ord",
+    "action_date",
+    "action_text",
+    "action_code",
+    "source_system",
+)
+
+_SUBJECT_COLUMNS: tuple[str, ...] = ("bill_id", "subject")
+
+_TITLE_COLUMNS: tuple[str, ...] = (
+    "bill_id",
+    "ord",
+    "title_type",
+    "title_text",
+    "chamber",
+)
+
+_SUMMARY_COLUMNS: tuple[str, ...] = (
+    "bill_id",
+    "version_code",
+    "action_date",
+    "action_desc",
+    "summary_text",
+)
+
+
+def _insert_sql(table: str, columns: tuple[str, ...]) -> str:
+    return (
+        f"INSERT INTO {table} ("
+        + ", ".join(columns)
+        + ") VALUES ("
+        + ", ".join("?" for _ in columns)
+        + ")"
+    )
+
+
+_COSPONSOR_INSERT_SQL = _insert_sql("bill_cosponsors", _COSPONSOR_COLUMNS)
+_ACTION_INSERT_SQL = _insert_sql("bill_actions", _ACTION_COLUMNS)
+_SUBJECT_INSERT_SQL = _insert_sql("bill_subjects", _SUBJECT_COLUMNS)
+_TITLE_INSERT_SQL = _insert_sql("bill_titles", _TITLE_COLUMNS)
+_SUMMARY_INSERT_SQL = _insert_sql("bill_summaries", _SUMMARY_COLUMNS)
 
 # Vec-only schema. Only created when load_vec=True.
 _VEC_SCHEMA = """
@@ -504,6 +642,224 @@ class SqliteStorage:
         )
         row: sqlite3.Row | None = cursor.fetchone()
         return row
+
+    # -- Bills tier-2 child tables (Phase 2b) -----------------------------
+
+    def replace_bill_cosponsors(
+        self,
+        bill_id: str,
+        cosponsors: Sequence[Cosponsor],
+        *,
+        fetched_at: str,
+    ) -> None:
+        """DELETE-then-INSERT every Cosponsor for one bill_id; stamp the fetched_at column.
+
+        Idempotent: re-running with the same set produces the same final
+        state. Safe to call for a Bill not in the ``bills`` table — the
+        FK will block the INSERT before any rows are written; callers
+        should filter out unknown ``bill_id`` before invoking.
+        """
+        try:
+            self._conn.execute("BEGIN")
+            self._conn.execute("DELETE FROM bill_cosponsors WHERE bill_id = ?", (bill_id,))
+            if cosponsors:
+                self._conn.executemany(
+                    _COSPONSOR_INSERT_SQL,
+                    [
+                        (
+                            bill_id,
+                            c.bioguide_id,
+                            c.sponsorship_date,
+                            c.sponsorship_withdrawn_date,
+                            1 if c.is_original_cosponsor else 0,
+                        )
+                        for c in cosponsors
+                    ],
+                )
+            self._conn.execute(
+                "UPDATE bills SET cosponsors_fetched_at = ? WHERE bill_id = ?",
+                (fetched_at, bill_id),
+            )
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+
+    def replace_bill_actions(
+        self,
+        bill_id: str,
+        actions: Sequence[BillAction],
+        *,
+        fetched_at: str,
+    ) -> None:
+        """DELETE-then-INSERT every BillAction for one bill_id; stamp the column."""
+        try:
+            self._conn.execute("BEGIN")
+            self._conn.execute("DELETE FROM bill_actions WHERE bill_id = ?", (bill_id,))
+            if actions:
+                self._conn.executemany(
+                    _ACTION_INSERT_SQL,
+                    [
+                        (
+                            bill_id,
+                            i,
+                            a.action_date,
+                            a.action_text,
+                            a.action_code,
+                            a.source_system,
+                        )
+                        for i, a in enumerate(actions)
+                    ],
+                )
+            self._conn.execute(
+                "UPDATE bills SET actions_fetched_at = ? WHERE bill_id = ?",
+                (fetched_at, bill_id),
+            )
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+
+    def replace_bill_subjects(
+        self,
+        bill_id: str,
+        subjects: Sequence[BillSubject],
+        *,
+        fetched_at: str,
+    ) -> None:
+        """DELETE-then-INSERT every BillSubject for one bill_id; stamp the column.
+
+        Duplicate ``name`` values in the input are dedup'd before INSERT
+        so the per-row PK (``bill_id, subject``) doesn't trip.
+        """
+        seen: set[str] = set()
+        deduped: list[BillSubject] = []
+        for s in subjects:
+            if s.name in seen:
+                continue
+            seen.add(s.name)
+            deduped.append(s)
+        try:
+            self._conn.execute("BEGIN")
+            self._conn.execute("DELETE FROM bill_subjects WHERE bill_id = ?", (bill_id,))
+            if deduped:
+                self._conn.executemany(
+                    _SUBJECT_INSERT_SQL,
+                    [(bill_id, s.name) for s in deduped],
+                )
+            self._conn.execute(
+                "UPDATE bills SET subjects_fetched_at = ? WHERE bill_id = ?",
+                (fetched_at, bill_id),
+            )
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+
+    def replace_bill_titles(
+        self,
+        bill_id: str,
+        titles: Sequence[BillTitle],
+        *,
+        fetched_at: str,
+    ) -> None:
+        """DELETE-then-INSERT every BillTitle for one bill_id; stamp the column."""
+        try:
+            self._conn.execute("BEGIN")
+            self._conn.execute("DELETE FROM bill_titles WHERE bill_id = ?", (bill_id,))
+            if titles:
+                self._conn.executemany(
+                    _TITLE_INSERT_SQL,
+                    [
+                        (bill_id, i, t.title_type, t.title_text, t.chamber)
+                        for i, t in enumerate(titles)
+                    ],
+                )
+            self._conn.execute(
+                "UPDATE bills SET titles_fetched_at = ? WHERE bill_id = ?",
+                (fetched_at, bill_id),
+            )
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+
+    def replace_bill_summaries(
+        self,
+        bill_id: str,
+        summaries: Sequence[BillSummary],
+        *,
+        fetched_at: str,
+    ) -> None:
+        """DELETE-then-INSERT every BillSummary for one bill_id; stamp the column.
+
+        Duplicate ``version_code`` values in the input are dedup'd; the
+        latest by list order wins.
+        """
+        latest_per_version: dict[str, BillSummary] = {}
+        for s in summaries:
+            latest_per_version[s.version_code] = s
+        try:
+            self._conn.execute("BEGIN")
+            self._conn.execute("DELETE FROM bill_summaries WHERE bill_id = ?", (bill_id,))
+            if latest_per_version:
+                self._conn.executemany(
+                    _SUMMARY_INSERT_SQL,
+                    [
+                        (
+                            bill_id,
+                            s.version_code,
+                            s.action_date,
+                            s.action_desc,
+                            s.summary_text,
+                        )
+                        for s in latest_per_version.values()
+                    ],
+                )
+            self._conn.execute(
+                "UPDATE bills SET summaries_fetched_at = ? WHERE bill_id = ?",
+                (fetched_at, bill_id),
+            )
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+
+    def cosponsors_for_bill(self, bill_id: str) -> list[sqlite3.Row]:
+        cursor = self._conn.execute(
+            "SELECT * FROM bill_cosponsors WHERE bill_id = ? "
+            "ORDER BY is_original_cosponsor DESC, sponsorship_date ASC, bioguide_id ASC",
+            (bill_id,),
+        )
+        return cursor.fetchall()
+
+    def actions_for_bill(self, bill_id: str) -> list[sqlite3.Row]:
+        cursor = self._conn.execute(
+            "SELECT * FROM bill_actions WHERE bill_id = ? ORDER BY ord ASC",
+            (bill_id,),
+        )
+        return cursor.fetchall()
+
+    def subjects_for_bill(self, bill_id: str) -> list[sqlite3.Row]:
+        cursor = self._conn.execute(
+            "SELECT * FROM bill_subjects WHERE bill_id = ? ORDER BY subject ASC",
+            (bill_id,),
+        )
+        return cursor.fetchall()
+
+    def titles_for_bill(self, bill_id: str) -> list[sqlite3.Row]:
+        cursor = self._conn.execute(
+            "SELECT * FROM bill_titles WHERE bill_id = ? ORDER BY ord ASC",
+            (bill_id,),
+        )
+        return cursor.fetchall()
+
+    def summaries_for_bill(self, bill_id: str) -> list[sqlite3.Row]:
+        cursor = self._conn.execute(
+            "SELECT * FROM bill_summaries WHERE bill_id = ? ORDER BY action_date ASC",
+            (bill_id,),
+        )
+        return cursor.fetchall()
 
     # -- introspection ----------------------------------------------------
 

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -834,8 +834,13 @@ class SqliteStorage:
         return cursor.fetchall()
 
     def actions_for_bill(self, bill_id: str) -> list[sqlite3.Row]:
+        # Sort newest-first by date; fall back to scrape-order ord for
+        # same-date ties. Sorting in SQL (not relying on the API's
+        # newest-first order) keeps the UI's reverse-chronological
+        # rendering correct if the upstream order ever flips.
         cursor = self._conn.execute(
-            "SELECT * FROM bill_actions WHERE bill_id = ? ORDER BY ord ASC",
+            "SELECT * FROM bill_actions WHERE bill_id = ? "
+            "ORDER BY (action_date IS NULL), action_date DESC, ord ASC",
             (bill_id,),
         )
         return cursor.fetchall()

--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -23,7 +23,7 @@ only — the other routes don't call OpenAI and don't need protection.
 import re
 import sqlite3
 from collections.abc import Iterator
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -120,6 +120,7 @@ def create_app(
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
     templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+    templates.env.filters["humanize_age"] = humanize_age
     app.state.templates = templates
 
     if _STATIC_DIR.exists():
@@ -453,6 +454,55 @@ def _is_htmx(request: Request) -> bool:
     return request.headers.get("HX-Request", "").lower() == "true"
 
 
+#: Coarse buckets used by :func:`humanize_age`. Order matters: each tuple
+#: is ``(threshold_in_seconds, singular_unit_seconds, unit_name)``; the
+#: first whose threshold the elapsed time crosses determines the unit.
+_AGE_BUCKETS: tuple[tuple[int, int, str], ...] = (
+    (60, 1, "second"),
+    (3600, 60, "minute"),
+    (86_400, 3600, "hour"),
+    (2_592_000, 86_400, "day"),
+    (31_536_000, 2_592_000, "month"),
+    (10**18, 31_536_000, "year"),
+)
+
+#: Threshold (in seconds) below which we collapse to "just now".
+_JUST_NOW_SECONDS = 30
+
+
+def humanize_age(value: str | datetime | None, *, now: datetime | None = None) -> str:
+    """Render an ISO 8601 timestamp as a coarse "N units ago" string.
+
+    Returns ``"just now"`` for ages under 30 seconds, ``"in the future"``
+    for future timestamps (clock skew), and an empty string for ``None``
+    or unparseable input. Used by the Bill profile to label each tier-2
+    section's last-fetched moment.
+    """
+    if value is None or value == "":
+        return ""
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return ""
+    else:
+        parsed = value
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    current = now if now is not None else datetime.now(UTC)
+    delta = (current - parsed).total_seconds()
+    if delta < 0:
+        return "in the future"
+    if delta < _JUST_NOW_SECONDS:
+        return "just now"
+    for threshold, unit_seconds, unit_name in _AGE_BUCKETS:
+        if delta < threshold:
+            count = int(delta // unit_seconds)
+            plural = "" if count == 1 else "s"
+            return f"{count} {unit_name}{plural} ago"
+    return ""
+
+
 def _parse_optional_date(value: str | None) -> date | None:
     if not value:
         return None
@@ -472,4 +522,5 @@ __all__: list[Any] = [
     "SEARCH_PAGE_SIZE",
     "SEARCH_RATE_LIMIT",
     "create_app",
+    "humanize_age",
 ]

--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -342,6 +342,8 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR
         )
         sponsored = search_mod.sponsored_bills_for_member(db, bioguide_id, limit=25)
         sponsored_total = search_mod.count_sponsored_bills_for_member(db, bioguide_id)
+        cosponsored = search_mod.cosponsored_bills_for_member(db, bioguide_id, limit=25)
+        cosponsored_total = search_mod.count_cosponsored_bills_for_member(db, bioguide_id)
         return templates.TemplateResponse(  # type: ignore[no-any-return]
             request,
             "members/profile.html",
@@ -351,6 +353,8 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR
                 "current_term": current_term,
                 "sponsored_bills": sponsored,
                 "sponsored_bills_total": sponsored_total,
+                "cosponsored_bills": cosponsored,
+                "cosponsored_bills_total": cosponsored_total,
             },
         )
 
@@ -410,8 +414,23 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR
                 {"granule_id": f"{congress}/{bt}/{bill_number}"},
                 status_code=404,
             )
+        bill_id = bill["bill_id"]
+        cosponsors = search_mod.cosponsors_for_bill(db, bill_id)
+        actions = search_mod.actions_for_bill(db, bill_id)
+        subjects = search_mod.subjects_for_bill(db, bill_id)
+        titles = search_mod.titles_for_bill(db, bill_id)
+        summaries = search_mod.summaries_for_bill(db, bill_id)
         return templates.TemplateResponse(  # type: ignore[no-any-return]
-            request, "bills/profile.html", {"bill": bill}
+            request,
+            "bills/profile.html",
+            {
+                "bill": bill,
+                "cosponsors": cosponsors,
+                "actions": actions,
+                "subjects": subjects,
+                "titles": titles,
+                "summaries": summaries,
+            },
         )
 
     @app.get("/healthz")

--- a/src/concord/web/search.py
+++ b/src/concord/web/search.py
@@ -646,9 +646,14 @@ def cosponsors_for_bill(db: sqlite3.Connection, bill_id: str) -> list[dict[str, 
 
 
 def actions_for_bill(db: sqlite3.Connection, bill_id: str) -> list[dict[str, Any]]:
-    """Return action rows in reverse-chronological order (latest first)."""
+    """Return action rows newest-first by ``action_date``, ord ASC as tiebreaker.
+
+    We sort in SQL rather than relying on the API's order so the UI stays
+    correct if the upstream flips.
+    """
     rows = db.execute(
-        "SELECT * FROM bill_actions WHERE bill_id = ? ORDER BY ord ASC",
+        "SELECT * FROM bill_actions WHERE bill_id = ? "
+        "ORDER BY (action_date IS NULL), action_date DESC, ord ASC",
         (bill_id,),
     ).fetchall()
     return [dict(r) for r in rows]

--- a/src/concord/web/search.py
+++ b/src/concord/web/search.py
@@ -577,6 +577,115 @@ def count_sponsored_bills_for_member(
     return int(count)
 
 
+def cosponsored_bills_for_member(
+    db: sqlite3.Connection,
+    bioguide_id: str,
+    *,
+    limit: int = 25,
+) -> list[BillHit]:
+    """Return Bills the Member cosponsored, newest introduced first.
+
+    Joins ``bill_cosponsors`` to ``bills`` so the row carries the same
+    columns as :func:`sponsored_bills_for_member`. Empty when no
+    enrichment has run for any of the Member's cosponsorships.
+    """
+    rows = db.execute(
+        """
+        SELECT
+            b.bill_id              AS bill_id,
+            b.congress             AS congress,
+            b.bill_type            AS bill_type,
+            b.bill_number          AS bill_number,
+            b.title                AS title,
+            b.origin_chamber       AS origin_chamber,
+            b.policy_area          AS policy_area,
+            b.latest_action_date   AS latest_action_date,
+            b.sponsor_bioguide_id  AS sponsor_bioguide_id,
+            NULL                   AS sponsor_display_name
+        FROM bills b
+        JOIN bill_cosponsors c ON c.bill_id = b.bill_id
+        WHERE c.bioguide_id = ?
+        ORDER BY (b.introduced_date IS NULL), b.introduced_date DESC,
+                 b.congress DESC, b.bill_number ASC
+        LIMIT ?
+        """,
+        (bioguide_id, limit),
+    ).fetchall()
+    return [_bill_hit_from_row(r) for r in rows]
+
+
+def count_cosponsored_bills_for_member(
+    db: sqlite3.Connection,
+    bioguide_id: str,
+) -> int:
+    (count,) = db.execute(
+        "SELECT COUNT(*) FROM bill_cosponsors WHERE bioguide_id = ?",
+        (bioguide_id,),
+    ).fetchone()
+    return int(count)
+
+
+def cosponsors_for_bill(db: sqlite3.Connection, bill_id: str) -> list[dict[str, Any]]:
+    """Return cosponsor rows joined with the Member's display name when indexed."""
+    rows = db.execute(
+        """
+        SELECT
+            c.bioguide_id                  AS bioguide_id,
+            c.sponsorship_date             AS sponsorship_date,
+            c.sponsorship_withdrawn_date   AS sponsorship_withdrawn_date,
+            c.is_original_cosponsor        AS is_original_cosponsor,
+            m.display_name                 AS display_name
+        FROM bill_cosponsors c
+        LEFT JOIN members m ON m.bioguide_id = c.bioguide_id
+        WHERE c.bill_id = ?
+        ORDER BY c.is_original_cosponsor DESC, c.sponsorship_date ASC, c.bioguide_id ASC
+        """,
+        (bill_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def actions_for_bill(db: sqlite3.Connection, bill_id: str) -> list[dict[str, Any]]:
+    """Return action rows in reverse-chronological order (latest first)."""
+    rows = db.execute(
+        "SELECT * FROM bill_actions WHERE bill_id = ? ORDER BY ord ASC",
+        (bill_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def subjects_for_bill(db: sqlite3.Connection, bill_id: str) -> list[str]:
+    """Return the bill's CRS legislative subjects, alphabetical."""
+    rows = db.execute(
+        "SELECT subject FROM bill_subjects WHERE bill_id = ? ORDER BY subject ASC",
+        (bill_id,),
+    ).fetchall()
+    return [r["subject"] for r in rows]
+
+
+def titles_for_bill(db: sqlite3.Connection, bill_id: str) -> list[dict[str, Any]]:
+    """Return all title variants for a bill in scrape order."""
+    rows = db.execute(
+        "SELECT * FROM bill_titles WHERE bill_id = ? ORDER BY ord ASC",
+        (bill_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def summaries_for_bill(db: sqlite3.Connection, bill_id: str) -> list[dict[str, Any]]:
+    """Return all CRS summary versions for a bill, oldest first.
+
+    The template renders the most recent (last in the list) open by
+    default and collapses the rest.
+    """
+    rows = db.execute(
+        "SELECT * FROM bill_summaries WHERE bill_id = ? "
+        "ORDER BY (action_date IS NULL), action_date ASC, version_code ASC",
+        (bill_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
 def list_current_members(
     db: sqlite3.Connection,
     *,

--- a/src/concord/web/templates/bills/_action_row.html
+++ b/src/concord/web/templates/bills/_action_row.html
@@ -1,0 +1,15 @@
+{# One row of a Bill's action history list.
+
+   Procedural noise (committee referrals, motions to recommit, etc.) is
+   visually dimmed so the eye can latch onto the substantive milestones.
+   The pattern lives here in the template — extending it doesn't
+   require a re-scrape. #}
+{%- set minor_codes = ("H11100", "S11100", "Intro-H", "Intro-S") -%}
+{%- set is_minor = action.action_code in minor_codes -%}
+<li class="border-t border-stone-100 py-2 text-sm {% if is_minor %}text-stone-400{% else %}text-stone-800{% endif %}">
+  <span class="font-mono text-xs text-stone-500 mr-2">{{ action.action_date }}</span>
+  <span>{{ action.action_text }}</span>
+  {% if action.source_system %}
+    <span class="text-xs text-stone-400 ml-1">· {{ action.source_system }}</span>
+  {% endif %}
+</li>

--- a/src/concord/web/templates/bills/_action_row.html
+++ b/src/concord/web/templates/bills/_action_row.html
@@ -1,10 +1,16 @@
 {# One row of a Bill's action history list.
 
-   Procedural noise (committee referrals, motions to recommit, etc.) is
-   visually dimmed so the eye can latch onto the substantive milestones.
-   The pattern lives here in the template — extending it doesn't
+   Procedural noise (committee referrals, motions to recommit, sponsor
+   remarks) is visually dimmed so the eye can latch onto the substantive
+   milestones (introductions, passage, presidential signature, becoming
+   law). The pattern lives here in the template — extending it doesn't
    require a re-scrape. #}
-{%- set minor_codes = ("H11100", "S11100", "Intro-H", "Intro-S") -%}
+{%- set minor_codes = (
+  "H11000", "H11100",   "Referred-H",
+  "S11000", "S11100",   "Referred-S",
+  "H37300",
+  "H38310", "S38310"
+) -%}
 {%- set is_minor = action.action_code in minor_codes -%}
 <li class="border-t border-stone-100 py-2 text-sm {% if is_minor %}text-stone-400{% else %}text-stone-800{% endif %}">
   <span class="font-mono text-xs text-stone-500 mr-2">{{ action.action_date }}</span>

--- a/src/concord/web/templates/bills/profile.html
+++ b/src/concord/web/templates/bills/profile.html
@@ -32,7 +32,7 @@
       </div>
     {% endif %}
     <div class="text-xs text-stone-400">
-      Updated: {{ updated_at }}
+      Updated {{ updated_at|humanize_age }}
     </div>
   </aside>
 
@@ -114,10 +114,10 @@
             </li>
           {% endfor %}
         </ul>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.cosponsors_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.cosponsors_fetched_at|humanize_age }}.</p>
       {% else %}
         <p class="text-stone-500 text-sm">No cosponsors recorded.</p>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.cosponsors_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.cosponsors_fetched_at|humanize_age }}.</p>
       {% endif %}
     </section>
 
@@ -136,10 +136,10 @@
             {% include "bills/_action_row.html" %}
           {% endfor %}
         </ul>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.actions_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.actions_fetched_at|humanize_age }}.</p>
       {% else %}
         <p class="text-stone-500 text-sm">No actions recorded.</p>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.actions_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.actions_fetched_at|humanize_age }}.</p>
       {% endif %}
     </section>
 
@@ -158,10 +158,10 @@
             <span class="inline-block px-2 py-0.5 rounded bg-stone-100 text-stone-700 text-xs">{{ s }}</span>
           {% endfor %}
         </div>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.subjects_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.subjects_fetched_at|humanize_age }}.</p>
       {% else %}
         <p class="text-stone-500 text-sm">No subjects assigned.</p>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.subjects_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.subjects_fetched_at|humanize_age }}.</p>
       {% endif %}
     </section>
 
@@ -183,10 +183,10 @@
             </li>
           {% endfor %}
         </ul>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.titles_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.titles_fetched_at|humanize_age }}.</p>
       {% else %}
         <p class="text-stone-500 text-sm">No titles recorded.</p>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.titles_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.titles_fetched_at|humanize_age }}.</p>
       {% endif %}
     </section>
 
@@ -212,10 +212,10 @@
             </details>
           {% endfor %}
         </div>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.summaries_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.summaries_fetched_at|humanize_age }}.</p>
       {% else %}
         <p class="text-stone-500 text-sm">No summaries published.</p>
-        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.summaries_fetched_at }}.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.summaries_fetched_at|humanize_age }}.</p>
       {% endif %}
     </section>
 

--- a/src/concord/web/templates/bills/profile.html
+++ b/src/concord/web/templates/bills/profile.html
@@ -1,6 +1,14 @@
 {% extends "base.html" %}
 {% block title %}{{ bill.bill_type|upper }} {{ bill.bill_number }} — Concord{% endblock %}
 {% block content %}
+{# Compute the most recent fetched_at across tier-1 + tier-2 sections. #}
+{%- set tier2_stamps = [bill.cosponsors_fetched_at, bill.actions_fetched_at,
+                        bill.subjects_fetched_at, bill.titles_fetched_at,
+                        bill.summaries_fetched_at] -%}
+{%- set updated_at = bill.fetched_at -%}
+{%- for stamp in tier2_stamps -%}
+  {%- if stamp and stamp > updated_at -%}{%- set updated_at = stamp -%}{%- endif -%}
+{%- endfor -%}
 <article class="grid grid-cols-1 md:grid-cols-4 gap-6">
   <aside class="md:col-span-1 text-sm text-stone-600 space-y-3">
     <div>
@@ -24,7 +32,7 @@
       </div>
     {% endif %}
     <div class="text-xs text-stone-400">
-      Updated: {{ bill.fetched_at }}
+      Updated: {{ updated_at }}
     </div>
   </aside>
 
@@ -68,30 +76,151 @@
       {% endif %}
     </section>
 
+    {# -- Cosponsors --------------------------------------------------- #}
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Cosponsors</h2>
+      {% if bill.cosponsors_fetched_at is none %}
+        <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+          Cosponsors not yet fetched. Run
+          <code class="font-mono text-stone-700">concord scrape bills enrich --bill-ids {{ bill.bill_id }}</code>
+          to populate.
+        </div>
+      {% elif cosponsors %}
+        <ul class="space-y-1">
+          {% for c in cosponsors %}
+            <li class="text-sm">
+              {% if c.sponsorship_withdrawn_date %}
+                <del class="text-stone-500">
+                  {% if c.display_name %}
+                    <a href="/members/{{ c.bioguide_id }}" class="hover:text-stone-700">{{ c.display_name }}</a>
+                  {% else %}
+                    <span class="font-mono">{{ c.bioguide_id }}</span>
+                  {% endif %}
+                </del>
+                <span class="text-xs text-stone-400 ml-1">(withdrawn {{ c.sponsorship_withdrawn_date }})</span>
+              {% else %}
+                {% if c.display_name %}
+                  <a href="/members/{{ c.bioguide_id }}" class="text-stone-800 hover:text-stone-600">{{ c.display_name }}</a>
+                {% else %}
+                  <span class="font-mono text-stone-700">{{ c.bioguide_id }}</span>
+                  <span class="text-xs text-stone-400">(not indexed)</span>
+                {% endif %}
+                {% if c.is_original_cosponsor %}
+                  <span class="text-xs text-stone-400 ml-1">· original</span>
+                {% elif c.sponsorship_date %}
+                  <span class="text-xs text-stone-400 ml-1">· joined {{ c.sponsorship_date }}</span>
+                {% endif %}
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.cosponsors_fetched_at }}.</p>
+      {% else %}
+        <p class="text-stone-500 text-sm">No cosponsors recorded.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.cosponsors_fetched_at }}.</p>
+      {% endif %}
+    </section>
+
+    {# -- Action history ----------------------------------------------- #}
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Action history</h2>
+      {% if bill.actions_fetched_at is none %}
+        <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+          Action history not yet fetched. Run
+          <code class="font-mono text-stone-700">concord scrape bills enrich --bill-ids {{ bill.bill_id }}</code>
+          to populate.
+        </div>
+      {% elif actions %}
+        <ul>
+          {% for action in actions %}
+            {% include "bills/_action_row.html" %}
+          {% endfor %}
+        </ul>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.actions_fetched_at }}.</p>
+      {% else %}
+        <p class="text-stone-500 text-sm">No actions recorded.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.actions_fetched_at }}.</p>
+      {% endif %}
+    </section>
+
+    {# -- Subjects ----------------------------------------------------- #}
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Subjects</h2>
+      {% if bill.subjects_fetched_at is none %}
+        <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+          Subjects not yet fetched. Run
+          <code class="font-mono text-stone-700">concord scrape bills enrich --bill-ids {{ bill.bill_id }}</code>
+          to populate.
+        </div>
+      {% elif subjects %}
+        <div class="flex flex-wrap gap-1">
+          {% for s in subjects %}
+            <span class="inline-block px-2 py-0.5 rounded bg-stone-100 text-stone-700 text-xs">{{ s }}</span>
+          {% endfor %}
+        </div>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.subjects_fetched_at }}.</p>
+      {% else %}
+        <p class="text-stone-500 text-sm">No subjects assigned.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.subjects_fetched_at }}.</p>
+      {% endif %}
+    </section>
+
+    {# -- Titles ------------------------------------------------------- #}
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Titles</h2>
+      {% if bill.titles_fetched_at is none %}
+        <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+          Titles not yet fetched. Run
+          <code class="font-mono text-stone-700">concord scrape bills enrich --bill-ids {{ bill.bill_id }}</code>
+          to populate.
+        </div>
+      {% elif titles %}
+        <ul class="space-y-2">
+          {% for t in titles %}
+            <li class="text-sm">
+              <div class="text-xs uppercase tracking-wide text-stone-400">{{ t.title_type }}{% if t.chamber %} · {{ t.chamber }}{% endif %}</div>
+              <div class="text-stone-800">{{ t.title_text }}</div>
+            </li>
+          {% endfor %}
+        </ul>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.titles_fetched_at }}.</p>
+      {% else %}
+        <p class="text-stone-500 text-sm">No titles recorded.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.titles_fetched_at }}.</p>
+      {% endif %}
+    </section>
+
+    {# -- Summaries ---------------------------------------------------- #}
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Summaries</h2>
+      {% if bill.summaries_fetched_at is none %}
+        <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
+          Summaries not yet fetched. Run
+          <code class="font-mono text-stone-700">concord scrape bills enrich --bill-ids {{ bill.bill_id }}</code>
+          to populate.
+        </div>
+      {% elif summaries %}
+        {% set latest_index = summaries|length - 1 %}
+        <div class="space-y-2">
+          {% for s in summaries %}
+            <details {% if loop.index0 == latest_index %}open{% endif %} class="border border-stone-200 rounded p-3 bg-white">
+              <summary class="cursor-pointer text-sm font-medium text-stone-800">
+                {{ s.action_desc or s.version_code }}
+                {% if s.action_date %}<span class="text-xs text-stone-400 ml-1">· {{ s.action_date }}</span>{% endif %}
+              </summary>
+              <div class="prose prose-sm mt-2 text-stone-800">{{ s.summary_text|safe }}</div>
+            </details>
+          {% endfor %}
+        </div>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.summaries_fetched_at }}.</p>
+      {% else %}
+        <p class="text-stone-500 text-sm">No summaries published.</p>
+        <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.summaries_fetched_at }}.</p>
+      {% endif %}
+    </section>
+
     <section class="space-y-3">
       <h2 class="text-sm uppercase tracking-wide text-stone-500">Coming in later phases</h2>
-
-      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
-        <div class="font-medium text-stone-600">Cosponsors (Phase 2b)</div>
-        <div class="text-xs">Members who signed on after introduction will appear here.</div>
-      </div>
-      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
-        <div class="font-medium text-stone-600">Action history (Phase 2b)</div>
-        <div class="text-xs">Full chronological action list will appear here.</div>
-      </div>
-      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
-        <div class="font-medium text-stone-600">Subjects (Phase 2b)</div>
-        <div class="text-xs">CRS-assigned subject tags will appear here.</div>
-      </div>
-      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
-        <div class="font-medium text-stone-600">Titles (Phase 2b)</div>
-        <div class="text-xs">Short, popular, and official titles will appear here.</div>
-      </div>
-      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
-        <div class="font-medium text-stone-600">Summaries (Phase 2b)</div>
-        <div class="text-xs">CRS summaries will appear here as the bill progresses.</div>
-      </div>
-
       <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
         <div class="font-medium text-stone-600">Vote history (Phase 3)</div>
         <div class="text-xs">Roll-call votes referencing this bill will appear here.</div>

--- a/src/concord/web/templates/members/profile.html
+++ b/src/concord/web/templates/members/profile.html
@@ -123,12 +123,42 @@
       {% endif %}
     </section>
 
+    <section>
+      <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Cosponsored bills</h2>
+      {% if cosponsored_bills %}
+        <ul class="space-y-2">
+          {% for b in cosponsored_bills %}
+            <li class="border border-stone-200 rounded p-3 bg-white">
+              <div class="flex items-baseline gap-2 mb-1">
+                <a
+                  href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+                  class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
+                >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
+                <span class="text-xs text-stone-400">· {{ b.congress }}th</span>
+              </div>
+              <a
+                href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+                class="block text-sm text-stone-800 hover:text-stone-600"
+              >{{ b.title|truncate(120) }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+        {% if cosponsored_bills_total > cosponsored_bills|length %}
+          <p class="mt-2 text-sm text-stone-500">
+            Showing {{ cosponsored_bills|length }} of {{ cosponsored_bills_total }}.
+          </p>
+        {% endif %}
+      {% else %}
+        <p class="text-stone-500 text-sm">
+          No cosponsored bills indexed for this Member yet. Run
+          <code class="font-mono text-stone-700">concord scrape bills enrich --db data/proceedings.db --limit 100</code>
+          to populate.
+        </p>
+      {% endif %}
+    </section>
+
     <section class="space-y-3">
       <h2 class="text-sm uppercase tracking-wide text-stone-500">Coming in later phases</h2>
-      <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
-        <div class="font-medium text-stone-600">Cosponsored bills (Phase 2b)</div>
-        <div class="text-xs">Bills this Member signed on to after introduction will appear here.</div>
-      </div>
       <div class="border border-dashed border-stone-300 rounded p-4 text-stone-500 text-sm">
         <div class="font-medium text-stone-600">Recent votes (Phase 3)</div>
         <div class="text-xs">Recent roll-call positions will appear here.</div>

--- a/tests/fixtures/api/bills/actions_119_hr_1.json
+++ b/tests/fixtures/api/bills/actions_119_hr_1.json
@@ -1,0 +1,56 @@
+{
+  "actions": [
+    {
+      "actionDate": "2026-03-30",
+      "text": "Became Public Law No: 119-1.",
+      "type": "BecameLaw",
+      "actionCode": "E40000",
+      "sourceSystem": {"code": 9, "name": "Library of Congress"}
+    },
+    {
+      "actionDate": "2026-03-29",
+      "text": "Signed by President.",
+      "type": "President",
+      "actionCode": "E30000",
+      "sourceSystem": {"code": 9, "name": "Library of Congress"}
+    },
+    {
+      "actionDate": "2026-03-25",
+      "text": "Presented to President.",
+      "type": "Floor",
+      "actionCode": "E20000",
+      "sourceSystem": {"code": 9, "name": "Library of Congress"}
+    },
+    {
+      "actionDate": "2026-03-20",
+      "text": "Resolving differences -- Senate actions: Senate agreed to House amendment by Unanimous Consent.",
+      "type": "Floor",
+      "actionCode": "17000",
+      "sourceSystem": {"code": 0, "name": "Senate"}
+    },
+    {
+      "actionDate": "2025-01-09",
+      "text": "Referred to the Committee on Energy and Commerce, and in addition to the Committees on Natural Resources, and the Judiciary.",
+      "type": "IntroReferral",
+      "actionCode": "H11100",
+      "sourceSystem": {"code": 2, "name": "House floor actions"}
+    },
+    {
+      "actionDate": "2025-01-09",
+      "text": "Introduced in House",
+      "type": "IntroReferral",
+      "actionCode": "Intro-H",
+      "sourceSystem": {"code": 9, "name": "Library of Congress"}
+    }
+  ],
+  "pagination": {
+    "count": 6
+  },
+  "request": {
+    "billNumber": "1",
+    "billType": "hr",
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/fixtures/api/bills/cosponsors_119_hr_22.json
+++ b/tests/fixtures/api/bills/cosponsors_119_hr_22.json
@@ -1,0 +1,54 @@
+{
+  "cosponsors": [
+    {
+      "bioguideId": "B001302",
+      "fullName": "Rep. Bishop, Dan [R-NC-8]",
+      "firstName": "Dan",
+      "lastName": "Bishop",
+      "party": "R",
+      "state": "NC",
+      "district": 8,
+      "sponsorshipDate": "2025-01-09",
+      "isOriginalCosponsor": true,
+      "sponsorshipWithdrawnDate": null,
+      "url": "https://api.congress.gov/v3/member/B001302?format=json"
+    },
+    {
+      "bioguideId": "G000591",
+      "fullName": "Rep. Gimenez, Carlos A. [R-FL-28]",
+      "firstName": "Carlos",
+      "lastName": "Gimenez",
+      "party": "R",
+      "state": "FL",
+      "district": 28,
+      "sponsorshipDate": "2025-01-09",
+      "isOriginalCosponsor": true,
+      "sponsorshipWithdrawnDate": null,
+      "url": "https://api.congress.gov/v3/member/G000591?format=json"
+    },
+    {
+      "bioguideId": "M001212",
+      "fullName": "Rep. Mast, Brian J. [R-FL-21]",
+      "firstName": "Brian",
+      "lastName": "Mast",
+      "party": "R",
+      "state": "FL",
+      "district": 21,
+      "sponsorshipDate": "2025-02-04",
+      "isOriginalCosponsor": false,
+      "sponsorshipWithdrawnDate": null,
+      "url": "https://api.congress.gov/v3/member/M001212?format=json"
+    }
+  ],
+  "pagination": {
+    "count": 3,
+    "countIncludingWithdrawnCosponsors": 3
+  },
+  "request": {
+    "billNumber": "22",
+    "billType": "hr",
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/fixtures/api/bills/cosponsors_119_hr_22_withdrawn.json
+++ b/tests/fixtures/api/bills/cosponsors_119_hr_22_withdrawn.json
@@ -1,0 +1,41 @@
+{
+  "cosponsors": [
+    {
+      "bioguideId": "B001302",
+      "fullName": "Rep. Bishop, Dan [R-NC-8]",
+      "firstName": "Dan",
+      "lastName": "Bishop",
+      "party": "R",
+      "state": "NC",
+      "district": 8,
+      "sponsorshipDate": "2025-01-09",
+      "isOriginalCosponsor": true,
+      "sponsorshipWithdrawnDate": null,
+      "url": "https://api.congress.gov/v3/member/B001302?format=json"
+    },
+    {
+      "bioguideId": "Z000001",
+      "fullName": "Rep. Doe, Jane [I-XX-0]",
+      "firstName": "Jane",
+      "lastName": "Doe",
+      "party": "I",
+      "state": "XX",
+      "district": 0,
+      "sponsorshipDate": "2025-01-15",
+      "isOriginalCosponsor": false,
+      "sponsorshipWithdrawnDate": "2025-04-02",
+      "url": "https://api.congress.gov/v3/member/Z000001?format=json"
+    }
+  ],
+  "pagination": {
+    "count": 1,
+    "countIncludingWithdrawnCosponsors": 2
+  },
+  "request": {
+    "billNumber": "22",
+    "billType": "hr",
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/fixtures/api/bills/subjects_119_hr_1.json
+++ b/tests/fixtures/api/bills/subjects_119_hr_1.json
@@ -1,0 +1,29 @@
+{
+  "subjects": {
+    "legislativeSubjects": [
+      {"name": "Energy"},
+      {"name": "Energy assistance for the poor and aged"},
+      {"name": "Energy efficiency and conservation"},
+      {"name": "Energy prices"},
+      {"name": "Environmental Protection Agency (EPA)"},
+      {"name": "Government Operations and Politics"},
+      {"name": "Natural gas"},
+      {"name": "Oil and gas"},
+      {"name": "Pipelines"},
+      {"name": "Renewable energy resources"}
+    ],
+    "policyArea": {
+      "name": "Energy"
+    }
+  },
+  "pagination": {
+    "count": 10
+  },
+  "request": {
+    "billNumber": "1",
+    "billType": "hr",
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/fixtures/api/bills/summaries_119_hr_1.json
+++ b/tests/fixtures/api/bills/summaries_119_hr_1.json
@@ -1,0 +1,35 @@
+{
+  "summaries": [
+    {
+      "versionCode": "00",
+      "actionDate": "2025-01-09",
+      "actionDesc": "Introduced in House",
+      "updateDate": "2025-01-20T10:11:12Z",
+      "text": "<p><strong>Lower Energy Costs Act</strong></p><p>This bill addresses energy production, exports, and infrastructure.</p>"
+    },
+    {
+      "versionCode": "18",
+      "actionDate": "2026-03-20",
+      "actionDesc": "Passed House",
+      "updateDate": "2026-03-22T08:00:00Z",
+      "text": "<p>As passed by the House, this bill...</p>"
+    },
+    {
+      "versionCode": "55",
+      "actionDate": "2026-03-29",
+      "actionDesc": "Public Law",
+      "updateDate": "2026-04-01T12:34:56Z",
+      "text": "<p>This Act was signed into law on 2026-03-29 and addresses energy production, exports, and infrastructure.</p>"
+    }
+  ],
+  "pagination": {
+    "count": 3
+  },
+  "request": {
+    "billNumber": "1",
+    "billType": "hr",
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/fixtures/api/bills/titles_119_hr_1.json
+++ b/tests/fixtures/api/bills/titles_119_hr_1.json
@@ -1,0 +1,38 @@
+{
+  "titles": [
+    {
+      "titleType": "Display Title",
+      "title": "Lower Energy Costs Act",
+      "chamberCode": null,
+      "chamberName": null
+    },
+    {
+      "titleType": "Official Title as Introduced",
+      "title": "To lower energy costs by increasing American energy production, exports, infrastructure, and critical minerals processing, by promoting transparency, accountability, permitting, and production of American resources, and by improving water quality certification and energy projects, and for other purposes.",
+      "chamberCode": null,
+      "chamberName": null
+    },
+    {
+      "titleType": "Short Title(s) as Introduced",
+      "title": "Lower Energy Costs Act",
+      "chamberCode": null,
+      "chamberName": null
+    },
+    {
+      "titleType": "Short Title(s) as Passed House",
+      "title": "Lower Energy Costs Act",
+      "chamberCode": "H",
+      "chamberName": "House"
+    }
+  ],
+  "pagination": {
+    "count": 4
+  },
+  "request": {
+    "billNumber": "1",
+    "billType": "hr",
+    "congress": "119",
+    "contentType": "application/json",
+    "format": "json"
+  }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -546,3 +546,136 @@ class TestGetBillDetail:
         client = _make_client(lambda r: _json_response({"notBill": {}}))
         with client, pytest.raises(ApiError, match="expected 'bill' object"):
             client.get_bill_detail(congress=119, bill_type="hr", bill_number=1)
+
+
+# -- bill sub-endpoints (Phase 2b) -------------------------------------------
+
+
+class TestGetBillCosponsors:
+    def test_returns_cosponsors_payload(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/cosponsors_119_hr_22.json").read_text())
+        client = _make_client(lambda r: _json_response(payload))
+        with client:
+            result = client.get_bill_cosponsors(119, "hr", 22)
+        assert len(result["cosponsors"]) == 3
+        assert result["cosponsors"][0]["bioguideId"] == "B001302"
+
+    def test_paginates_until_no_next(self, fixtures_dir: Path) -> None:
+        page1 = json.loads((fixtures_dir / "api/bills/cosponsors_119_hr_22.json").read_text())
+        page1 = {**page1, "pagination": {"count": 5, "next": "https://example.invalid/next"}}
+        page2 = {
+            "cosponsors": [
+                {
+                    "bioguideId": "X000001",
+                    "sponsorshipDate": "2025-03-01",
+                    "isOriginalCosponsor": False,
+                    "sponsorshipWithdrawnDate": None,
+                },
+                {
+                    "bioguideId": "X000002",
+                    "sponsorshipDate": "2025-03-02",
+                    "isOriginalCosponsor": False,
+                    "sponsorshipWithdrawnDate": None,
+                },
+            ],
+            "pagination": {"count": 5},
+        }
+        responses = iter([page1, page2])
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return _json_response(next(responses))
+
+        client = _make_client(handler)
+        with client:
+            result = client.get_bill_cosponsors(119, "hr", 22)
+        assert len(result["cosponsors"]) == 5
+        assert result["cosponsors"][-1]["bioguideId"] == "X000002"
+
+    def test_canonicalizes_bill_type(self) -> None:
+        captured: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request.url.path)
+            return _json_response({"cosponsors": [], "pagination": {"count": 0}})
+
+        client = _make_client(handler)
+        with client:
+            client.get_bill_cosponsors(119, "HR", 1)
+        assert captured == ["/v3/bill/119/hr/1/cosponsors"]
+
+
+class TestGetBillActions:
+    def test_returns_actions_payload(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/actions_119_hr_1.json").read_text())
+        client = _make_client(lambda r: _json_response(payload))
+        with client:
+            result = client.get_bill_actions(119, "hr", 1)
+        assert len(result["actions"]) == 6
+        assert result["actions"][0]["actionDate"] == "2026-03-30"
+
+    def test_paginates(self) -> None:
+        page1 = {
+            "actions": [{"actionDate": "2026-03-30", "text": "A"}],
+            "pagination": {"count": 2, "next": "..."},
+        }
+        page2 = {
+            "actions": [{"actionDate": "2026-03-29", "text": "B"}],
+            "pagination": {"count": 2},
+        }
+        responses = iter([page1, page2])
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return _json_response(next(responses))
+
+        client = _make_client(handler)
+        with client:
+            result = client.get_bill_actions(119, "hr", 1)
+        assert [a["text"] for a in result["actions"]] == ["A", "B"]
+
+
+class TestGetBillSubjects:
+    def test_concatenates_legislative_subjects_across_pages(self) -> None:
+        page1 = {
+            "subjects": {
+                "legislativeSubjects": [{"name": "Energy"}, {"name": "Oil"}],
+                "policyArea": {"name": "Energy"},
+            },
+            "pagination": {"count": 4, "next": "..."},
+        }
+        page2 = {
+            "subjects": {
+                "legislativeSubjects": [{"name": "Gas"}, {"name": "Renewables"}],
+                "policyArea": {"name": "Energy"},
+            },
+            "pagination": {"count": 4},
+        }
+        responses = iter([page1, page2])
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            return _json_response(next(responses))
+
+        client = _make_client(handler)
+        with client:
+            result = client.get_bill_subjects(119, "hr", 1)
+        names = [s["name"] for s in result["subjects"]["legislativeSubjects"]]
+        assert names == ["Energy", "Oil", "Gas", "Renewables"]
+        assert result["subjects"]["policyArea"]["name"] == "Energy"
+
+
+class TestGetBillTitles:
+    def test_returns_titles_payload(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/titles_119_hr_1.json").read_text())
+        client = _make_client(lambda r: _json_response(payload))
+        with client:
+            result = client.get_bill_titles(119, "hr", 1)
+        assert len(result["titles"]) == 4
+
+
+class TestGetBillSummaries:
+    def test_returns_summaries_payload(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/summaries_119_hr_1.json").read_text())
+        client = _make_client(lambda r: _json_response(payload))
+        with client:
+            result = client.get_bill_summaries(119, "hr", 1)
+        assert len(result["summaries"]) == 3
+        assert result["summaries"][0]["versionCode"] == "00"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1306,6 +1306,45 @@ class TestScrapeBillsEnrichCommand:
         files = {p.name for p in tmp_path.iterdir()}
         assert files == {"bill_cosponsors.jsonl", "bill_actions.jsonl"}
 
+    def test_limit_caps_bill_ids_input(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--limit applies to --bill-ids count too (Fix #2 regression)."""
+        handler = _enrichment_handler()
+        original_init = Client.__init__
+
+        def patched_init(self, **kwargs):
+            kwargs.setdefault("transport", httpx.MockTransport(handler))
+            kwargs.setdefault("sleep", lambda _s: None)
+            original_init(self, **kwargs)
+
+        monkeypatch.setattr(Client, "__init__", patched_init)
+
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "enrich",
+                "--bill-ids",
+                "119-hr-1,119-hr-22,119-hr-47",
+                "--storage-dir",
+                str(tmp_path),
+                "--limit",
+                "1",
+                "--no-progress",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Only one bill should have been enriched per section, despite
+        # three bill_ids being supplied.
+        cosponsors_lines = (tmp_path / "bill_cosponsors.jsonl").read_text().splitlines()
+        assert len(cosponsors_lines) == 1
+
     def test_rejects_unknown_section(
         self,
         runner: CliRunner,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1175,3 +1175,202 @@ class TestLoadBillsCommand:
         plain = _strip(result.output)
         assert "No input file" in plain
         assert "scrape bills" in plain
+
+
+# -- `concord scrape bills enrich` -------------------------------------------
+
+
+def _enrichment_handler():
+    """Return an httpx handler that answers /cosponsors, /actions, ... from fixtures."""
+    fixtures_path = Path(__file__).parent / "fixtures" / "api" / "bills"
+    fixtures = {
+        "cosponsors": json.loads((fixtures_path / "cosponsors_119_hr_22.json").read_text()),
+        "actions": json.loads((fixtures_path / "actions_119_hr_1.json").read_text()),
+        "subjects": json.loads((fixtures_path / "subjects_119_hr_1.json").read_text()),
+        "titles": json.loads((fixtures_path / "titles_119_hr_1.json").read_text()),
+        "summaries": json.loads((fixtures_path / "summaries_119_hr_1.json").read_text()),
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        parts = request.url.path.rstrip("/").split("/")
+        if len(parts) != 7:
+            return httpx.Response(404)
+        section = parts[-1]
+        return httpx.Response(
+            200,
+            content=json.dumps(fixtures[section]),
+            headers={"content-type": "application/json"},
+        )
+
+    return handler
+
+
+class TestScrapeBillsEnrichCommand:
+    def test_help_lists_flags(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli_module.app, ["scrape", "bills", "enrich", "--help"])
+        assert result.exit_code == 0
+        plain = _strip(result.output)
+        for flag in ["--bill-ids", "--sections", "--storage-dir", "--db", "--limit"]:
+            assert flag in plain
+
+    def test_requires_bill_ids_or_db(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "enrich",
+                "--storage-dir",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code == 2
+        plain = _strip(result.output) + _strip(result.stderr or "")
+        assert "--bill-ids" in plain
+        assert "--db" in plain
+
+    def test_writes_one_envelope_per_section(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        handler = _enrichment_handler()
+        original_init = Client.__init__
+
+        def patched_init(self, **kwargs):
+            kwargs.setdefault("transport", httpx.MockTransport(handler))
+            kwargs.setdefault("sleep", lambda _s: None)
+            original_init(self, **kwargs)
+
+        monkeypatch.setattr(Client, "__init__", patched_init)
+
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "enrich",
+                "--bill-ids",
+                "119-hr-1",
+                "--storage-dir",
+                str(tmp_path),
+                "--no-progress",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        for section in ("cosponsors", "actions", "subjects", "titles", "summaries"):
+            path = tmp_path / f"bill_{section}.jsonl"
+            assert path.exists(), f"missing {path}"
+            assert len(path.read_text().splitlines()) == 1
+
+    def test_sections_subset(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        handler = _enrichment_handler()
+        original_init = Client.__init__
+
+        def patched_init(self, **kwargs):
+            kwargs.setdefault("transport", httpx.MockTransport(handler))
+            kwargs.setdefault("sleep", lambda _s: None)
+            original_init(self, **kwargs)
+
+        monkeypatch.setattr(Client, "__init__", patched_init)
+
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "enrich",
+                "--bill-ids",
+                "119-hr-1",
+                "--sections",
+                "cosponsors,actions",
+                "--storage-dir",
+                str(tmp_path),
+                "--no-progress",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        files = {p.name for p in tmp_path.iterdir()}
+        assert files == {"bill_cosponsors.jsonl", "bill_actions.jsonl"}
+
+    def test_rejects_unknown_section(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "enrich",
+                "--bill-ids",
+                "119-hr-1",
+                "--sections",
+                "wibble",
+                "--storage-dir",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code != 0
+        plain = _strip(result.output) + _strip(result.stderr or "")
+        assert "unknown section" in plain.lower()
+
+    def test_rejects_bad_bill_id(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "enrich",
+                "--bill-ids",
+                "bad-token",
+                "--storage-dir",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_db_autoselect_no_unenriched(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+    ) -> None:
+        # Empty DB → empty result; should report "nothing to do".
+        db = tmp_path / "test.db"
+        SqliteStorage(db, load_vec=False).close()
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "enrich",
+                "--db",
+                str(db),
+                "--storage-dir",
+                str(tmp_path),
+                "--no-progress",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "nothing to do" in _strip(result.output).lower()

--- a/tests/test_models_bills.py
+++ b/tests/test_models_bills.py
@@ -14,6 +14,11 @@ from concord.models import (
     BillSnapshot,
     bill_id_from_components,
     parse_bill,
+    parse_bill_action,
+    parse_bill_subject,
+    parse_bill_summary,
+    parse_bill_title,
+    parse_cosponsor,
 )
 
 from ._snapshots import wrap_snapshot
@@ -105,6 +110,78 @@ class TestParseBill:
         assert bill.sponsor_bioguide_id is None
         assert bill.policy_area is None
         assert bill.latest_action_date is None
+
+
+class TestParseCosponsor:
+    def test_parses_cosponsor_fixture(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/cosponsors_119_hr_22.json").read_text())
+        rows = [parse_cosponsor(p) for p in payload["cosponsors"]]
+        assert all(r is not None for r in rows)
+        first = rows[0]
+        assert first is not None
+        assert first.bioguide_id == "B001302"
+        assert first.is_original_cosponsor is True
+        assert first.sponsorship_withdrawn_date is None
+
+    def test_parses_withdrawn_row(self, fixtures_dir: Path) -> None:
+        payload = json.loads(
+            (fixtures_dir / "api/bills/cosponsors_119_hr_22_withdrawn.json").read_text()
+        )
+        rows = [parse_cosponsor(p) for p in payload["cosponsors"]]
+        withdrawn = next(r for r in rows if r is not None and r.sponsorship_withdrawn_date)
+        assert withdrawn.sponsorship_withdrawn_date == "2025-04-02"
+        assert withdrawn.is_original_cosponsor is False
+
+    def test_returns_none_for_row_without_bioguide(self) -> None:
+        assert parse_cosponsor({"sponsorshipDate": "2025-01-09"}) is None
+
+
+class TestParseBillAction:
+    def test_parses_action_fixture(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/actions_119_hr_1.json").read_text())
+        rows = [parse_bill_action(p) for p in payload["actions"]]
+        assert all(r is not None for r in rows)
+        first = rows[0]
+        assert first is not None
+        assert first.action_date == "2026-03-30"
+        assert first.action_text == "Became Public Law No: 119-1."
+        assert first.source_system == "Library of Congress"
+
+    def test_returns_none_for_action_without_date(self) -> None:
+        assert parse_bill_action({"text": "Some action"}) is None
+
+
+class TestParseBillSubject:
+    def test_parses_subjects_fixture(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/subjects_119_hr_1.json").read_text())
+        rows = [parse_bill_subject(p) for p in payload["subjects"]["legislativeSubjects"]]
+        assert all(r is not None for r in rows)
+        names = [r.name for r in rows if r is not None]
+        assert "Energy" in names
+        assert "Pipelines" in names
+
+    def test_returns_none_for_empty_name(self) -> None:
+        assert parse_bill_subject({"name": ""}) is None
+
+
+class TestParseBillTitle:
+    def test_parses_titles_fixture(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/titles_119_hr_1.json").read_text())
+        rows = [parse_bill_title(p) for p in payload["titles"]]
+        assert all(r is not None for r in rows)
+        short = next(r for r in rows if r is not None and r.title_type.startswith("Short Title"))
+        assert short.title_text == "Lower Energy Costs Act"
+
+
+class TestParseBillSummary:
+    def test_parses_summaries_fixture(self, fixtures_dir: Path) -> None:
+        payload = json.loads((fixtures_dir / "api/bills/summaries_119_hr_1.json").read_text())
+        rows = [parse_bill_summary(p) for p in payload["summaries"]]
+        assert all(r is not None for r in rows)
+        first = rows[0]
+        assert first is not None
+        assert first.version_code == "00"
+        assert "<p>" in first.summary_text
 
 
 class TestBillSnapshot:

--- a/tests/test_pipeline_bills.py
+++ b/tests/test_pipeline_bills.py
@@ -235,6 +235,40 @@ class TestLoadBillsTier2:
         assert stats.bills_written == 0
         assert stats.tier2_orphans_skipped == 1
 
+    def test_rerunning_load_preserves_fetched_at(self, tmp_path: Path) -> None:
+        """Re-running tier-1 load after enrichment must NOT clear *_fetched_at.
+
+        Guards against a regression where the parent UPSERT clobbers the
+        tier-2 stamp columns. The plan's DDL listed them on the bills
+        row, but the upsert SQL deliberately omits them — this test
+        pins that.
+        """
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        self._write_tier1(storage_dir)
+        (storage_dir / enrichment_jsonl_name("cosponsors")).write_text(
+            json.dumps(
+                _envelope_for_section(
+                    _fixture("cosponsors_119_hr_22.json"), bill_key=(119, "hr", 1)
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        load_bills(storage_dir=storage_dir, db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            initial = storage.get_bill("119-hr-1")
+            assert initial is not None
+            assert initial["cosponsors_fetched_at"] is not None
+            initial_stamp = initial["cosponsors_fetched_at"]
+
+        # Re-run the loader; the parent tier-1 row gets UPSERTed again.
+        load_bills(storage_dir=storage_dir, db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            row = storage.get_bill("119-hr-1")
+            assert row is not None
+            assert row["cosponsors_fetched_at"] == initial_stamp
+
     def test_idempotent_rerun_tier2(self, tmp_path: Path) -> None:
         storage_dir = tmp_path / "data"
         db = tmp_path / "test.db"
@@ -289,6 +323,38 @@ class TestIndexBills:
         with SqliteStorage(db, load_vec=False) as storage:
             (count,) = storage.connection.execute("SELECT COUNT(*) FROM bills_fts").fetchone()
             assert count == 1
+
+    def test_subjects_indexed_alphabetically(self, tmp_path: Path) -> None:
+        """The bills_fts.subjects column must be byte-stable across re-runs."""
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        _write_jsonl(
+            storage_dir,
+            [_envelope_for(_detail_payload("detail_119_hr_1.json"))],
+        )
+        # Subjects in deliberately non-alphabetical order.
+        subjects_payload = {
+            "subjects": {
+                "legislativeSubjects": [
+                    {"name": "Zebra studies"},
+                    {"name": "Apples"},
+                    {"name": "Mangoes"},
+                ],
+                "policyArea": {"name": "Energy"},
+            },
+            "pagination": {"count": 3},
+        }
+        (storage_dir / enrichment_jsonl_name("subjects")).write_text(
+            json.dumps(_envelope_for_section(subjects_payload, bill_key=(119, "hr", 1))) + "\n",
+            encoding="utf-8",
+        )
+        load_bills(storage_dir=storage_dir, db_path=db)
+        index_bills(db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            row = storage.connection.execute(
+                "SELECT subjects FROM bills_fts WHERE bill_id = ?", ("119-hr-1",)
+            ).fetchone()
+            assert row["subjects"] == "Apples | Mangoes | Zebra studies"
 
     def test_short_title_and_subjects_indexed_when_present(self, tmp_path: Path) -> None:
         storage_dir = tmp_path / "data"

--- a/tests/test_pipeline_bills.py
+++ b/tests/test_pipeline_bills.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from concord.pipeline.index_bills import index as index_bills
 from concord.pipeline.load_bills import load as load_bills
-from concord.scraper.bills import BILLS_JSONL_NAME
+from concord.scraper.bills import BILLS_JSONL_NAME, enrichment_jsonl_name
 from concord.storage.sqlite import SqliteStorage
 
 from ._snapshots import wrap_snapshot
@@ -48,6 +48,24 @@ def _write_jsonl(storage_dir: Path, envelopes: list[dict[str, Any]]) -> None:
     (storage_dir / BILLS_JSONL_NAME).write_text(
         "\n".join(json.dumps(e) for e in envelopes) + "\n",
         encoding="utf-8",
+    )
+
+
+def _envelope_for_section(
+    payload: dict[str, Any],
+    *,
+    bill_key: tuple[int, str, int],
+    fetched_at: datetime = FIXED_FETCHED_AT,
+) -> dict[str, Any]:
+    congress, bill_type, bill_number = bill_key
+    return wrap_snapshot(
+        payload,
+        fetched_at=fetched_at,
+        key={
+            "congress": congress,
+            "bill_type": bill_type.lower(),
+            "bill_number": bill_number,
+        },
     )
 
 
@@ -110,7 +128,12 @@ class TestLoadBills:
         storage_dir = tmp_path / "no_such_dir"
         db = tmp_path / "test.db"
         stats = load_bills(storage_dir=storage_dir, db_path=db)
-        assert stats == (0, 0, 0)
+        assert stats.bills_written == 0
+        assert stats.snapshots_read == 0
+        assert stats.malformed == 0
+        assert stats.tier2_snapshots_read == 0
+        assert stats.tier2_bills_updated == 0
+        assert stats.tier2_orphans_skipped == 0
 
     def test_idempotent_rerun(self, tmp_path: Path) -> None:
         storage_dir = tmp_path / "data"
@@ -124,6 +147,112 @@ class TestLoadBills:
         with SqliteStorage(db, load_vec=False) as storage:
             count = storage.connection.execute("SELECT COUNT(*) FROM bills").fetchone()[0]
             assert count == 1
+
+
+class TestLoadBillsTier2:
+    def _write_tier1(self, storage_dir: Path) -> None:
+        _write_jsonl(
+            storage_dir,
+            [
+                _envelope_for(_detail_payload("detail_119_hr_1.json")),
+                _envelope_for(_detail_payload("detail_119_hr_22.json")),
+            ],
+        )
+
+    def test_tier1_only_leaves_fetched_at_columns_null(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        self._write_tier1(storage_dir)
+        load_bills(storage_dir=storage_dir, db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            row = storage.get_bill("119-hr-1")
+            assert row is not None
+            assert row["cosponsors_fetched_at"] is None
+            assert row["actions_fetched_at"] is None
+            assert row["subjects_fetched_at"] is None
+            assert row["titles_fetched_at"] is None
+            assert row["summaries_fetched_at"] is None
+
+    def test_loads_all_five_sections_when_present(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        self._write_tier1(storage_dir)
+
+        # Write tier-2 files for 119-hr-1.
+        section_to_fixture = {
+            "cosponsors": "cosponsors_119_hr_22.json",
+            "actions": "actions_119_hr_1.json",
+            "subjects": "subjects_119_hr_1.json",
+            "titles": "titles_119_hr_1.json",
+            "summaries": "summaries_119_hr_1.json",
+        }
+        for section, name in section_to_fixture.items():
+            (storage_dir / enrichment_jsonl_name(section)).write_text(
+                json.dumps(_envelope_for_section(_fixture(name), bill_key=(119, "hr", 1))) + "\n",
+                encoding="utf-8",
+            )
+
+        stats = load_bills(storage_dir=storage_dir, db_path=db)
+        assert stats.tier2_bills_updated == 5  # one bill, five sections
+        assert stats.tier2_orphans_skipped == 0
+
+        with SqliteStorage(db, load_vec=False) as storage:
+            row = storage.get_bill("119-hr-1")
+            assert row is not None
+            assert row["cosponsors_fetched_at"] is not None
+            assert row["actions_fetched_at"] is not None
+            cosponsors = storage.cosponsors_for_bill("119-hr-1")
+            assert len(cosponsors) == 3
+            actions = storage.actions_for_bill("119-hr-1")
+            assert len(actions) == 6
+            subjects = storage.subjects_for_bill("119-hr-1")
+            assert len(subjects) == 10
+            titles = storage.titles_for_bill("119-hr-1")
+            assert len(titles) == 4
+            summaries = storage.summaries_for_bill("119-hr-1")
+            assert len(summaries) == 3
+            # The other bill (119-hr-22) stays tier-1-only.
+            other = storage.get_bill("119-hr-22")
+            assert other is not None
+            assert other["cosponsors_fetched_at"] is None
+
+    def test_tier2_orphan_skipped(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        # Tier-2 only, with a bill_id that isn't in bills.jsonl (because
+        # bills.jsonl doesn't exist).
+        (storage_dir / enrichment_jsonl_name("cosponsors")).write_text(
+            json.dumps(
+                _envelope_for_section(
+                    _fixture("cosponsors_119_hr_22.json"), bill_key=(119, "hr", 22)
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        stats = load_bills(storage_dir=storage_dir, db_path=db)
+        assert stats.bills_written == 0
+        assert stats.tier2_orphans_skipped == 1
+
+    def test_idempotent_rerun_tier2(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        self._write_tier1(storage_dir)
+        (storage_dir / enrichment_jsonl_name("cosponsors")).write_text(
+            json.dumps(
+                _envelope_for_section(
+                    _fixture("cosponsors_119_hr_22.json"), bill_key=(119, "hr", 1)
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        load_bills(storage_dir=storage_dir, db_path=db)
+        load_bills(storage_dir=storage_dir, db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            cosponsors = storage.cosponsors_for_bill("119-hr-1")
+            assert len(cosponsors) == 3
 
 
 class TestIndexBills:
@@ -160,6 +289,40 @@ class TestIndexBills:
         with SqliteStorage(db, load_vec=False) as storage:
             (count,) = storage.connection.execute("SELECT COUNT(*) FROM bills_fts").fetchone()
             assert count == 1
+
+    def test_short_title_and_subjects_indexed_when_present(self, tmp_path: Path) -> None:
+        storage_dir = tmp_path / "data"
+        db = tmp_path / "test.db"
+        _write_jsonl(
+            storage_dir,
+            [_envelope_for(_detail_payload("detail_119_hr_1.json"))],
+        )
+        # Tier-2: titles + subjects.
+        titles_payload = _fixture("titles_119_hr_1.json")
+        subjects_payload = _fixture("subjects_119_hr_1.json")
+        (storage_dir / enrichment_jsonl_name("titles")).write_text(
+            json.dumps(_envelope_for_section(titles_payload, bill_key=(119, "hr", 1))) + "\n",
+            encoding="utf-8",
+        )
+        (storage_dir / enrichment_jsonl_name("subjects")).write_text(
+            json.dumps(_envelope_for_section(subjects_payload, bill_key=(119, "hr", 1))) + "\n",
+            encoding="utf-8",
+        )
+        load_bills(storage_dir=storage_dir, db_path=db)
+        index_bills(db_path=db)
+        with SqliteStorage(db, load_vec=False) as storage:
+            # Short title is "Lower Energy Costs Act" — matches "lower".
+            rows = storage.connection.execute(
+                "SELECT bill_id FROM bills_fts WHERE bills_fts MATCH ?",
+                ("lower",),
+            ).fetchall()
+            assert [r["bill_id"] for r in rows] == ["119-hr-1"]
+            # Subjects column contains "Pipelines".
+            rows = storage.connection.execute(
+                "SELECT bill_id FROM bills_fts WHERE bills_fts MATCH ?",
+                ("pipelines",),
+            ).fetchall()
+            assert [r["bill_id"] for r in rows] == ["119-hr-1"]
 
     def test_fts_matches_title_and_policy_area(self, tmp_path: Path) -> None:
         storage_dir = tmp_path / "data"

--- a/tests/test_scraper_bills.py
+++ b/tests/test_scraper_bills.py
@@ -8,9 +8,18 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+import pytest
 
 from concord.api import Client
-from concord.scraper.bills import BILLS_JSONL_NAME, ScrapeProgressEvent, scrape_basic
+from concord.scraper.bills import (
+    BILL_ENRICHMENT_SECTIONS,
+    BILLS_JSONL_NAME,
+    EnrichProgressEvent,
+    ScrapeProgressEvent,
+    enrichment_jsonl_name,
+    scrape_basic,
+    scrape_enrichment,
+)
 
 FIXED_FETCHED_AT = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC)
 
@@ -187,3 +196,133 @@ class TestScrapeBasic:
                 bill_types=["hr"],
             )
         assert (nested / BILLS_JSONL_NAME).exists()
+
+
+def _enrichment_client(
+    *,
+    failing_sections: set[str] | None = None,
+) -> Client:
+    """Return a Client that answers all five sub-endpoints from local fixtures."""
+    fixtures = {
+        "cosponsors": _fixture("cosponsors_119_hr_22.json"),
+        "actions": _fixture("actions_119_hr_1.json"),
+        "subjects": _fixture("subjects_119_hr_1.json"),
+        "titles": _fixture("titles_119_hr_1.json"),
+        "summaries": _fixture("summaries_119_hr_1.json"),
+    }
+    failing = failing_sections or set()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        parts = request.url.path.rstrip("/").split("/")
+        # /v3/bill/{c}/{t}/{n}/{section}
+        if len(parts) != 7:
+            return httpx.Response(404)
+        section = parts[-1]
+        if section in failing:
+            return httpx.Response(500)
+        body = fixtures[section]
+        return httpx.Response(
+            200,
+            content=json.dumps(body),
+            headers={"content-type": "application/json"},
+        )
+
+    return Client(
+        api_key="test-key",
+        transport=httpx.MockTransport(handler),
+        sleep=lambda _s: None,
+    )
+
+
+class TestScrapeEnrichment:
+    def test_writes_one_envelope_per_section(self, tmp_path: Path) -> None:
+        client = _enrichment_client()
+        with client:
+            stats = scrape_enrichment(
+                client=client,
+                bill_keys=[(119, "hr", 1)],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+            )
+        assert stats.bills_enriched == 1
+        assert stats.snapshots_written == 5
+        for section in BILL_ENRICHMENT_SECTIONS:
+            path = tmp_path / enrichment_jsonl_name(section)
+            assert path.exists()
+            lines = path.read_text().splitlines()
+            assert len(lines) == 1
+            env = json.loads(lines[0])
+            assert env["key"] == {"congress": 119, "bill_type": "hr", "bill_number": 1}
+            assert env["fetched_at"] == FIXED_FETCHED_AT.isoformat()
+
+    def test_sections_subset_only_writes_listed_files(self, tmp_path: Path) -> None:
+        client = _enrichment_client()
+        with client:
+            scrape_enrichment(
+                client=client,
+                bill_keys=[(119, "hr", 1)],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                sections=["cosponsors", "actions"],
+            )
+        files = {p.name for p in tmp_path.iterdir()}
+        assert files == {
+            enrichment_jsonl_name("cosponsors"),
+            enrichment_jsonl_name("actions"),
+        }
+
+    def test_partial_failure_leaves_other_sections_intact(self, tmp_path: Path) -> None:
+        client = _enrichment_client(failing_sections={"summaries"})
+        events: list[EnrichProgressEvent] = []
+        with client:
+            stats = scrape_enrichment(
+                client=client,
+                bill_keys=[(119, "hr", 1)],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                progress=events.append,
+            )
+        # Four sections written, one failed.
+        assert stats.snapshots_written == 4
+        assert stats.section_failures == 1
+        assert (tmp_path / enrichment_jsonl_name("cosponsors")).exists()
+        assert (tmp_path / enrichment_jsonl_name("summaries")).read_text() == ""
+        assert events[0].partial_failures == ("summaries",)
+
+    def test_limit_caps_bills(self, tmp_path: Path) -> None:
+        client = _enrichment_client()
+        with client:
+            stats = scrape_enrichment(
+                client=client,
+                bill_keys=[(119, "hr", 1), (119, "hr", 22), (119, "hr", 47)],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                limit=2,
+            )
+        assert stats.bills_enriched == 2
+
+    def test_canonicalizes_bill_type(self, tmp_path: Path) -> None:
+        client = _enrichment_client()
+        with client:
+            scrape_enrichment(
+                client=client,
+                bill_keys=[(119, "HR", 1)],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                sections=["cosponsors"],
+            )
+        env = json.loads(
+            (tmp_path / enrichment_jsonl_name("cosponsors")).read_text().splitlines()[0]
+        )
+        assert env["key"]["bill_type"] == "hr"
+
+    def test_unknown_section_raises(self, tmp_path: Path) -> None:
+        client = _enrichment_client()
+        with client, pytest.raises(ValueError, match="unknown enrichment section"):
+            scrape_enrichment(
+                client=client,
+                bill_keys=[(119, "hr", 1)],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                sections=["nonsense"],
+            )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -14,7 +14,7 @@ from concord.pipeline.index_bills import index as index_bills
 from concord.pipeline.index_members import index as index_members
 from concord.pipeline.load_bills import load as load_bills
 from concord.pipeline.load_members import load as load_members
-from concord.scraper.bills import BILLS_JSONL_NAME
+from concord.scraper.bills import BILLS_JSONL_NAME, enrichment_jsonl_name
 from concord.storage.sqlite import SqliteStorage
 from concord.web.app import create_app
 
@@ -161,9 +161,85 @@ def test_bills_end_to_end(tmp_path: Path) -> None:
 
     resp = client.get("/bills/119/hr/1")
     assert resp.status_code == 200
-    assert "Cosponsors (Phase 2b)" in resp.text
+    # Bill is tier-1 only — the five tier-2 sections render their
+    # "not yet fetched" empty states.
+    assert "Cosponsors not yet fetched" in resp.text
 
     # Bare-identifier query: with only one Bill in scope, this redirects.
     resp = client.get("/search?q=HR+1", follow_redirects=False)
     assert resp.status_code == 307
     assert resp.headers["location"] == "/bills/119/hr/1"
+
+
+def test_bills_tier2_end_to_end(tmp_path: Path) -> None:
+    """Phase 2b smoke: write tier-1 + tier-2 JSONL for one bill, load + index,
+    poke routes for both the enriched bill and a tier-1-only bill.
+    """
+    fixtures = Path(__file__).parent / "fixtures" / "api" / "bills"
+    storage_dir = tmp_path / "data"
+    storage_dir.mkdir()
+    fetched_at = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC).isoformat()
+
+    def _envelope(payload: dict, key: dict) -> str:
+        return json.dumps({"fetched_at": fetched_at, "key": key, "payload": payload}) + "\n"
+
+    bill_hr_1 = json.loads((fixtures / "detail_119_hr_1.json").read_text())["bill"]
+    bill_hr_22 = json.loads((fixtures / "detail_119_hr_22.json").read_text())["bill"]
+    (storage_dir / BILLS_JSONL_NAME).write_text(
+        _envelope(bill_hr_1, {"congress": 119, "bill_type": "hr", "bill_number": 1})
+        + _envelope(bill_hr_22, {"congress": 119, "bill_type": "hr", "bill_number": 22}),
+        encoding="utf-8",
+    )
+    # Enrichment only for 119-hr-1.
+    section_fixtures = {
+        "cosponsors": "cosponsors_119_hr_22.json",
+        "actions": "actions_119_hr_1.json",
+        "subjects": "subjects_119_hr_1.json",
+        "titles": "titles_119_hr_1.json",
+        "summaries": "summaries_119_hr_1.json",
+    }
+    for section, name in section_fixtures.items():
+        payload = json.loads((fixtures / name).read_text())
+        (storage_dir / enrichment_jsonl_name(section)).write_text(
+            _envelope(payload, {"congress": 119, "bill_type": "hr", "bill_number": 1}),
+            encoding="utf-8",
+        )
+
+    db = tmp_path / "test.db"
+    SqliteStorage(db).close()
+    load_bills(storage_dir=storage_dir, db_path=db)
+    index_bills(db_path=db)
+
+    class _StubResp:
+        def __init__(self, vectors: list[list[float]]) -> None:
+            self.data = [type("D", (), {"embedding": v})() for v in vectors]
+
+    class _StubEmb:
+        def create(self, *, model: str, input: list[str]) -> _StubResp:
+            return _StubResp([[0.5] * EMBEDDING_DIM for _ in input])
+
+    class _Stub:
+        embeddings = _StubEmb()
+
+    app = create_app(db, embedder=Embedder(_Stub()))
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # Enriched bill renders live sections.
+    resp = client.get("/bills/119/hr/1")
+    assert resp.status_code == 200
+    assert "Cosponsors not yet fetched" not in resp.text
+    # First cosponsor bioguide id from the fixture should be present.
+    assert "B001302" in resp.text
+    # First action text from the fixture.
+    assert "Became Public Law No: 119-1." in resp.text
+    # Subject chip.
+    assert "Pipelines" in resp.text
+
+    # Tier-1-only bill shows the empty-state for every tier-2 section.
+    resp = client.get("/bills/119/hr/22")
+    assert resp.status_code == 200
+    assert "Cosponsors not yet fetched" in resp.text
+    assert "Action history not yet fetched" in resp.text
+    assert "Subjects not yet fetched" in resp.text
+    assert "Titles not yet fetched" in resp.text
+    assert "Summaries not yet fetched" in resp.text

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 import concord
 from concord.embedding import EMBEDDING_DIM, Embedder
+from concord.models import Member, Term
 from concord.pipeline.index_bills import index as index_bills
 from concord.pipeline.index_members import index as index_members
 from concord.pipeline.load_bills import load as load_bills
@@ -210,6 +211,51 @@ def test_bills_tier2_end_to_end(tmp_path: Path) -> None:
     load_bills(storage_dir=storage_dir, db_path=db)
     index_bills(db_path=db)
 
+    # Seed two Members so the Member-profile cross-link assertions can
+    # resolve names — B001302 cosponsored the enriched bill, R000614
+    # sponsored the tier-1-only bill.
+    with SqliteStorage(db, load_vec=False) as storage:
+        storage.upsert_member(
+            Member(
+                bioguide_id="B001302",
+                first_name="Dan",
+                last_name="Bishop",
+                display_name="Dan Bishop",
+            ),
+            [
+                Term(
+                    bioguide_id="B001302",
+                    congress=119,
+                    chamber="house",
+                    state="NC",
+                    district=8,
+                    party="Republican",
+                    start_date="2025-01-03",
+                ),
+            ],
+            fetched_at=fetched_at,
+        )
+        storage.upsert_member(
+            Member(
+                bioguide_id="R000614",
+                first_name="Chip",
+                last_name="Roy",
+                display_name="Chip Roy",
+            ),
+            [
+                Term(
+                    bioguide_id="R000614",
+                    congress=119,
+                    chamber="house",
+                    state="TX",
+                    district=21,
+                    party="Republican",
+                    start_date="2025-01-03",
+                ),
+            ],
+            fetched_at=fetched_at,
+        )
+
     class _StubResp:
         def __init__(self, vectors: list[list[float]]) -> None:
             self.data = [type("D", (), {"embedding": v})() for v in vectors]
@@ -243,3 +289,18 @@ def test_bills_tier2_end_to_end(tmp_path: Path) -> None:
     assert "Subjects not yet fetched" in resp.text
     assert "Titles not yet fetched" in resp.text
     assert "Summaries not yet fetched" in resp.text
+
+    # Cosponsor of the enriched bill: Cosponsored bills section lists it.
+    resp = client.get("/members/B001302")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Cosponsored bills" in body
+    assert "Lower Energy Costs Act" in body
+    assert "No cosponsored bills indexed" not in body
+
+    # Sponsor of the tier-1-only bill: Cosponsored bills section is empty.
+    resp = client.get("/members/R000614")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Cosponsored bills" in body
+    assert "No cosponsored bills indexed" in body

--- a/tests/test_storage_bills_sqlite.py
+++ b/tests/test_storage_bills_sqlite.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import pytest
 
-from concord.models import Bill
+from concord.models import (
+    Bill,
+    BillAction,
+    BillSubject,
+    BillSummary,
+    BillTitle,
+    Cosponsor,
+)
 from concord.storage.sqlite import SqliteStorage
 
 
@@ -104,11 +111,165 @@ class TestSchemaConstraints:
 class TestBillsFtsTable:
     def test_table_exists_and_is_queryable(self, storage: SqliteStorage) -> None:
         storage.connection.execute(
-            "INSERT INTO bills_fts (bill_id, identifier, title, policy_area) VALUES (?, ?, ?, ?)",
-            ("119-hr-1", "hr 1", "Lower Energy Costs Act", "Energy"),
+            "INSERT INTO bills_fts "
+            "(bill_id, identifier, title, policy_area, short_title, subjects) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("119-hr-1", "hr 1", "Lower Energy Costs Act", "Energy", "", ""),
         )
         rows = storage.connection.execute(
             "SELECT bill_id FROM bills_fts WHERE bills_fts MATCH ?",
             ("energy",),
         ).fetchall()
         assert [r["bill_id"] for r in rows] == ["119-hr-1"]
+
+    def test_short_title_column_searchable(self, storage: SqliteStorage) -> None:
+        storage.connection.execute(
+            "INSERT INTO bills_fts "
+            "(bill_id, identifier, title, policy_area, short_title, subjects) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("119-hr-1", "hr 1", "Long Official Title", None, "Cool Bill", ""),
+        )
+        rows = storage.connection.execute(
+            "SELECT bill_id FROM bills_fts WHERE bills_fts MATCH ?",
+            ("cool",),
+        ).fetchall()
+        assert [r["bill_id"] for r in rows] == ["119-hr-1"]
+
+
+class TestBillTier2:
+    def _seed_bill(self, storage: SqliteStorage) -> str:
+        storage.upsert_bill(_bill(), fetched_at="2026-05-25T14:02:11+00:00")
+        return "119-hr-1"
+
+    def test_replace_cosponsors_inserts_and_stamps(self, storage: SqliteStorage) -> None:
+        bill_id = self._seed_bill(storage)
+        storage.replace_bill_cosponsors(
+            bill_id,
+            [
+                Cosponsor(
+                    bioguide_id="A000001", sponsorship_date="2025-01-09", is_original_cosponsor=True
+                ),
+                Cosponsor(
+                    bioguide_id="B000002",
+                    sponsorship_date="2025-02-04",
+                    is_original_cosponsor=False,
+                ),
+            ],
+            fetched_at="2026-05-26T00:00:00+00:00",
+        )
+        rows = storage.cosponsors_for_bill(bill_id)
+        assert {r["bioguide_id"] for r in rows} == {"A000001", "B000002"}
+        # is_original DESC → A000001 first.
+        assert rows[0]["bioguide_id"] == "A000001"
+        assert rows[0]["is_original_cosponsor"] == 1
+        row = storage.get_bill(bill_id)
+        assert row is not None
+        assert row["cosponsors_fetched_at"] == "2026-05-26T00:00:00+00:00"
+
+    def test_replace_cosponsors_is_idempotent(self, storage: SqliteStorage) -> None:
+        bill_id = self._seed_bill(storage)
+        cosponsors = [Cosponsor(bioguide_id="A000001")]
+        storage.replace_bill_cosponsors(bill_id, cosponsors, fetched_at="2026-05-26T00:00:00Z")
+        storage.replace_bill_cosponsors(bill_id, cosponsors, fetched_at="2026-05-27T00:00:00Z")
+        rows = storage.cosponsors_for_bill(bill_id)
+        assert len(rows) == 1
+
+    def test_replace_cosponsors_drops_removed(self, storage: SqliteStorage) -> None:
+        bill_id = self._seed_bill(storage)
+        storage.replace_bill_cosponsors(
+            bill_id,
+            [Cosponsor(bioguide_id="A000001"), Cosponsor(bioguide_id="B000002")],
+            fetched_at="2026-05-26T00:00:00Z",
+        )
+        storage.replace_bill_cosponsors(
+            bill_id,
+            [Cosponsor(bioguide_id="A000001")],
+            fetched_at="2026-05-27T00:00:00Z",
+        )
+        rows = storage.cosponsors_for_bill(bill_id)
+        assert [r["bioguide_id"] for r in rows] == ["A000001"]
+
+    def test_replace_actions(self, storage: SqliteStorage) -> None:
+        bill_id = self._seed_bill(storage)
+        storage.replace_bill_actions(
+            bill_id,
+            [
+                BillAction(action_date="2026-03-30", action_text="Became law"),
+                BillAction(action_date="2025-01-09", action_text="Introduced"),
+            ],
+            fetched_at="2026-05-26T00:00:00Z",
+        )
+        rows = storage.actions_for_bill(bill_id)
+        assert [r["action_text"] for r in rows] == ["Became law", "Introduced"]
+        row = storage.get_bill(bill_id)
+        assert row is not None
+        assert row["actions_fetched_at"] == "2026-05-26T00:00:00Z"
+
+    def test_replace_subjects_deduplicates(self, storage: SqliteStorage) -> None:
+        bill_id = self._seed_bill(storage)
+        storage.replace_bill_subjects(
+            bill_id,
+            [BillSubject(name="Energy"), BillSubject(name="Energy"), BillSubject(name="Gas")],
+            fetched_at="2026-05-26T00:00:00Z",
+        )
+        rows = storage.subjects_for_bill(bill_id)
+        assert {r["subject"] for r in rows} == {"Energy", "Gas"}
+
+    def test_replace_titles(self, storage: SqliteStorage) -> None:
+        bill_id = self._seed_bill(storage)
+        storage.replace_bill_titles(
+            bill_id,
+            [
+                BillTitle(title_type="Display Title", title_text="Cool Act"),
+                BillTitle(title_type="Short Title(s) as Introduced", title_text="Cool Act"),
+            ],
+            fetched_at="2026-05-26T00:00:00Z",
+        )
+        rows = storage.titles_for_bill(bill_id)
+        assert len(rows) == 2
+        assert rows[0]["title_type"] == "Display Title"
+
+    def test_replace_summaries_dedups_by_version(self, storage: SqliteStorage) -> None:
+        bill_id = self._seed_bill(storage)
+        storage.replace_bill_summaries(
+            bill_id,
+            [
+                BillSummary(version_code="00", summary_text="<p>a</p>"),
+                BillSummary(version_code="18", summary_text="<p>b</p>"),
+                BillSummary(version_code="00", summary_text="<p>a-newer</p>"),
+            ],
+            fetched_at="2026-05-26T00:00:00Z",
+        )
+        rows = storage.summaries_for_bill(bill_id)
+        assert {r["version_code"] for r in rows} == {"00", "18"}
+        text_00 = next(r["summary_text"] for r in rows if r["version_code"] == "00")
+        assert text_00 == "<p>a-newer</p>"
+
+    def test_bill_delete_cascades_to_children(self, storage: SqliteStorage) -> None:
+        bill_id = self._seed_bill(storage)
+        storage.replace_bill_cosponsors(
+            bill_id, [Cosponsor(bioguide_id="A000001")], fetched_at="2026-05-26T00:00:00Z"
+        )
+        storage.replace_bill_actions(
+            bill_id,
+            [BillAction(action_date="2025-01-09", action_text="Introduced")],
+            fetched_at="2026-05-26T00:00:00Z",
+        )
+        storage.connection.execute("DELETE FROM bills WHERE bill_id = ?", (bill_id,))
+        storage.connection.commit()
+        assert storage.cosponsors_for_bill(bill_id) == []
+        assert storage.actions_for_bill(bill_id) == []
+
+    def test_upsert_bill_preserves_fetched_at_stamps(self, storage: SqliteStorage) -> None:
+        """Re-running tier-1 upsert must NOT reset *_fetched_at columns."""
+        bill_id = self._seed_bill(storage)
+        storage.replace_bill_cosponsors(
+            bill_id, [Cosponsor(bioguide_id="A000001")], fetched_at="2026-05-26T00:00:00Z"
+        )
+        # Now re-upsert the parent bill row with a new title.
+        storage.upsert_bill(_bill(title="Renamed"), fetched_at="2026-06-01T00:00:00+00:00")
+        row = storage.get_bill(bill_id)
+        assert row is not None
+        assert row["title"] == "Renamed"
+        # The tier-2 stamp must still be set.
+        assert row["cosponsors_fetched_at"] == "2026-05-26T00:00:00Z"

--- a/tests/test_storage_bills_sqlite.py
+++ b/tests/test_storage_bills_sqlite.py
@@ -205,6 +205,22 @@ class TestBillTier2:
         assert row is not None
         assert row["actions_fetched_at"] == "2026-05-26T00:00:00Z"
 
+    def test_actions_returned_newest_first_regardless_of_ord(self, storage: SqliteStorage) -> None:
+        """Regression: ordering uses action_date, not the insert-order ord."""
+        bill_id = self._seed_bill(storage)
+        # Insert with intentionally-shuffled date order: middle, newest, oldest.
+        storage.replace_bill_actions(
+            bill_id,
+            [
+                BillAction(action_date="2025-06-15", action_text="middle"),
+                BillAction(action_date="2026-03-30", action_text="newest"),
+                BillAction(action_date="2025-01-09", action_text="oldest"),
+            ],
+            fetched_at="2026-05-26T00:00:00Z",
+        )
+        rows = storage.actions_for_bill(bill_id)
+        assert [r["action_text"] for r in rows] == ["newest", "middle", "oldest"]
+
     def test_replace_subjects_deduplicates(self, storage: SqliteStorage) -> None:
         bill_id = self._seed_bill(storage)
         storage.replace_bill_subjects(

--- a/tests/test_web_bills.py
+++ b/tests/test_web_bills.py
@@ -8,7 +8,16 @@ import pytest
 from fastapi.testclient import TestClient
 
 from concord.embedding import EMBEDDING_DIM, Embedder
-from concord.models import Bill, Member, Term
+from concord.models import (
+    Bill,
+    BillAction,
+    BillSubject,
+    BillSummary,
+    BillTitle,
+    Cosponsor,
+    Member,
+    Term,
+)
 from concord.pipeline.index_bills import index as index_bills
 from concord.storage.sqlite import SqliteStorage
 from concord.web.app import create_app
@@ -189,9 +198,12 @@ class TestBillProfile:
         # Sponsor link present (Member in table).
         assert "Steve Scalise" in body
         assert "/members/S001176" in body
-        # Phase 2b placeholders visible.
-        assert "Cosponsors (Phase 2b)" in body
-        assert "Action history (Phase 2b)" in body
+        # Tier-2 empty-states are visible — this bill has no enrichment loaded.
+        assert "Cosponsors not yet fetched" in body
+        assert "Action history not yet fetched" in body
+        assert "Subjects not yet fetched" in body
+        assert "Titles not yet fetched" in body
+        assert "Summaries not yet fetched" in body
         # Phase 3/4/5 placeholders.
         assert "Vote history (Phase 3)" in body
         assert "Committee path (Phase 4)" in body
@@ -212,6 +224,78 @@ class TestBillProfile:
         body = resp.text
         assert "R000614" in body
         assert "(not indexed)" in body
+
+    def test_enriched_bill_renders_sections(self, client: TestClient) -> None:
+        db_path = client.app.state.db_path
+        with SqliteStorage(db_path, load_vec=False) as storage:
+            storage.replace_bill_cosponsors(
+                "119-hr-1",
+                [
+                    Cosponsor(
+                        bioguide_id="S001176",
+                        sponsorship_date="2025-01-09",
+                        is_original_cosponsor=True,
+                    ),
+                    Cosponsor(
+                        bioguide_id="Z999999",
+                        sponsorship_date="2025-02-01",
+                        sponsorship_withdrawn_date="2025-03-15",
+                    ),
+                ],
+                fetched_at="2026-05-26T00:00:00Z",
+            )
+            storage.replace_bill_actions(
+                "119-hr-1",
+                [
+                    BillAction(action_date="2026-03-30", action_text="Became Public Law"),
+                    BillAction(action_date="2025-01-09", action_text="Introduced in House"),
+                ],
+                fetched_at="2026-05-26T00:00:00Z",
+            )
+            storage.replace_bill_subjects(
+                "119-hr-1",
+                [BillSubject(name="Energy"), BillSubject(name="Pipelines")],
+                fetched_at="2026-05-26T00:00:00Z",
+            )
+            storage.replace_bill_titles(
+                "119-hr-1",
+                [
+                    BillTitle(
+                        title_type="Short Title(s) as Introduced",
+                        title_text="Lower Energy Costs Act",
+                    ),
+                ],
+                fetched_at="2026-05-26T00:00:00Z",
+            )
+            storage.replace_bill_summaries(
+                "119-hr-1",
+                [
+                    BillSummary(
+                        version_code="00",
+                        action_date="2025-01-09",
+                        action_desc="Introduced",
+                        summary_text="<p>Intro summary</p>",
+                    ),
+                ],
+                fetched_at="2026-05-26T00:00:00Z",
+            )
+
+        resp = client.get("/bills/119/hr/1")
+        assert resp.status_code == 200
+        body = resp.text
+        # Empty states are gone for this bill.
+        assert "Cosponsors not yet fetched" not in body
+        # Cosponsor: indexed Member shows up by name.
+        assert "Steve Scalise" in body
+        # Withdrawn cosponsor renders as <del> with a (withdrawn ...) marker.
+        assert "(withdrawn 2025-03-15)" in body
+        assert "<del" in body
+        # Action history present with reverse-chrono date.
+        assert "Became Public Law" in body
+        # Subjects rendered as chips.
+        assert "Pipelines" in body
+        # Summary's HTML body is rendered (safe).
+        assert "Intro summary" in body
 
 
 class TestFederatedBillsSearch:
@@ -252,5 +336,33 @@ class TestMemberProfileSponsoredCrossLink:
         body = resp.text
         assert "Sponsored bills" in body
         assert "Lower Energy Costs Act" in body
-        # Cosponsored placeholder still visible, but relabeled for 2b.
-        assert "Cosponsored bills (Phase 2b)" in body
+        # Cosponsored section is now live; with no enrichment in the seed,
+        # it shows the empty-state CLI hint.
+        assert "Cosponsored bills" in body
+        assert "No cosponsored bills indexed" in body
+
+
+class TestMemberProfileCosponsoredEnriched:
+    def test_cosponsored_lists_bill_when_enriched(self, client: TestClient, tmp_path: Path) -> None:
+        # Reach into the seeded DB and add a cosponsor edge.
+        db_path = client.app.state.db_path
+        with SqliteStorage(db_path, load_vec=False) as storage:
+            storage.replace_bill_cosponsors(
+                "119-hr-22",
+                [
+                    Cosponsor(
+                        bioguide_id="S001176",
+                        sponsorship_date="2025-02-04",
+                        is_original_cosponsor=False,
+                    )
+                ],
+                fetched_at="2026-05-26T00:00:00Z",
+            )
+
+        resp = client.get("/members/S001176")
+        assert resp.status_code == 200
+        body = resp.text
+        # Scalise now appears in the Cosponsored bills section as 119-hr-22.
+        assert "Safeguard American Voter Eligibility Act" in body
+        # The "No cosponsored" empty-state should be gone for this member.
+        assert "No cosponsored bills indexed" not in body

--- a/tests/test_web_bills.py
+++ b/tests/test_web_bills.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -20,7 +21,7 @@ from concord.models import (
 )
 from concord.pipeline.index_bills import index as index_bills
 from concord.storage.sqlite import SqliteStorage
-from concord.web.app import create_app
+from concord.web.app import create_app, humanize_age
 
 
 class _StubData:
@@ -366,3 +367,60 @@ class TestMemberProfileCosponsoredEnriched:
         assert "Safeguard American Voter Eligibility Act" in body
         # The "No cosponsored" empty-state should be gone for this member.
         assert "No cosponsored bills indexed" not in body
+
+
+class TestHumanizeAge:
+    """The Jinja filter that renders ISO timestamps as 'N units ago'."""
+
+    _NOW = datetime(2026, 5, 25, 14, 0, 0, tzinfo=UTC)
+
+    def test_none_returns_empty(self) -> None:
+        assert humanize_age(None) == ""
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert humanize_age("") == ""
+
+    def test_unparseable_returns_empty(self) -> None:
+        assert humanize_age("not-a-timestamp") == ""
+
+    def test_just_now_under_30s(self) -> None:
+        recent = "2026-05-25T13:59:45+00:00"
+        assert humanize_age(recent, now=self._NOW) == "just now"
+
+    def test_seconds_ago(self) -> None:
+        assert humanize_age("2026-05-25T13:59:15+00:00", now=self._NOW) == "45 seconds ago"
+
+    def test_minutes_ago_singular(self) -> None:
+        assert humanize_age("2026-05-25T13:59:00+00:00", now=self._NOW) == "1 minute ago"
+
+    def test_minutes_ago_plural(self) -> None:
+        assert humanize_age("2026-05-25T13:55:00+00:00", now=self._NOW) == "5 minutes ago"
+
+    def test_hours_ago(self) -> None:
+        assert humanize_age("2026-05-25T11:00:00+00:00", now=self._NOW) == "3 hours ago"
+
+    def test_days_ago(self) -> None:
+        assert humanize_age("2026-05-22T14:00:00+00:00", now=self._NOW) == "3 days ago"
+
+    def test_in_the_future(self) -> None:
+        assert humanize_age("2026-05-26T14:00:00+00:00", now=self._NOW) == "in the future"
+
+    def test_naive_timestamp_assumed_utc(self) -> None:
+        assert humanize_age("2026-05-25T13:55:00", now=self._NOW) == "5 minutes ago"
+
+    def test_renders_in_bill_profile(self, client: TestClient) -> None:
+        """End-to-end: the filter renders something other than the raw ISO."""
+        db_path = client.app.state.db_path
+        with SqliteStorage(db_path, load_vec=False) as storage:
+            storage.replace_bill_cosponsors(
+                "119-hr-1",
+                [Cosponsor(bioguide_id="A000001")],
+                fetched_at="2020-01-01T00:00:00+00:00",
+            )
+        resp = client.get("/bills/119/hr/1")
+        assert resp.status_code == 200
+        # Raw ISO must not appear in the body.
+        assert "2020-01-01T00:00:00+00:00" not in resp.text
+        # "Fetched ... ago" should appear (years old, so "year(s) ago").
+        assert "year" in resp.text
+        assert "ago" in resp.text


### PR DESCRIPTION
## Summary

Implements [docs/plans/phase-2b-bills-enrichment.md](docs/plans/phase-2b-bills-enrichment.md): ad-hoc per-bill enrichment via the five congress.gov sub-endpoints, projected into child tables, and surfaced on the Bill / Member profiles with explicit per-section "fetched X" vs "not yet fetched" states.

- **API client** (`src/concord/api.py`): five new methods (`get_bill_cosponsors`, `_actions`, `_subjects`, `_titles`, `_summaries`) with a shared sub-endpoint paginator that concatenates pages into one returned dict.
- **Models**: `Cosponsor`, `BillAction`, `BillSubject`, `BillTitle`, `BillSummary` + matching `parse_*` projectors.
- **Storage** (`src/concord/storage/sqlite.py`): five new child tables (FK to `bills` with `ON DELETE CASCADE`), five `bills.*_fetched_at` columns, `bills_fts` extended with `short_title` and `subjects`. The tier-1 `upsert_bill` deliberately leaves the tier-2 stamps alone so re-running `concord load bills` doesn't wipe enrichment state. Per-section `replace_bill_*` (DELETE-then-INSERT, transactional) + `*_for_bill` readers.
- **Scraper** (`src/concord/scraper/bills.py`): new `scrape_enrichment(client, bill_keys, …, sections=…, limit=…)`. Per ADR 0009, writes one envelope per (bill, section) to `data/bill_<section>.jsonl`. A failure in one section doesn't prevent the other four from being written.
- **Loader** (`src/concord/pipeline/load_bills.py`): reads the five tier-2 JSONLs when present, projects latest-per-key into child tables, stamps the `*_fetched_at` columns. Tier-2 rows whose `bill_id` isn't in `bills` are counted as `tier2_orphans_skipped` (no FK violation).
- **Indexer** (`src/concord/pipeline/index_bills.py`): populates `bills_fts.short_title` (first `Short Title%` row) and `bills_fts.subjects` (pipe-joined, alphabetized for byte-stable re-indexes). Tier-1-only bills are still indexed; those columns are simply empty.
- **CLI** (`src/concord/cli.py`): `concord scrape bills` is now a sub-typer; new `concord scrape bills enrich --bill-ids 119-hr-1,… [--sections …] [--db …] [--limit N]`. The auto-select form (`--db` without `--bill-ids`) picks the newest-introduced bills where `cosponsors_fetched_at IS NULL`. `--limit` applies to both forms.
- **Web**: Bill profile renders all five sections live, with per-section empty-state CLI hints when `*_fetched_at IS NULL`. Cosponsors render with original / withdrawn-with-`<del>` styling. Action history dims committee referrals and motions-to-recommit; introductions / passage / law are rendered prominently. Summaries collapse with the latest open. Fetched/Updated timestamps render via a new `humanize_age` Jinja filter ("3 days ago"). Member profile's Cosponsored bills is now live (cross-link via `bill_cosponsors`).
- **Tests**: new fixtures for all five sub-endpoints; extended `test_api`, `test_models_bills`, `test_storage_bills_sqlite`, `test_scraper_bills`, `test_pipeline_bills`, `test_cli`, `test_web_bills`, `test_smoke`.

437 tests pass; `ruff check`, `ruff format --check`, and `mypy --strict` are clean.

## Reviewer notes

- Per ADR 0003, no schema migration: the upgrade path is `rm data/proceedings.db && concord load proceedings && concord load bills`.
- `--db`-driven auto-select uses `cosponsors_fetched_at` as the canonical "is this bill enriched?" signal — sections typically fetch together.
- Bulk enrichment of 117–119 (~700K API calls, ~30 GB) is intentionally **not** triggered by this PR — operators choose a strategy.
- **`_BILL_UPSERT_SQL` deliberately excludes the five `*_fetched_at` columns** even though they live on the `bills` row. The plan listed them on `bills` for storage reasons, but they're owned by the tier-2 loader pass — including them in the tier-1 upsert would reset enrichment state every time `concord load bills` runs. Locked in by `test_rerunning_load_preserves_fetched_at`.
- `actions_for_bill` and the indexer's `subjects` aggregator both sort in SQL rather than relying on input order; regression tests pin the new ordering.

## Test plan

- [x] `pytest` clean (437 passing)
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy` clean
- [x] Smoke: `test_bills_tier2_end_to_end` covers enriched/tier-1-only Bill pages plus the two Member-profile (cosponsor / sponsor) routes.
- [ ] Manual: with `CONGRESS_API_KEY` set, `concord scrape bills enrich --bill-ids 119-hr-1 --storage-dir /tmp/concord` writes five non-empty files.

## Deferred (separate PR)

Two perf items the review flagged as deferrable until bulk enrichment is actually being run:

- Loader's orphan check is N+1 (`storage.get_bill(bill_id)` per row × per section).
- Each `replace_bill_*` opens its own BEGIN/COMMIT (5N tiny transactions on a fresh enrichment load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)