### PR TITLE
Bills enrichment loader: batch orphan lookup + single transaction

### DIFF
--- a/src/concord/pipeline/load_bills.py
+++ b/src/concord/pipeline/load_bills.py
@@ -99,12 +99,17 @@ def load(
         tier2_snapshots_read = 0
         tier2_bills_updated = 0
         tier2_orphans_skipped = 0
-        for section in BILL_ENRICHMENT_SECTIONS:
-            t2 = _load_tier2_section(storage_dir, section, storage)
-            tier2_snapshots_read += t2["snapshots_read"]
-            tier2_bills_updated += t2["bills_updated"]
-            tier2_orphans_skipped += t2["orphans_skipped"]
-            malformed += t2["malformed"]
+        # Collapse the 5N tier-2 per-section transactions into one
+        # batch. Each replace_bill_* joins this transaction via
+        # storage._maybe_transaction. A bulk load that previously
+        # paid the fsync cost per section per bill now pays it once.
+        with storage.transaction():
+            for section in BILL_ENRICHMENT_SECTIONS:
+                t2 = _load_tier2_section(storage_dir, section, storage)
+                tier2_snapshots_read += t2["snapshots_read"]
+                tier2_bills_updated += t2["bills_updated"]
+                tier2_orphans_skipped += t2["orphans_skipped"]
+                malformed += t2["malformed"]
     finally:
         storage.close()
 
@@ -199,8 +204,11 @@ def _load_tier2_section(
             if current is None or fetched_at > current[0]:
                 latest[bill_id] = (fetched_at, payload)
 
+    # One IN-list query instead of N point-lookups: at full-Congress
+    # scale the orphan check used to dominate the loader.
+    present = storage.bill_ids_present(list(latest.keys()))
     for bill_id, (fetched_at, payload) in latest.items():
-        if storage.get_bill(bill_id) is None:
+        if bill_id not in present:
             counters["orphans_skipped"] += 1
             _log.info(
                 "tier-2 orphan: %s in %s but no parent bill row; skipping",

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -23,7 +23,8 @@ caller can pass ``load_vec=False`` to skip the extension entirely.
 """
 
 import sqlite3
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
+from contextlib import contextmanager
 from pathlib import Path
 from types import TracebackType
 from typing import Any
@@ -342,6 +343,13 @@ _BILL_COLUMNS: tuple[str, ...] = (
 # The five *_fetched_at columns are upserted only when their tier-2
 # loader has new snapshots to flush; the parent bills row uses the
 # columns above. Listed for use by per-section UPDATE statements.
+#: Cap on placeholders per ``bill_id IN (...)`` lookup. SQLite defaults to
+#: 32766 in modern builds but historically 999; keeping the chunk well
+#: below either limit avoids the compile-time complaints on older
+#: distros without measurably hurting throughput.
+_BILL_IDS_PRESENT_CHUNK = 500
+
+
 BILL_TIER2_SECTIONS: tuple[str, ...] = (
     "cosponsors",
     "actions",
@@ -454,6 +462,10 @@ class SqliteStorage:
         self._conn = sqlite3.connect(self._path)
         self._conn.row_factory = sqlite3.Row
         self._load_vec = load_vec
+        # Set when a caller-owned :meth:`transaction` context is active.
+        # The per-section ``replace_bill_*`` writers consult this so they
+        # don't open nested BEGIN/COMMITs inside an outer batch.
+        self._in_tx = False
 
         if load_vec:
             self._conn.enable_load_extension(True)
@@ -643,6 +655,29 @@ class SqliteStorage:
         row: sqlite3.Row | None = cursor.fetchone()
         return row
 
+    def bill_ids_present(self, bill_ids: Sequence[str]) -> set[str]:
+        """Return the subset of ``bill_ids`` that already have a row in ``bills``.
+
+        Used by the tier-2 loader to filter out orphan rows in one query
+        instead of an N+1 ``get_bill`` loop. Empty input returns an
+        empty set without touching the DB. The query is chunked at
+        :data:`_BILL_IDS_PRESENT_CHUNK` placeholders to stay under
+        SQLite's compile-time variable cap.
+        """
+        if not bill_ids:
+            return set()
+        present: set[str] = set()
+        ids = list(bill_ids)
+        for start in range(0, len(ids), _BILL_IDS_PRESENT_CHUNK):
+            chunk = ids[start : start + _BILL_IDS_PRESENT_CHUNK]
+            placeholders = ",".join("?" for _ in chunk)
+            cursor = self._conn.execute(
+                f"SELECT bill_id FROM bills WHERE bill_id IN ({placeholders})",
+                chunk,
+            )
+            present.update(row["bill_id"] for row in cursor)
+        return present
+
     # -- Bills tier-2 child tables (Phase 2b) -----------------------------
 
     def replace_bill_cosponsors(
@@ -657,10 +692,11 @@ class SqliteStorage:
         Idempotent: re-running with the same set produces the same final
         state. Safe to call for a Bill not in the ``bills`` table — the
         FK will block the INSERT before any rows are written; callers
-        should filter out unknown ``bill_id`` before invoking.
+        should filter out unknown ``bill_id`` before invoking. When the
+        caller has an outer :meth:`transaction` open, the BEGIN/COMMIT
+        here is skipped — the work joins the batch.
         """
-        try:
-            self._conn.execute("BEGIN")
+        with self._maybe_transaction():
             self._conn.execute("DELETE FROM bill_cosponsors WHERE bill_id = ?", (bill_id,))
             if cosponsors:
                 self._conn.executemany(
@@ -680,10 +716,6 @@ class SqliteStorage:
                 "UPDATE bills SET cosponsors_fetched_at = ? WHERE bill_id = ?",
                 (fetched_at, bill_id),
             )
-            self._conn.execute("COMMIT")
-        except Exception:
-            self._conn.execute("ROLLBACK")
-            raise
 
     def replace_bill_actions(
         self,
@@ -693,8 +725,7 @@ class SqliteStorage:
         fetched_at: str,
     ) -> None:
         """DELETE-then-INSERT every BillAction for one bill_id; stamp the column."""
-        try:
-            self._conn.execute("BEGIN")
+        with self._maybe_transaction():
             self._conn.execute("DELETE FROM bill_actions WHERE bill_id = ?", (bill_id,))
             if actions:
                 self._conn.executemany(
@@ -715,10 +746,6 @@ class SqliteStorage:
                 "UPDATE bills SET actions_fetched_at = ? WHERE bill_id = ?",
                 (fetched_at, bill_id),
             )
-            self._conn.execute("COMMIT")
-        except Exception:
-            self._conn.execute("ROLLBACK")
-            raise
 
     def replace_bill_subjects(
         self,
@@ -739,8 +766,7 @@ class SqliteStorage:
                 continue
             seen.add(s.name)
             deduped.append(s)
-        try:
-            self._conn.execute("BEGIN")
+        with self._maybe_transaction():
             self._conn.execute("DELETE FROM bill_subjects WHERE bill_id = ?", (bill_id,))
             if deduped:
                 self._conn.executemany(
@@ -751,10 +777,6 @@ class SqliteStorage:
                 "UPDATE bills SET subjects_fetched_at = ? WHERE bill_id = ?",
                 (fetched_at, bill_id),
             )
-            self._conn.execute("COMMIT")
-        except Exception:
-            self._conn.execute("ROLLBACK")
-            raise
 
     def replace_bill_titles(
         self,
@@ -764,8 +786,7 @@ class SqliteStorage:
         fetched_at: str,
     ) -> None:
         """DELETE-then-INSERT every BillTitle for one bill_id; stamp the column."""
-        try:
-            self._conn.execute("BEGIN")
+        with self._maybe_transaction():
             self._conn.execute("DELETE FROM bill_titles WHERE bill_id = ?", (bill_id,))
             if titles:
                 self._conn.executemany(
@@ -779,10 +800,6 @@ class SqliteStorage:
                 "UPDATE bills SET titles_fetched_at = ? WHERE bill_id = ?",
                 (fetched_at, bill_id),
             )
-            self._conn.execute("COMMIT")
-        except Exception:
-            self._conn.execute("ROLLBACK")
-            raise
 
     def replace_bill_summaries(
         self,
@@ -799,8 +816,7 @@ class SqliteStorage:
         latest_per_version: dict[str, BillSummary] = {}
         for s in summaries:
             latest_per_version[s.version_code] = s
-        try:
-            self._conn.execute("BEGIN")
+        with self._maybe_transaction():
             self._conn.execute("DELETE FROM bill_summaries WHERE bill_id = ?", (bill_id,))
             if latest_per_version:
                 self._conn.executemany(
@@ -820,10 +836,6 @@ class SqliteStorage:
                 "UPDATE bills SET summaries_fetched_at = ? WHERE bill_id = ?",
                 (fetched_at, bill_id),
             )
-            self._conn.execute("COMMIT")
-        except Exception:
-            self._conn.execute("ROLLBACK")
-            raise
 
     def cosponsors_for_bill(self, bill_id: str) -> list[sqlite3.Row]:
         cursor = self._conn.execute(
@@ -886,6 +898,56 @@ class SqliteStorage:
         cursor = self._conn.execute("SELECT COUNT(*) FROM proceedings")
         (count,) = cursor.fetchone()
         return int(count)
+
+    # -- batched writes ---------------------------------------------------
+
+    @contextmanager
+    def _maybe_transaction(self) -> Iterator[None]:
+        """Open BEGIN/COMMIT iff no caller-owned transaction is active.
+
+        Internal helper for the per-section ``replace_bill_*`` writers
+        so the same code path works whether invoked standalone or
+        inside an outer :meth:`transaction` block.
+        """
+        if self._in_tx:
+            yield
+            return
+        self._conn.execute("BEGIN")
+        try:
+            yield
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
+        else:
+            self._conn.execute("COMMIT")
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Group many tier-2 writes into one BEGIN/COMMIT.
+
+        Callers that flush hundreds of bills across five sections
+        benefit substantially (5N small transactions collapse to one). The
+        ``replace_bill_*`` methods check :attr:`_in_tx` and skip their
+        own transaction wrappers when this context is active. Nested
+        ``transaction()`` calls aren't supported — raises if entered
+        recursively.
+
+        Rolls back on any exception so a partial bulk load doesn't
+        leave the DB half-projected.
+        """
+        if self._in_tx:
+            raise RuntimeError("SqliteStorage.transaction() is not re-entrant")
+        self._conn.execute("BEGIN")
+        self._in_tx = True
+        try:
+            yield
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            self._in_tx = False
+            raise
+        else:
+            self._conn.execute("COMMIT")
+            self._in_tx = False
 
     # -- lifecycle --------------------------------------------------------
 

--- a/tests/test_storage_bills_sqlite.py
+++ b/tests/test_storage_bills_sqlite.py
@@ -261,6 +261,18 @@ class TestBillTier2:
         text_00 = next(r["summary_text"] for r in rows if r["version_code"] == "00")
         assert text_00 == "<p>a-newer</p>"
 
+    def test_bill_ids_present_filters_to_known_rows(self, storage: SqliteStorage) -> None:
+        storage.upsert_bill(_bill(bill_id="119-hr-1"), fetched_at="2026-05-25T00:00:00Z")
+        storage.upsert_bill(
+            _bill(bill_id="119-hr-22", bill_number=22, title="X"),
+            fetched_at="2026-05-25T00:00:00Z",
+        )
+        result = storage.bill_ids_present(["119-hr-1", "119-hr-22", "119-hr-9999", "118-s-47"])
+        assert result == {"119-hr-1", "119-hr-22"}
+
+    def test_bill_ids_present_empty_input(self, storage: SqliteStorage) -> None:
+        assert storage.bill_ids_present([]) == set()
+
     def test_bill_delete_cascades_to_children(self, storage: SqliteStorage) -> None:
         bill_id = self._seed_bill(storage)
         storage.replace_bill_cosponsors(
@@ -275,6 +287,59 @@ class TestBillTier2:
         storage.connection.commit()
         assert storage.cosponsors_for_bill(bill_id) == []
         assert storage.actions_for_bill(bill_id) == []
+
+    def test_transaction_batches_writes(self, storage: SqliteStorage) -> None:
+        """All replace_bill_* calls inside one transaction commit together."""
+        bill_id = self._seed_bill(storage)
+        with storage.transaction():
+            storage.replace_bill_cosponsors(
+                bill_id,
+                [Cosponsor(bioguide_id="A000001")],
+                fetched_at="2026-05-26T00:00:00Z",
+            )
+            storage.replace_bill_actions(
+                bill_id,
+                [BillAction(action_date="2025-01-09", action_text="Introduced")],
+                fetched_at="2026-05-26T00:00:00Z",
+            )
+            storage.replace_bill_subjects(
+                bill_id,
+                [BillSubject(name="Energy")],
+                fetched_at="2026-05-26T00:00:00Z",
+            )
+        # After the block commits, every section is visible.
+        assert len(storage.cosponsors_for_bill(bill_id)) == 1
+        assert len(storage.actions_for_bill(bill_id)) == 1
+        assert len(storage.subjects_for_bill(bill_id)) == 1
+
+    def test_transaction_rolls_back_on_error(self, storage: SqliteStorage) -> None:
+        """An exception inside transaction() must revert every nested replace_*."""
+        bill_id = self._seed_bill(storage)
+
+        def _inside_transaction() -> None:
+            with storage.transaction():
+                storage.replace_bill_cosponsors(
+                    bill_id,
+                    [Cosponsor(bioguide_id="A000001")],
+                    fetched_at="2026-05-26T00:00:00Z",
+                )
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _inside_transaction()
+        assert storage.cosponsors_for_bill(bill_id) == []
+        # The bills row's fetched_at column must also be untouched.
+        row = storage.get_bill(bill_id)
+        assert row is not None
+        assert row["cosponsors_fetched_at"] is None
+
+    def test_transaction_is_not_reentrant(self, storage: SqliteStorage) -> None:
+        def _nested() -> None:
+            with storage.transaction(), storage.transaction():
+                pass
+
+        with pytest.raises(RuntimeError, match="not re-entrant"):
+            _nested()
 
     def test_upsert_bill_preserves_fetched_at_stamps(self, storage: SqliteStorage) -> None:
         """Re-running tier-1 upsert must NOT reset *_fetched_at columns."""


### PR DESCRIPTION
## Summary

Two perf items deferred from PR #55. Both are no-ops at the current 50-bill demo scale but matter as soon as bulk enrichment of a full Congress (5k–7k bills × 5 sections) is attempted.

- **Batch orphan check.** `SqliteStorage.bill_ids_present(ids)` runs one `SELECT bill_id FROM bills WHERE bill_id IN (...)` (chunked at 500 placeholders), and `_load_tier2_section` now pre-filters the orphan set against it instead of running `storage.get_bill(bill_id)` per row per section. At full-Congress scale that's ~30k fewer single-row lookups per enrichment pass.
- **One transaction per tier-2 pass.** New `SqliteStorage.transaction()` context manager opens one BEGIN/COMMIT around the whole tier-2 projection. The five `replace_bill_*` writers detect the outer transaction via a new `_in_tx` flag and skip their own per-call BEGIN/COMMIT. 5N small commits collapse to one batch, which is the real win — SQLite WAL fsync per commit is the dominant cost. Rolls back on exception; rejects re-entry.

## Reviewer notes

- The `replace_bill_*` methods stay callable standalone: when no outer `transaction()` context is active, each still wraps itself in BEGIN/COMMIT exactly as before. Existing single-bill call sites (the web tests, the per-bill smoke flows) need no changes.
- The new behavior is locked in by three storage-level tests: a happy-path batch, an exception-rolls-back-everything test (no rows visible after the block raises), and a re-entry guard.
- No DDL change, no plan change — purely an implementation refactor inside the loader and storage layer.

## Test plan

- [x] `pytest` clean (442 passing — five new storage-layer tests on top of PR #55's 437)
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy` clean
- [ ] Manual: a `concord load bills` over a tier-2-populated `data/` directory should still produce the same SQL state byte-for-byte as before this PR (idempotency + correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)