### PR TITLE
Phase 3 (Votes) plans — 3a (House) + 3b (Senate)

### DIFF
--- a/docs/plans/members-bills-votes-roadmap.md
+++ b/docs/plans/members-bills-votes-roadmap.md
@@ -69,11 +69,16 @@ Companion ADRs created during Phase 2 planning:
 
 ### Phase 3 — Votes
 
-- Stage 0: scrape `/house-vote` + `/senate-vote`. Augment from clerk.house.gov / senate.gov bulk XML for full per-member positions (the API is thin here).
-- Stage 1: `votes`, `vote_positions` (member × vote → yea/nay/present/not-voting) tables
-- Web: `/votes/{chamber}/{congress}/{session}/{roll}` page; Member page gains "Recent votes" + party-line alignment stat; Bill page gains "Vote history".
+Split into two parts during planning, after an API spike revealed `api.congress.gov` has no Senate vote endpoint at all (the roadmap's original "API is thin" phrase turned out to mean "absent for Senate"), and that the House API exposes full per-member positions via `/v3/house-vote/{c}/{s}/{roll}/members` — so the natural seam is **chamber** rather than metadata-vs-positions. Recorded in ADR 0010.
 
-**Done means:** the Member↔Bill loop closes through Votes. Party-line break stats are computable.
+- **[Phase 3a — Votes (House)](./phase-3a-votes-house.md).** House end-to-end from `api.congress.gov`. `votes`, `vote_positions`, and `member_party_unity` SQLite tables. `/votes` index + `/votes/{chamber}/{congress}/{session}/{roll}` profile with full ~430-row position roster. Bill page gains live "Vote history". House Member pages gain "Recent votes" + Party Unity Score (per ADR 0011); Senate Member pages render "(Phase 3b)" placeholders for both sections. `/about/methodology` page documents the score.
+- **[Phase 3b — Votes (Senate)](./phase-3b-votes-senate.md).** Senate end-to-end from senate.gov LIS XML (`https://www.senate.gov/legislative/LIS/roll_call_votes/...`) and the Senate roster XML (`senators_cfm.xml`). Builds a load-time, in-memory `member_full` → Bioguide bridge — no persistent alias table. Populates the same `votes` + `vote_positions` tables. Refines [ADR 0011](../adr/0011-party-unity-score-methodology.md) in place: party-unity is now chamber-scoped, so `member_party_unity` gains a `chamber` column. Removes the `--chambers senate` no-op and changes the default to include both chambers. Senate Member pages get live Recent-votes + party-unity sections.
+
+Companion ADRs created during Phase 3 planning:
+- ADR 0010 — Votes phased by chamber, not metadata-vs-positions — records the split. Committed in 3a.
+- ADR 0011 — Party Unity Score methodology — defines the methodology behind the Member-page party-line stat. Committed in 3a (House-only); amended in place during 3b to add chamber scoping.
+
+**Done means** (combined across 3a + 3b): the Member↔Bill loop closes through Votes. Party-line break stats are computable for both chambers. After 3a alone: House votes are browsable, Bill vote-history is complete for House votes, and House members have full party-unity coverage. After 3b: the same for Senate members and Senate-originated rolls.
 
 ### Phase 4 — Committees + Amendments
 
@@ -127,7 +132,7 @@ Captured so we don't quietly drift into them mid-v1:
 Tracked here so each phase's plan can re-check them:
 
 - **Staleness.** Each ingest source needs a daily refresh cadence wired up before its surface goes public. Phase plans must specify cadence + failure visibility.
-- **Editorial neutrality.** Phase 7's ranking surfaces are the highest-risk; Phase 3's party-line stat is the first place this bites. Define the stat with a named methodology, not a vibe.
+- **Editorial neutrality.** Phase 7's ranking surfaces are the highest-risk; Phase 3a's party-line stat is the first place this bites. Resolved by ADR 0011 (Party Unity Score, modeled on the CQ Almanac methodology) and a `/about/methodology` page surfaced from each Member profile.
 - **Mutability mismatch.** ADR 0006 handles the storage side. UI side: surface `fetched_at` on every Bill/Vote page so staleness is legible.
 - **Viz-vs-utility.** No network graphs in v1. If the urge appears mid-phase, push it to v2.
 

--- a/docs/plans/phase-3a-votes-house.md
+++ b/docs/plans/phase-3a-votes-house.md
@@ -1,0 +1,561 @@
+# Phase 3a — Votes (House) ingest
+
+> Ingest House roll-call votes — metadata, totals, bill/amendment subject, and full per-member positions — from `api.congress.gov` into Concord, surface them as `/votes/house/{congress}/{session}/{roll}` profile pages, federate Vote history onto the Bill profile, add a "Recent votes" section + a CQ-style party-unity score to each House Member's profile, and ship the methodology page that documents the stat.
+
+## Source
+
+- Roadmap: [docs/plans/members-bills-votes-roadmap.md](./members-bills-votes-roadmap.md) (Phase 3 section, lines 70–77)
+- Sibling plan (follow-up): **Phase 3b — Votes (Senate)** — to be planned after this lands; covers senate.gov LIS XML ingest end-to-end.
+- Phase 2a exemplar (template for this plan's structure and patterns): [docs/plans/phase-2a-bills-basic.md](./phase-2a-bills-basic.md)
+- Phase 1 exemplar (template for scraper / loader / indexer module shape): [docs/plans/phase-1-members.md](./phase-1-members.md)
+- Spike that reshaped the phase: [docs/plans/.spike-votes-api.md](./.spike-votes-api.md) and [docs/plans/.spike-votes-api-findings.md](./.spike-votes-api-findings.md). **Both files should be deleted once this plan is approved** — their findings are reflected below.
+
+## Context
+
+Concord's roadmap calls Phase 3 "Votes." The original sketch described one phase ingesting `/house-vote` + `/senate-vote` from `api.congress.gov`, augmented by clerk.house.gov / senate.gov bulk XML for full per-member positions. A spike against the live API (see findings file linked above) surfaced two facts that reshape the work:
+
+1. **api.congress.gov has no Senate vote endpoint at all** — `/v3/house-vote/{c}/{s}/{roll}` works but every Senate variant (`/senate-vote`, `/senate-rollcall-vote`, …) returns 404. The roadmap's "API is thin" phrasing turned out to mean "absent for Senate." Senate work must read senate.gov LIS XML from the start.
+2. **The House API delivers full per-member positions** at `/v3/house-vote/{c}/{s}/{roll}/members` (Bioguide-keyed, one ~100KB call per roll). The clerk.house.gov XML augmentation the roadmap named is not needed — the API has everything Phase 3 wants for the House half.
+
+Together these collapse the roadmap's implied "metadata vs positions" split and replace it with a **chamber split**: Phase 3a covers House end-to-end via the API; Phase 3b covers Senate end-to-end via senate.gov LIS XML (Legislative Information System — the Senate's internal data interchange format, exposed publicly per-roll at `https://www.senate.gov/legislative/LIS/roll_call_votes/...`). Recorded in [ADR 0010](../adr/0010-votes-phased-by-chamber.md) (new, created with this plan).
+
+A **Vote** is one recorded roll-call decision in a chamber. It is keyed by the tuple `(chamber, congress, session, roll_number)`. Concord's internal `vote_id` flattens that to `"{chamber}-{congress}-{session}-{roll}"` (e.g. `"house-119-1-240"`). A vote may be on a **Bill** (passage, motion to recommit), on an **Amendment** to a Bill, or on something else entirely (Speaker election, motion to adjourn, journal approval). The free-text `vote_question` field always carries the API's description of what was decided. New terms are added to the **Entities** section of [CONTEXT.md](../../CONTEXT.md) as part of this plan.
+
+The roadmap calls out two risks Phase 3 has to address head-on:
+
+- **Editorial neutrality on party-line alignment stats.** The Member-page party-line summary is the first place this risk bites. We commit to a **Party Unity Score** modeled on the *Congressional Quarterly* (CQ) Almanac's long-running methodology — published annually since 1953 and widely cited in political science — defined in [ADR 0011](../adr/0011-party-unity-score-methodology.md) (new, created with this plan), rather than an unnamed vibe number.
+- **Staleness.** Vote refresh is a daily-cadence operator-driven `concord run votes` job, same stance as Phase 2a. The Vote page header surfaces `Updated: {fetched_at}` so staleness is legible.
+
+## Goals
+
+1. The Tier 1 scraper fetches, for every House roll-call vote in Congresses 117, 118, and 119 (six `(congress, session)` slots — three congresses × two sessions), two endpoints per vote — the list endpoint `/v3/house-vote/{c}/{s}` (stubs, for discovery; not persisted) and the detail endpoint `/v3/house-vote/{c}/{s}/{roll}` (full vote record). For every detail fetched, also fetch `/v3/house-vote/{c}/{s}/{roll}/members` (the per-member positions sub-endpoint). Appends one [ADR 0006](../adr/0006-snapshot-on-fetch-for-mutable-entities.md) snapshot envelope per detail fetch to `data/house_votes.jsonl` and one per members fetch to `data/house_vote_positions.jsonl`.
+2. The loader projects the latest snapshot per `(chamber, congress, session, roll_number)` into a `votes` SQLite table and the latest members snapshot into `vote_positions` (one row per `(vote_id, bioguide_id)`).
+3. The indexer (Stage 2) populates `votes.is_party_unity` (a boolean denormalized onto each vote) and writes the `member_party_unity` table (denominator + numerator per `(bioguide_id, congress)`). No FTS5 over votes in this phase — see Non-goals.
+4. The web app serves:
+   - `GET /votes/{chamber}/{congress}/{session}/{roll}` — Vote profile (header + result block + subject + full position roster). Renders `chamber='senate'` rolls with a "(Phase 3b)" placeholder body if the route is hit before 3b ships.
+   - `GET /votes` — paginated browse, default sort `start_date DESC`, filters for `chamber`, `congress`, `result`, `vote_kind`, `bill` (by bill_id substring). 50 per page.
+5. The existing `/bills/{c}/{t}/{n}` profile gets a **Vote history** section: every roll where `votes.bill_id` OR `votes.amendment_id` (resolved to its underlying bill via Phase 4 once that lands; for now `amendment_id`'s bill linkage is derived from the same API payload via a stored `amendment_underlying_bill_id` column — see [Approach > Storage shape](#storage-shape)) matches. Replaces the existing "Vote history (Phase 3)" placeholder.
+6. The existing `/members/{bioguide_id}` profile gets two new sections for House members:
+   - **Recent votes** — latest 25 votes by date desc; shows date, identifier, question (truncated), position, result.
+   - **Party-unity score** — formatted as "Voted with [Republican|Democratic] majority on N% of party-unity votes (X/Y in 119th Congress)" plus a small history strip for earlier Congresses. Independents get a muted "no party-unity score (Independent)" note. Members with <10 party-unity votes in a Congress get a "(not enough votes yet)" note. A `?` icon links to `/about/methodology#party-unity`.
+   - Senate members continue to show a "(Phase 3b)" muted placeholder for both sections.
+7. A new static **methodology page** at `/about/methodology` ships in 3a, documenting the party-unity score definition. Single page; not a CMS. Anchor target `#party-unity` is the only anchor in scope.
+8. The existing `/search` route does **not** federate Votes in 3a (no FTS5 index — see Non-goals). The bare-identifier redirect path (`HR 1234` → bill) is unchanged.
+9. CLI follows [ADR 0007](../adr/0007-parallel-pipelines-per-entity.md): `concord scrape votes`, `concord load votes`, `concord index votes`, `concord run votes`. Every command takes `--limit N`. Every command takes `--chambers house,senate` defaulting to `house` only in 3a (with senate becoming a no-op that prints "Senate ingest lands in Phase 3b — skipping.").
+10. The code layout matches ADR 0007: `src/concord/scraper/votes.py` (one entry point `scrape_house`; `scrape_senate` lands in 3b alongside it) and `src/concord/pipeline/{load,index}_votes.py`.
+11. Vote→Bill / Vote→Amendment / Vote→Member columns store bare-TEXT identifiers (no `REFERENCES`) so ingest is robust to gaps in any peer table.
+12. Two new ADRs land with this work: [ADR 0010 — Votes phased by chamber, not metadata-vs-positions](../adr/0010-votes-phased-by-chamber.md) and [ADR 0011 — Party Unity Score methodology](../adr/0011-party-unity-score-methodology.md).
+13. All existing tests continue to pass.
+
+## Non-goals
+
+1. **Senate votes.** Zero Senate rows are loaded by 3a. `votes.chamber` allows `'senate'`; no row will satisfy the check until 3b lands. The CLI `--chambers senate` switch is wired as a no-op in 3a. senate.gov LIS XML is not parsed; the Bioguide↔LIS-ID mapping is not built.
+2. **Vote FTS5 / Bills federation in /search.** `vote_question` is a small free-text field; the existing `/search` already grew last phase, and there is no clear query pattern that wants it (HR-number lookups already redirect via the bare-identifier path). Phase 7 may add it if it earns the slot. No `votes_fts` virtual table is created in 3a.
+3. **Amendment entity table or `/amendments/...` route.** Phase 4. 3a stores `votes.amendment_id` as bare TEXT and renders amendment-vote rows with the amendment-vote affordances (a chip noting "Amendment HAMDT 85"), but there is no Amendment profile page to link to.
+4. **Cosponsor / committee / lobbying-money cross-cuts.** Out of phase.
+5. **Vote text search.** No tokenized full-text index.
+6. **Auto-release / cron scheduling for vote refresh.** Same stance as Phase 1 and Phase 2a — the operator runs `concord run votes` daily out of band.
+7. **Backfill before Congress 117.** The API only carries House votes back to Congress 116; the roadmap scopes to 117–119. 116 is left for a future backfill if useful.
+8. **Per-member positions on the Vote profile page being paginated.** ~430 House members per vote; the entire roster renders inline. No infinite-scroll, no AJAX. Mitigated by tight row layout.
+9. **Historical party-line trends across multiple Congresses on one chart.** Member page shows the current Congress prominently with a small history strip (numbers, not a chart). Visualizations belong to Phase 7.
+10. **`Vote` as a Pydantic model with deep validation of every API field.** Cover only the fields the loader writes; pass everything else through verbatim into JSONL.
+11. **A `votes_subject_kind` enum.** The `(bill_id, amendment_id)` pair already encodes the subject; an explicit enum would duplicate that information without enabling a query the columns can't answer.
+
+## Relevant prior decisions
+
+- [ADR 0001 — Python end-to-end for the web layer](../adr/0001-python-end-to-end-for-the-web-layer.md) — `/votes` and `/votes/{...}` extend the existing FastAPI+Jinja2+HTMX surface.
+- [ADR 0002 — JSONL as canonical raw store](../adr/0002-jsonl-as-canonical-raw-store.md) — vote data goes to `data/house_votes.jsonl` and `data/house_vote_positions.jsonl`.
+- [ADR 0003 — SQLite as derived store](../adr/0003-sqlite-as-derived-store.md) — `votes`, `vote_positions`, `member_party_unity` live in `data/proceedings.db`.
+- [ADR 0005 — Chunks as the unit of retrieval](../adr/0005-chunks-as-unit-of-retrieval.md) — does **not** apply (votes aren't chunked).
+- [ADR 0006 — Snapshot-on-fetch for mutable entities](../adr/0006-snapshot-on-fetch-for-mutable-entities.md) — Votes are recorded as snapshots; even though most votes are immutable post-close, errata corrections happen and uniformity beats special-casing.
+- [ADR 0007 — Parallel pipelines per entity](../adr/0007-parallel-pipelines-per-entity.md) — `src/concord/scraper/votes.py`, `src/concord/pipeline/{load,index}_votes.py`, and the `concord <stage> votes` CLI verbs.
+- [ADR 0008 — Chunks generalize beyond Proceedings](../adr/0008-chunks-generalize-beyond-proceedings.md) — not exercised.
+- [ADR 0009 — Multi-endpoint entities split JSONL canonical store by sub-endpoint](../adr/0009-multi-endpoint-entities-split-jsonl.md) — 3a writes two of the four eventual files (the detail and members sub-endpoints for the House). 3b adds the Senate equivalents.
+- **[ADR 0010 — Votes phased by chamber, not metadata-vs-positions](../adr/0010-votes-phased-by-chamber.md)** *(new, created with this plan)* — records the chamber-based split that replaced the roadmap's implied metadata-based one after the API spike revealed Senate has no API at all.
+- **[ADR 0011 — Party Unity Score as the party-line methodology](../adr/0011-party-unity-score-methodology.md)** *(new, created with this plan)* — names CQ-style Party Unity Score as the methodology behind the Member-page stat and documents exclusion of unanimous / non-party-unity votes from the denominator.
+
+## Relevant files and code
+
+Files to **read** for context:
+
+- [CONTEXT.md](../../CONTEXT.md) — new entries land in this plan: Vote, Roll-call number, Session, Vote question, Vote position, Party Unity Score. Existing Member / Chamber / Party / Bill / Amendment entries stay unchanged.
+- [src/concord/api.py](../../src/concord/api.py) — `list_bills` and `get_bill_detail` (lines ~205 and ~280) are the pagination + detail-endpoint template for the four new vote-endpoint methods.
+- [src/concord/models.py](../../src/concord/models.py) — `Bill` and `BillSnapshot` (~lines 350 and 430) demonstrate the camelCase aliasing and `@field_validator` lowercasing pattern.
+- [src/concord/scraper/bills.py](../../src/concord/scraper/bills.py) — Phase 2a scraper. Mirror its `scrape_basic(...)` shape and `ScrapeProgressEvent` pattern.
+- [src/concord/pipeline/load_bills.py](../../src/concord/pipeline/load_bills.py) — "latest snapshot per key" projection.
+- [src/concord/pipeline/index_bills.py](../../src/concord/pipeline/index_bills.py) — truncate-then-repopulate pattern (3a's indexer follows it but writes computed-stat tables instead of FTS5).
+- [src/concord/storage/sqlite.py](../../src/concord/storage/sqlite.py) — `_BASE_SCHEMA` (line 59) gets three new tables (`votes`, `vote_positions`, `member_party_unity`). `upsert_bill` (line 490) is the model for `upsert_vote`. The `_BILL_COLUMNS` (line 257) / `_BILL_UPSERT_SQL` (line 273) pattern repeats for votes.
+- [src/concord/web/app.py](../../src/concord/web/app.py) — routes at line 159 (`/search`), 287 (`/members`), 320 (`/members/{id}`), 357 (`/bills`), 394 (`/bills/{...}`). `/votes*` routes are added; `/bills/{...}` and `/members/{...}` are extended.
+- [src/concord/web/search.py](../../src/concord/web/search.py) — `search_bills` / `list_bills` / `get_bill` are templates for `list_votes`, `get_vote`, and the cross-link helpers.
+- [src/concord/web/templates/bills/profile.html](../../src/concord/web/templates/bills/profile.html) — the Phase-3 placeholder card here is replaced with live data. Pattern for the new `votes/profile.html`.
+- [src/concord/web/templates/members/profile.html](../../src/concord/web/templates/members/profile.html) — gets the two new sections (Recent votes, Party-unity score).
+- [src/concord/web/templates/base.html](../../src/concord/web/templates/base.html) — global nav; gets a "Votes" link.
+- [src/concord/cli.py](../../src/concord/cli.py) — Bills commands (the four `*_bills_command` functions added in Phase 2a) are the literal template.
+- [tests/_snapshots.py](../../tests/_snapshots.py) — shared ADR 0006 envelope helper; 3a tests use it unchanged.
+- [tests/test_scraper_bills.py](../../tests/test_scraper_bills.py), [tests/test_pipeline_bills.py](../../tests/test_pipeline_bills.py), [tests/test_web_bills.py](../../tests/test_web_bills.py) — patterns to follow.
+
+Files to **create**:
+
+- `src/concord/scraper/votes.py` — Tier 1 orchestrator (`scrape_house`); 3b adds `scrape_senate` to the same file.
+- `src/concord/pipeline/load_votes.py` — Stage 1 loader; reads `data/house_votes.jsonl` + `data/house_vote_positions.jsonl`; projects to `votes` + `vote_positions`. 3b extends this file.
+- `src/concord/pipeline/index_votes.py` — Stage 2 derived-stat indexer; writes `votes.is_party_unity` + `member_party_unity`. Truncate-then-repopulate.
+- `src/concord/web/templates/votes/list.html`
+- `src/concord/web/templates/votes/profile.html`
+- `src/concord/web/templates/about/methodology.html` — methodology page; only `#party-unity` anchor in 3a.
+- `src/concord/web/templates/_vote_row.html` — partial used on the Bill page's Vote history and the Member page's Recent votes (consistent row layout across surfaces).
+- `tests/fixtures/api/votes/` — already populated by the spike. List, detail (bill / amendment / procedural variants), members.
+- `tests/test_models_votes.py`
+- `tests/test_storage_votes_sqlite.py`
+- `tests/test_scraper_votes.py`
+- `tests/test_pipeline_votes.py`
+- `tests/test_index_votes.py`
+- `tests/test_web_votes.py`
+- `docs/adr/0010-votes-phased-by-chamber.md`
+- `docs/adr/0011-party-unity-score-methodology.md`
+
+Files to **modify**:
+
+- `src/concord/api.py` — add `VOTES_PAGE_SIZE = 250` and four methods: `list_house_votes(congress, session) -> Iterator[dict]`, `get_house_vote_detail(congress, session, roll_number) -> dict`, `get_house_vote_members(congress, session, roll_number) -> dict`. (No senate-vote methods in 3a.)
+- `src/concord/models.py` — add `Vote`, `VotePosition`, `VoteSnapshot`, `VotePositionsSnapshot`, plus `parse_vote_threshold(vote_type: str) -> str | None` and `vote_id_from_components(...) -> str`.
+- `src/concord/storage/sqlite.py` — append three table definitions to `_BASE_SCHEMA`; add `upsert_vote`, `upsert_vote_positions` (bulk), `get_vote`, `list_vote_positions_for_vote`, `list_recent_votes_for_member`, `get_party_unity_for_member`.
+- `src/concord/web/app.py` — register `/votes` and `/votes/{chamber}/{congress}/{session}/{roll}` routes; register `/about/methodology` route; extend `/bills/{...}` handler to fetch and pass vote history; extend `/members/{id}` handler to fetch and pass recent votes + party-unity score.
+- `src/concord/web/search.py` — add `VoteHit`, `list_votes`, `get_vote`, `vote_history_for_bill`, `recent_votes_for_member`, `party_unity_for_member`.
+- `src/concord/web/templates/bills/profile.html` — replace "Vote history (Phase 3)" placeholder with live section.
+- `src/concord/web/templates/members/profile.html` — replace "Recent votes (Phase 3)" and "Party-line alignment (Phase 3)" placeholders with live sections for House members; keep Senate placeholders relabeled to "(Phase 3b)".
+- `src/concord/web/templates/base.html` — add `/votes` link to global nav.
+- `src/concord/cli.py` — add `scrape_votes_command`, `load_votes_command`, `index_votes_command`, `run_votes_command`. Each takes `--limit N` and `--chambers house,senate` (defaulting to `house`).
+- `CONTEXT.md` — new Vote / Roll-call number / Session / Vote question / Vote position / Party Unity Score entries.
+
+## Approach
+
+### Domain model
+
+A Vote is identified by `(chamber, congress, session, roll_number)`. The internal `vote_id` flattens to `"{chamber}-{congress}-{session}-{roll}"` (e.g. `"house-119-1-240"`). The flattened form is the SQLite PK and the `vote_positions` FK; URL routes still take the four components explicitly (`/votes/{chamber}/{congress}/{session}/{roll}`).
+
+A Vote's *subject* — what was being decided — is captured by three fields stored independently:
+- `bill_id TEXT` — populated whenever the API supplies `legislationType` + `legislationNumber`. On amendment votes the API returns the **underlying bill** in these fields (the spike's "amendment trap"); we capture that linkage directly.
+- `amendment_id TEXT` — populated whenever the API supplies `amendmentType` + `amendmentNumber`. Formatted as `"{congress}-{amendment_type_lower}-{number}"` mirroring `bill_id` shape.
+- `question TEXT NOT NULL` — the free-text `voteQuestion` field; always populated.
+
+The combination cleanly distinguishes the four subject cases:
+
+| Subject               | `bill_id`   | `amendment_id` | `question`                              |
+|-----------------------|-------------|----------------|-----------------------------------------|
+| Bill (passage, MTR)   | populated   | NULL           | "On Passage of the Bill"                |
+| Amendment to a Bill   | populated   | populated      | "On Agreeing to the Amendment"          |
+| Procedural / election | NULL        | NULL           | "Election of the Speaker" etc.          |
+| (Treaty / nomination) | NULL        | NULL           | free text — out of scope for v1 anyway  |
+
+A **Vote position** is one Member's recorded choice on one Vote. Stored in `vote_positions` keyed by `(vote_id, bioguide_id)`. `position` is free TEXT — not an enum — to accommodate election votes where the value is a candidate's surname (per the spike's Speaker-vote finding). `vote_party` and `vote_state` are denormalized onto the row from the API payload so party-unity computation doesn't have to join `terms`.
+
+A **Party Unity Score** is per `(bioguide_id, congress)`. Definition lives in [ADR 0011](../adr/0011-party-unity-score-methodology.md):
+- **Party-unity vote** = a Vote where a majority of Republican-party positions opposed a majority of Democratic-party positions on that Vote. Both majorities are computed from `vote_positions.vote_party` for that Vote, restricting to `position IN ('Yea', 'Nay')`. Independents do not count toward either majority.
+- **Denominator** for a member = count of party-unity Votes in the Congress where the member cast `Yea` or `Nay`. Present / Not Voting excluded.
+- **Numerator** = of those, count where the member's `position` agreed with their `vote_party` majority on that Vote.
+- Independents (`vote_party = 'I'` across their entire Term in the Congress) get no row in `member_party_unity` — their Member page shows the muted "no party-unity score (Independent)" treatment.
+- Members with denominator < 10 in a Congress get the "(not enough votes yet)" treatment — the row exists but the UI suppresses the percentage.
+
+### Storage shape
+
+Phase 3a writes two JSONL files. Per [ADR 0009](../adr/0009-multi-endpoint-entities-split-jsonl.md):
+
+- `data/house_votes.jsonl` — one snapshot envelope per `/v3/house-vote/{c}/{s}/{roll}` detail fetch. Envelope:
+
+```json
+{"fetched_at": "2026-05-26T14:02:11Z",
+ "key": {"chamber": "house", "congress": 119, "session": 1, "roll_number": 240},
+ "payload": {... full houseRollCallVote body ...}}
+```
+
+- `data/house_vote_positions.jsonl` — one snapshot envelope per `/v3/house-vote/{c}/{s}/{roll}/members` fetch. Same `key` shape. `payload` is the full `houseRollCallVoteMemberVotes` body including the `results` array.
+
+SQLite schema appended to `_BASE_SCHEMA` in [src/concord/storage/sqlite.py](../../src/concord/storage/sqlite.py):
+
+```sql
+CREATE TABLE IF NOT EXISTS votes (
+  vote_id              TEXT PRIMARY KEY,            -- "{chamber}-{congress}-{session}-{roll}"
+  chamber              TEXT NOT NULL
+    CHECK (chamber IN ('house', 'senate')),
+  congress             INTEGER NOT NULL,
+  session              INTEGER NOT NULL
+    CHECK (session IN (1, 2)),
+  roll_number          INTEGER NOT NULL,
+  vote_kind            TEXT NOT NULL
+    CHECK (vote_kind IN ('standard', 'election')),
+  start_date           TEXT NOT NULL,                -- ISO8601 with offset, as API supplies
+  vote_question        TEXT NOT NULL,
+  vote_type            TEXT NOT NULL,                -- raw, e.g. "2/3 Yea-And-Nay"
+  threshold            TEXT
+    CHECK (threshold IN ('simple_majority', 'two_thirds', 'three_fifths')
+           OR threshold IS NULL),
+  result               TEXT NOT NULL,                -- "Passed"/"Failed"/"Agreed to" or winner name
+  yea_count            INTEGER,                      -- NULL on election votes
+  nay_count            INTEGER,
+  present_count        INTEGER,
+  not_voting_count     INTEGER,
+  bill_id              TEXT,                         -- bare TEXT, no FK
+  amendment_id         TEXT,                         -- bare TEXT, no FK
+  is_party_unity       INTEGER NOT NULL DEFAULT 0,   -- 0/1; populated by index_votes
+  update_date          TEXT NOT NULL,                -- API's updateDate
+  fetched_at           TEXT NOT NULL,
+  UNIQUE (chamber, congress, session, roll_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_votes_bill         ON votes (bill_id);
+CREATE INDEX IF NOT EXISTS idx_votes_amendment    ON votes (amendment_id);
+CREATE INDEX IF NOT EXISTS idx_votes_date         ON votes (start_date DESC);
+CREATE INDEX IF NOT EXISTS idx_votes_congress     ON votes (congress);
+
+CREATE TABLE IF NOT EXISTS vote_positions (
+  vote_id              TEXT NOT NULL,
+  bioguide_id          TEXT NOT NULL,                -- bare TEXT, no FK
+  position             TEXT NOT NULL,                -- free TEXT; standard: Yea/Nay/Present/Not Voting;
+                                                     -- election: candidate surname
+  vote_party           TEXT,                         -- "R" / "D" / "I" at time of vote
+  vote_state           TEXT,                         -- state at time of vote
+  PRIMARY KEY (vote_id, bioguide_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vote_positions_member ON vote_positions (bioguide_id);
+
+CREATE TABLE IF NOT EXISTS member_party_unity (
+  bioguide_id              TEXT NOT NULL,
+  congress                 INTEGER NOT NULL,
+  party                    TEXT NOT NULL             -- "R" or "D"; Independents not written
+    CHECK (party IN ('R', 'D')),
+  party_unity_votes_cast   INTEGER NOT NULL,         -- denominator
+  party_line_votes         INTEGER NOT NULL,         -- numerator
+  PRIMARY KEY (bioguide_id, congress)
+);
+```
+
+### Scraper structure
+
+`src/concord/scraper/votes.py` exports one entry point in 3a — `scrape_house(client, congresses, storage_dir, *, fetched_at, sessions=(1, 2), limit=None, progress=None) -> ScrapeStats`. The driver:
+
+1. For each `(congress, session)` pair, paginate `/v3/house-vote/{congress}/{session}` and collect roll-number stubs. Stubs are *not* persisted.
+2. For each stub, fetch detail (`/v3/house-vote/{c}/{s}/{roll}`) and append one envelope to `data/house_votes.jsonl`. Then fetch the per-member positions (`.../members`) and append one envelope to `data/house_vote_positions.jsonl`. Two HTTP calls per vote.
+3. **Stop after `limit` votes have been written**, if `limit` is set. The limit counts *detail* fetches; for each detail fetched, the corresponding members fetch always also runs (so JSONL files stay aligned).
+
+Cost envelope for full 117–119 House backfill: ~5K votes × 2 calls = ~10K calls, ~2 hours at 5K req/hr. ~50 MB JSONL total (heavier from the `members.jsonl` side since each is ~100 KB).
+
+3b adds `scrape_senate(client, ...)` to the same file alongside `scrape_house`.
+
+### Loader
+
+`src/concord/pipeline/load_votes.py` exports `load(storage_dir: Path, db_path: Path, *, limit: int | None = None) -> LoadStats`. The driver:
+
+1. Read `data/house_votes.jsonl`, group by `(chamber, congress, session, roll_number)`, keep latest by `fetched_at`. For each latest snapshot:
+   - Parse the `houseRollCallVote` payload into a `Vote` model.
+   - Compute `bill_id` = `bill_id_from_components(congress, legislationType, legislationNumber)` if `legislationType` and `legislationNumber` are both present.
+   - Compute `amendment_id` = `amendment_id_from_components(congress, amendmentType, amendmentNumber)` if `amendmentType` and `amendmentNumber` are both present.
+   - Sum chamber totals from `votePartyTotal` entries. For election votes (detected via candidate-bucketed shape — see [Models](#models)), all four counts stay NULL and `vote_kind = 'election'`; otherwise `vote_kind = 'standard'`.
+   - Parse `threshold` from `vote_type` via `parse_vote_threshold(vote_type)`.
+   - Upsert into `votes`.
+2. Read `data/house_vote_positions.jsonl`, group by `(chamber, congress, session, roll_number)`, keep latest. For each:
+   - For each entry in `results`, upsert into `vote_positions` keyed `(vote_id, bioguide_id)`. `position` = `voteCast` verbatim; `vote_party` = `voteParty`; `vote_state` = `voteState`.
+   - Use a bulk-INSERT-OR-REPLACE within a single transaction per vote (~430 rows).
+3. Stop after `limit` votes loaded.
+
+Idempotent. Re-running over unchanged JSONL is a no-op. 3b extends this file by adding a Senate branch that reads `data/senate_votes.jsonl` + `data/senate_vote_positions.jsonl` (different XML-derived shape, same target tables).
+
+### Indexer
+
+`src/concord/pipeline/index_votes.py` exports `index(db_path: Path, *, limit: int | None = None) -> IndexStats`. Truncate-then-repopulate. Two computed datasets:
+
+1. **`votes.is_party_unity`** — `UPDATE votes SET is_party_unity = 0` followed by an `UPDATE` driven by a CTE that, for each standard vote, counts Yea/Nay positions per `vote_party` from `vote_positions` and flags the vote as party-unity iff a majority of R's voted opposite a majority of D's. Election votes always `is_party_unity = 0`.
+2. **`member_party_unity`** — `DELETE FROM member_party_unity` followed by an `INSERT` driven by a query that joins `vote_positions` to `votes WHERE is_party_unity = 1 AND vote_positions.position IN ('Yea', 'Nay')`, groups by `(bioguide_id, congress)`, computes the numerator by comparing the member's position to the majority of their `vote_party` on each vote.
+   - Only writes rows for `vote_party IN ('R', 'D')`.
+
+A member's "vote_party" can differ across votes within a Congress (rare — Sinema's switch from D to I is the canonical example). The schema stores `vote_party` per position; `member_party_unity.party` is the member's *modal* `vote_party` across the Congress's party-unity votes. Members whose modal party is `I` get no `member_party_unity` row.
+
+Wiped and rebuilt on each index run. Cost: at 3 Congresses × ~1.7K votes × ~430 members ≈ 2M rows in `vote_positions`. The party-unity CTE is bounded to standard votes (~95% of total) and runs in <30s on the v1 dataset.
+
+### Web surface
+
+**`/votes` index.** Template `votes/list.html`. Default sort `ORDER BY start_date DESC`. Filters: `chamber` (3a values: always `house`), `congress`, `result`, `vote_kind`, `bill` (substring match on `bill_id`). 50 per page. Row layout: chamber chip, identifier (`H 240`), date, question (truncated ~80 chars), result chip (passed/failed colored), totals `Y/N`.
+
+**`/votes/{chamber}/{congress}/{session}/{roll}` profile.** Template `votes/profile.html`. If `chamber = 'senate'`, render a muted "Senate votes load in Phase 3b" placeholder body. Otherwise:
+
+1. **Header.** Identifier, date, `Updated: {fetched_at}`.
+2. **Result block.** Yea / Nay / Present / Not Voting counts, pass/fail chip, threshold formatted (`Required: simple majority` / `Required: 2/3` / etc.).
+3. **Subject.** Branch on `(bill_id, amendment_id)`:
+   - Both populated → "Amendment HAMDT 85 to [HR 3838](link)" (amendment chip + Bill link).
+   - Only `bill_id` → "[HR 3424](link) — [policy area]".
+   - Neither → free-text `question` displayed as the heading; small muted "Procedural / no bill subject" note.
+4. **Vote question.** Always displayed verbatim.
+5. **Position roster.** Full ~430 rows. Sortable client-side by party, position, state, name (CSS / small JS, no server round-trip). Each name links to `/members/{bioguide_id}`. For election votes, position values are surnames; no party / Yea-Nay grouping.
+
+**`/votes` index page does not render an FTS-style search box.** Filters only.
+
+**Bill page Vote history.** Replace the existing `bills/profile.html` Phase-3 placeholder. Query: `SELECT * FROM votes WHERE bill_id = ? ORDER BY start_date DESC`. Includes amendment votes (their `bill_id` is the underlying bill). Each row uses `_vote_row.html` partial. Empty state: "No votes recorded for this bill yet."
+
+**Member page Recent votes.** Query: `SELECT v.* FROM votes v JOIN vote_positions p USING (vote_id) WHERE p.bioguide_id = ? ORDER BY v.start_date DESC LIMIT 25`. Each row uses `_vote_row.html`. Empty state: "No vote positions recorded for this member yet." Senate members in 3a always hit empty state — the row also shows a muted "Senate positions load in Phase 3b" affordance directly inside the empty state.
+
+**Member page Party-unity score.** Query: `SELECT * FROM member_party_unity WHERE bioguide_id = ?` (returns one row per Congress). Layout:
+- Current Congress prominent: "Voted with [party] majority on N% of party-unity votes (X/Y in 119th Congress)".
+- History strip beneath: small `Congress 118: 89% (...)`, `Congress 117: 91% (...)`.
+- If member is Independent (`vote_party = 'I'` modal across positions): muted "No party-unity score (Independent — caucuses with [D/R])" note, no number.
+- If `member_party_unity` row missing for current Congress and member has positions: "Party-unity score not yet computed."
+- If `party_unity_votes_cast < 10` in current Congress: "Voted on N party-unity votes — not enough for a stable score yet" (no percentage, no fraction).
+- `?` icon on the right links to `/about/methodology#party-unity`.
+
+**`/about/methodology` page.** Static template, one anchor `#party-unity`. Content drawn directly from ADR 0011 but rewritten for a public audience — define party-unity vote, define the denominator, define the numerator, name the methodology (CQ Party Unity Score), link to the ADR for the technical definition.
+
+**Global nav.** Add a `<a href="/votes">Votes</a>` link to `base.html` between Bills and Proceedings.
+
+### Models
+
+`src/concord/models.py` additions:
+
+- `Vote` — pydantic model with the columns of the `votes` table. Includes:
+  - `@field_validator("chamber", "bill_type", "amendment_type", mode="before")` for lowercasing.
+  - `@model_validator(mode="after")` to compute `vote_id`.
+  - `@classmethod from_api_payload(cls, payload: dict, fetched_at: str) -> Vote` — handles the spike's gotchas (singular vs plural envelope keys, `votePartyTotal` summing, election-vote shape detection, amendment-trap handling).
+- `VotePosition` — pydantic model for `vote_positions` rows.
+- `VoteSnapshot` and `VotePositionsSnapshot` — generic ADR 0006 envelopes specialized for the two JSONL files.
+- `vote_id_from_components(chamber: str, congress: int, session: int, roll_number: int) -> str`.
+- `amendment_id_from_components(congress: int, amendment_type: str, amendment_number: int) -> str`.
+- `parse_vote_threshold(vote_type: str) -> str | None` — case-insensitive substring match. Returns `'two_thirds'` if the string contains `"2/3"`; `'three_fifths'` if `"3/5"`; `'simple_majority'` for any of `"Yea-and-Nay"`, `"Recorded Vote"`, or `"Quorum"` (case-insensitive); `None` for unrecognized (loader logs a warning). Tested against both capitalization variants the spike found.
+
+**Election-vote detection.** `Vote.from_api_payload` inspects the first entry of `votePartyTotal`: if it carries a `candidate` key (instead of `party` / `voteParty`), the loader sets `vote_kind = 'election'`, leaves totals NULL, and constructs `result` from the API's `result` field (which on election votes carries the winner's name verbatim).
+
+### CLI
+
+```
+concord scrape votes [--congresses 117,118,119]
+                     [--sessions 1,2]
+                     [--chambers house]
+                     [--storage-dir data/] [--limit N]
+                     [--progress/--no-progress]
+concord load votes   [--storage-dir data/] [--db data/proceedings.db] [--limit N]
+concord index votes  [--db data/proceedings.db] [--limit N]
+concord run votes    [scrape options] [--db ...] [--limit N]
+```
+
+`--chambers` defaults to `house` in 3a. If the user passes `senate` (or `house,senate`), the senate slice is a no-op that logs `"Senate ingest lands in Phase 3b — skipping."`. 3b will remove the no-op.
+
+`--limit N` semantics:
+- `scrape votes` — stop after N detail responses written (and their paired members responses).
+- `load votes` — stop after N vote rows upserted.
+- `index votes` — cap on rows processed in the party-unity CTE.
+- `run votes` — passed through to scrape.
+
+`_parse_csv` generalized in Phase 2a is reused for `--congresses`, `--sessions`, `--chambers`.
+
+### Backfill operations
+
+Phase 3a ships when the pipeline can scrape, load, index, and serve a `--limit`-bounded slice of House votes end-to-end. Cost envelope:
+
+| Operation | Calls | Time @ 5K/hr | JSONL |
+|---|---|---|---|
+| Tier 1 backfill (117–119 House, all sessions, both endpoints) | ~10K | ~2h | ~50 MB |
+
+Same operator-driven stance as Phase 2a — exercise against `--limit 50` locally, `--limit 500` in staging, unbounded on the VPS.
+
+## Step-by-step plan
+
+Eight sections — **ADRs**, **API client**, **Models & storage**, **Ingest**, **Indexer**, **CLI**, **Web — Vote pages**, **Web — cross-links & methodology**, **Verification**.
+
+### Section 1 — ADRs
+
+1. **Draft ADR 0010 — Votes phased by chamber.** Create [docs/adr/0010-votes-phased-by-chamber.md](../adr/0010-votes-phased-by-chamber.md) following the `docs/adr/` template. Context: roadmap implied a metadata/positions split; spike revealed Senate has no API and House has full positions, collapsing that split. Decision: phase by chamber — 3a House (API), 3b Senate (senate.gov LIS XML). Consequences: each phase has one source, asymmetric coverage between phases, party-unity score is House-only until 3b. Reject the original split.
+
+2. **Draft ADR 0011 — Party Unity Score methodology.** Create [docs/adr/0011-party-unity-score-methodology.md](../adr/0011-party-unity-score-methodology.md). Context: roadmap calls out party-line stat as the first editorial-neutrality risk. Decision: CQ-style Party Unity Score — define party-unity vote, denominator, numerator. Consequences: requires `vote_positions.vote_party` denormalization; Independents not scored; <10-vote threshold; methodology page surfaced at `/about/methodology#party-unity`. Reject naive party-line %, reject side-by-side display.
+
+### Section 2 — API client
+
+3. **Add vote-endpoint constants and methods.** In [src/concord/api.py](../../src/concord/api.py): add `VOTES_PAGE_SIZE = 250`. Add three methods on `Client`:
+   - `list_house_votes(congress: int, session: int) -> Iterator[dict]` — paginates `/v3/house-vote/{congress}/{session}`. Yields stubs from `houseRollCallVotes`. Honors `pagination.next`.
+   - `get_house_vote_detail(congress: int, session: int, roll_number: int) -> dict` — returns the `houseRollCallVote` object from `/v3/house-vote/{c}/{s}/{roll}`.
+   - `get_house_vote_members(congress: int, session: int, roll_number: int) -> dict` — returns the `houseRollCallVoteMemberVotes` object from `/v3/house-vote/{c}/{s}/{roll}/members`.
+
+   No `list_senate_votes` etc. in 3a.
+
+4. **Test the API client.** Extend [tests/test_api.py](../../tests/test_api.py) with one test class per new method using captured fixtures + `httpx.MockTransport`. Assert request paths, pagination termination (one page list fixture), and that the methods unwrap the outer envelope keys correctly (`houseRollCallVotes` / `houseRollCallVote` / `houseRollCallVoteMemberVotes`).
+
+### Section 3 — Models & storage
+
+5. **Add Vote pydantic models.** Extend [src/concord/models.py](../../src/concord/models.py):
+   - `Vote` — fields per the `votes` schema. `@field_validator` lowercases `chamber`, `bill_type` (alias of `legislationType`), `amendment_type` (alias of `amendmentType`).
+   - `VotePosition` — fields per the `vote_positions` schema. `position` is free `str`.
+   - `VoteSnapshot`, `VotePositionsSnapshot` — generic ADR 0006 envelopes.
+   - `Vote.from_api_payload(payload, fetched_at) -> Vote` — handles election-vote detection, `votePartyTotal` summing, amendment-trap (`bill_id` + `amendment_id` both set when amendment vote), threshold parsing.
+   - `vote_id_from_components`, `amendment_id_from_components`, `parse_vote_threshold` helpers.
+
+6. **Test the models.** Create [tests/test_models_votes.py](../../tests/test_models_votes.py). Cover: parsing each of the four captured fixture variants (bill / amendment / election / list); `vote_id_from_components` shape; `parse_vote_threshold` against `"Yea-and-Nay"`, `"2/3 Yea-And-Nay"`, `"Recorded Vote"`, unknown string (returns None); election-vote detection setting `vote_kind='election'` and leaving counts NULL; amendment-trap populating both `bill_id` and `amendment_id`.
+
+7. **Add Votes schema to SqliteStorage.** Append the three table definitions (`votes`, `vote_positions`, `member_party_unity`) + indexes from [Approach > Storage shape](#storage-shape) to `_BASE_SCHEMA` in [src/concord/storage/sqlite.py](../../src/concord/storage/sqlite.py). Define `_VOTE_COLUMNS`, `_VOTE_UPSERT_SQL`, `_VOTE_POSITION_COLUMNS`, `_VOTE_POSITION_UPSERT_SQL`, `_MEMBER_PARTY_UNITY_COLUMNS`, `_MEMBER_PARTY_UNITY_UPSERT_SQL`.
+
+8. **Add storage methods.** In `src/concord/storage/sqlite.py`:
+   - `upsert_vote(vote: Vote, *, fetched_at: str) -> None`
+   - `upsert_vote_positions(vote_id: str, positions: Iterable[VotePosition]) -> int` — bulk; wraps a single transaction. Returns row count.
+   - `get_vote(vote_id: str) -> sqlite3.Row | None`
+   - `list_vote_positions_for_vote(vote_id: str) -> list[sqlite3.Row]`
+   - `list_recent_votes_for_member(bioguide_id: str, limit: int = 25) -> list[sqlite3.Row]` — joins `vote_positions` to `votes`.
+   - `get_party_unity_for_member(bioguide_id: str) -> list[sqlite3.Row]` — one row per Congress.
+   - `vote_history_for_bill(bill_id: str) -> list[sqlite3.Row]`
+
+9. **Test storage.** [tests/test_storage_votes_sqlite.py](../../tests/test_storage_votes_sqlite.py): upsert idempotency on `vote_id`; the `chamber` / `session` / `vote_kind` / `threshold` / `party` CHECK constraints reject bad values; `vote_positions` PK uniqueness; bulk position upsert.
+
+### Section 4 — Ingest
+
+10. **Use the existing fixtures.** The spike already saved fixtures under `tests/fixtures/api/votes/` (see findings file). Confirm all six are present (`list_house_119_1.json`, `list_senate_119_1.json` [404 evidence], `detail_house_119_1_240.json`, `detail_house_119_1_subject_amendment.json`, `detail_house_119_1_subject_procedural.json`, `members_house_119_1_240.json`). Capture one additional `members` fixture for the amendment-vote roll if not already present (the loader test wants paired detail+members for the amendment case).
+
+11. **Build the Votes scraper (Tier 1).** Create [src/concord/scraper/votes.py](../../src/concord/scraper/votes.py) exporting `scrape_house(client, congresses, storage_dir, *, fetched_at, sessions=(1,2), limit=None, progress=None) -> ScrapeStats`. Per [Approach > Scraper structure](#scraper-structure). Emit `ScrapeProgressEvent(chamber='house', congress, session, votes_seen, votes_written)` once per `(congress, session)` pair. Verify in [tests/test_scraper_votes.py](../../tests/test_scraper_votes.py):
+    - Only the two House JSONL files are written.
+    - One detail envelope per `votes_written`, one members envelope per `votes_written` — counts match.
+    - `--limit` honored.
+    - `chamber='house'` in every key.
+
+12. **Build the Votes loader.** Create [src/concord/pipeline/load_votes.py](../../src/concord/pipeline/load_votes.py) exporting `load(storage_dir, db_path, *, limit=None) -> LoadStats`. Reads both files, groups by key, keeps latest per file, upserts `votes` and `vote_positions`. `LoadStats` carries `votes_written, positions_written, snapshots_read, malformed`. Verify in [tests/test_pipeline_votes.py](../../tests/test_pipeline_votes.py):
+    - Basic load with one vote (bill).
+    - Amendment vote — both `bill_id` and `amendment_id` populated.
+    - Election vote — `vote_kind='election'`, counts NULL, `position` carries candidate surname.
+    - Two snapshots same key — latest wins.
+    - `--limit` honored.
+    - Re-run is idempotent.
+
+### Section 5 — Indexer
+
+13. **Build the party-unity indexer.** Create [src/concord/pipeline/index_votes.py](../../src/concord/pipeline/index_votes.py) exporting `index(db_path, *, limit=None) -> IndexStats`. Implements the two-pass logic from [Approach > Indexer](#indexer). `IndexStats` carries `votes_flagged_party_unity, members_scored`. Use a single CTE for the `votes.is_party_unity` UPDATE and a single CTE for the `member_party_unity` INSERT.
+
+14. **Test the indexer.** [tests/test_index_votes.py](../../tests/test_index_votes.py):
+    - Two votes: one party-unity (R majority Yea, D majority Nay), one not (both parties Yea). After `index()`, `votes.is_party_unity` flagged correctly on the first only.
+    - Three members: an R who voted Yea on the party-unity vote (numerator hits), an R who voted Nay (numerator misses), a D who voted Nay (numerator hits). Resulting `member_party_unity` rows have correct numerators/denominators.
+    - Independent member with positions — no `member_party_unity` row written for them.
+    - Election votes never flagged as party-unity.
+    - Re-running `index()` is idempotent (truncate-then-repopulate).
+
+### Section 6 — CLI
+
+15. **Add `concord scrape votes`.** In [src/concord/cli.py](../../src/concord/cli.py) add `DEFAULT_VOTES_CHAMBERS = ("house",)` and `DEFAULT_VOTES_SESSIONS = (1, 2)`. Reuse `_parse_csv` for `--congresses`, `--sessions`, `--chambers`. Register `@scrape_app.command("votes")` with `--congresses` (default `117,118,119`), `--sessions` (default `1,2`), `--chambers` (default `house`), `--storage-dir`, `--limit`, `--progress/--no-progress`. If `senate` is in `--chambers`: log "Senate ingest lands in Phase 3b — skipping." Call `scrape_house(...)` for the house slice.
+
+16. **Add `concord load votes` / `concord index votes` / `concord run votes`.** Mirror the Bills 2a CLI commands. `load votes` takes `--storage-dir`, `--db`, `--limit`. `index votes` takes `--db`, `--limit`. `run votes` chains scrape → load → index. Each no-ops with an informational message if its inputs are missing.
+
+17. **Test the CLI.** Extend [tests/test_cli.py](../../tests/test_cli.py) with the help-smoke pattern. Add an end-to-end test: `scrape votes --congresses 119 --sessions 1 --limit 2` with a mocked `Client`, assert exactly 2 detail envelopes hit `data/house_votes.jsonl` and 2 positions envelopes hit `data/house_vote_positions.jsonl`. Assert `--chambers senate,house` logs the skip message and still runs the house slice.
+
+### Section 7 — Web: Vote pages
+
+18. **Add Votes web helpers.** Extend [src/concord/web/search.py](../../src/concord/web/search.py) with `VoteHit` (pydantic), `list_votes(db, *, chamber, congress, result, vote_kind, bill, limit, offset)`, `get_vote(db, chamber, congress, session, roll)`, `vote_history_for_bill(db, bill_id)`, `recent_votes_for_member(db, bioguide_id, limit=25)`, `party_unity_for_member(db, bioguide_id)`.
+
+19. **Register `/votes` index route.** In [src/concord/web/app.py](../../src/concord/web/app.py) add `VOTES_PAGE_SIZE = 50`. Register `GET /votes` reading `chamber`, `congress`, `result`, `vote_kind`, `bill`, `page`; calls `list_votes`; renders `votes/list.html`.
+
+20. **Register `/votes/{chamber}/{congress}/{session}/{roll}` profile route.** Validate `chamber ∈ ('house', 'senate')`, `session ∈ (1, 2)`, integer `roll`. Build `vote_id`. Call `get_vote`; 404 if missing AND chamber=house; render the "(Phase 3b)" placeholder body if chamber=senate; otherwise render `votes/profile.html`. Fetch positions via `list_vote_positions_for_vote` for the body.
+
+21. **Register `/about/methodology` route.** Static; renders `about/methodology.html`.
+
+22. **Add the templates.**
+    - [src/concord/web/templates/votes/list.html](../../src/concord/web/templates/votes/list.html) — filter form (chamber, congress, result, vote_kind, bill); paginated row list using `_vote_row.html`.
+    - [src/concord/web/templates/votes/profile.html](../../src/concord/web/templates/votes/profile.html) — header + result block + subject branch + position roster. For senate-chamber rolls render only the "Phase 3b" placeholder body.
+    - [src/concord/web/templates/_vote_row.html](../../src/concord/web/templates/_vote_row.html) — shared row partial used here, on the Bill page, and on the Member page.
+    - [src/concord/web/templates/about/methodology.html](../../src/concord/web/templates/about/methodology.html) — single static page; `#party-unity` anchor target with the definition.
+
+23. **Add the global nav link.** In [src/concord/web/templates/base.html](../../src/concord/web/templates/base.html) add `<a href="/votes">Votes</a>` between Bills and Proceedings.
+
+### Section 8 — Web: cross-links
+
+24. **Update Bill profile — Vote history.** Edit [src/concord/web/templates/bills/profile.html](../../src/concord/web/templates/bills/profile.html). Replace "Vote history (Phase 3)" placeholder card with a live section that iterates `vote_history` (passed by the route handler). Empty state when none. Use `_vote_row.html` for each row. The handler at the Bills profile route fetches via `vote_history_for_bill(db, bill_id)`.
+
+25. **Update Member profile — Recent votes + Party-unity score.** Edit [src/concord/web/templates/members/profile.html](../../src/concord/web/templates/members/profile.html):
+    - Replace "Recent votes (Phase 3)" placeholder with a live list for House members; Senate members get "(Phase 3b)".
+    - Replace "Party-line alignment (Phase 3)" placeholder with the party-unity score block (current Congress + history strip + Independent / low-N / missing variants). Senate members get "(Phase 3b)". Add `?` icon linking to `/about/methodology#party-unity`.
+    - The handler at [src/concord/web/app.py](../../src/concord/web/app.py) (`/members/{bioguide_id}`) calls `recent_votes_for_member` and `party_unity_for_member` and passes both to the template. Decide House vs Senate by looking at the member's most-recent term `chamber`.
+
+26. **Web tests.** Create [tests/test_web_votes.py](../../tests/test_web_votes.py). Cover:
+    - `/votes` with each filter changing the result set.
+    - `/votes/house/119/1/240` returns 200; shows correct totals + sponsor's Bill link.
+    - `/votes/house/119/1/2` (election) renders with no totals, no party rows, candidates listed.
+    - `/votes/senate/119/1/1` renders the Phase 3b placeholder body (no 404).
+    - `/votes/house/119/1/999999` returns 404.
+    - `/bills/119/hr/3424` profile contains a Vote history section listing the seeded vote.
+    - `/members/{house_member_bioguide}` shows Recent votes and a Party-unity score.
+    - `/members/{independent_bioguide}` shows the muted Independent treatment.
+    - `/members/{senate_member_bioguide}` shows the "(Phase 3b)" placeholder.
+    - `/about/methodology` returns 200 and contains the `#party-unity` heading.
+
+### Section 9 — Verification
+
+27. **End-to-end smoke test.** Extend [tests/test_smoke.py](../../tests/test_smoke.py). Write synthetic snapshot JSONL for one bill vote and one election vote (paired members) to a temp dir, run `load_votes.load()` → `index_votes.index()`, open the web app via `TestClient`, hit `/votes`, `/votes/house/119/1/240`, `/bills/119/hr/3424`, `/members/{sponsor_bioguide}`, `/about/methodology`.
+
+28. **Manual smoke against live data.** With `CONGRESS_API_KEY` set: `concord run votes --congresses 119 --sessions 1 --limit 50`, then `concord serve`. Click through `/votes`, a Vote profile, a Bill that has votes, a House member's profile (verify Recent votes and party-unity score render), a Senate member's profile (verify Phase 3b placeholder).
+
+29. **Run the full test suite.** `pytest` clean. `uv run ruff check`. `uv run ruff format --check`. **Phase 2a tests must continue to pass** — especially `tests/test_web_bills.py` (Vote history section is now live) and `tests/test_web_members.py` (Recent votes + Party-unity sections are now live for House members; Senate members still show placeholders).
+
+30. **Update CONTEXT.md.** Add Vote / Roll-call number / Session / Vote question / Vote position / Party Unity Score entries to the Entities section. Cross-link from Party Unity Score to ADR 0011.
+
+## Demo seed data
+
+Concord's demo derives from `data/*.jsonl`; there is no checked-in seed file (matches Phase 1 / Phase 2a). Equivalent: after step 29 lands, the operator runs `concord run votes --congresses 119 --sessions 1 --limit 100` once locally to populate `data/house_votes.jsonl`, `data/house_vote_positions.jsonl`, and the three new SQLite tables. Demo mode now illustrates: a Vote profile with a full position roster, a Bill page showing Vote history, a House Member page with Recent votes and a Party-unity score, the methodology page, and a Senate Member page that correctly defers to Phase 3b.
+
+## Testing strategy
+
+**Unit tests:**
+
+- [tests/test_models_votes.py](../../tests/test_models_votes.py) — `Vote`, `VotePosition`, `VoteSnapshot` round-trips; `vote_id_from_components` / `amendment_id_from_components`; `parse_vote_threshold` for all known values + unknown; election-vote detection; amendment-trap.
+- [tests/test_storage_votes_sqlite.py](../../tests/test_storage_votes_sqlite.py) — schema applies cleanly; upsert idempotency; all CHECK constraints; bulk positions upsert.
+
+**Integration tests:**
+
+- [tests/test_api.py](../../tests/test_api.py) extended — `list_house_votes`, `get_house_vote_detail`, `get_house_vote_members` against `httpx.MockTransport` with spike fixtures.
+- [tests/test_scraper_votes.py](../../tests/test_scraper_votes.py) — `scrape_house(...)` writes exactly two files, paired envelope counts, `--limit` honored.
+- [tests/test_pipeline_votes.py](../../tests/test_pipeline_votes.py) — `load(...)` projects both JSONL files to `votes` + `vote_positions`; bill / amendment / election variants; latest-snapshot-per-key wins; idempotent re-runs.
+- [tests/test_index_votes.py](../../tests/test_index_votes.py) — party-unity flag computation; `member_party_unity` numerator / denominator; Independents skipped; election votes never flagged; idempotent re-runs.
+- [tests/test_web_votes.py](../../tests/test_web_votes.py) — all routes per step 26.
+
+**Smoke test:** [tests/test_smoke.py](../../tests/test_smoke.py) extended per step 27.
+
+**Manual checks** (no frontend component tests per [ADR 0001](../adr/0001-python-end-to-end-for-the-web-layer.md)):
+
+- `/votes` renders; chamber/congress/result/vote_kind/bill filters change the result set; pagination works.
+- A real House Vote profile renders header, result block, subject branch (bill or amendment or procedural), and the full ~430-row position roster.
+- An election Vote (e.g. roll 2 in 119/1) renders with no totals, candidate-bucketed positions, winner highlighted.
+- A Senate Vote URL (any) renders the "(Phase 3b)" placeholder, not a 404.
+- A Bill page (one that had real votes — e.g. HR 3424 in 119) shows the Vote history section with live rows.
+- A House Member page shows Recent votes and a Party-unity score with sensible numbers.
+- An Independent Senator-or-House-member page shows the muted Independent treatment for Party-unity.
+- A Senate Member page shows the "(Phase 3b)" placeholders for both new sections.
+- `/about/methodology` page renders; the `?` icon link from a Member page jumps to the `#party-unity` anchor.
+
+**Regression risk:**
+
+- All Phase 2a tests must continue to pass — especially `tests/test_web_bills.py` (Vote history placeholder is now live) and `tests/test_web_members.py` (two placeholders are now live for House members, relabeled "(Phase 3b)" for Senate members).
+- Phase 1 tests unchanged.
+
+## Acceptance criteria
+
+- [ ] `concord scrape votes --congresses 119 --sessions 1 --limit 10 --storage-dir /tmp/concord` writes exactly 10 detail envelopes to `data/house_votes.jsonl` and 10 members envelopes to `data/house_vote_positions.jsonl`; no other JSONL files exist.
+- [ ] `concord load votes --storage-dir /tmp/concord --db /tmp/test.db` populates `votes` (10 rows) and `vote_positions` (~430 × 10 ≈ 4300 rows).
+- [ ] `concord index votes --db /tmp/test.db` populates `votes.is_party_unity` and writes `member_party_unity` rows.
+- [ ] `concord run votes --congresses 119 --sessions 1 --limit 10` does scrape + load + index in one shot.
+- [ ] `concord scrape votes --chambers senate` logs the Phase-3b skip message and does no work.
+- [ ] `concord scrape bills`, `concord scrape members`, `concord run proceedings` still work (Phase 1, 2a regression).
+- [ ] `pytest` passes (full suite + new tests).
+- [ ] `uv run ruff check` clean. `uv run ruff format --check` clean.
+- [ ] `GET /votes` returns 200; chamber/congress/result/vote_kind/bill filters change the result set.
+- [ ] `GET /votes/house/119/1/{roll}` returns 200 for a real roll; shows position roster of ~430 entries.
+- [ ] `GET /votes/house/119/1/2` (election) renders without totals; candidates listed.
+- [ ] `GET /votes/senate/119/1/{any}` renders the Phase 3b placeholder body (200, not 404).
+- [ ] `GET /votes/house/119/1/999999` returns 404.
+- [ ] `GET /bills/119/hr/{n}` for a bill that has votes shows the Vote history section with live rows (no longer a placeholder).
+- [ ] `GET /members/{house_member_bioguide}` shows live Recent votes and a Party-unity score block.
+- [ ] `GET /members/{independent_member_bioguide}` shows the muted Independent treatment for Party-unity.
+- [ ] `GET /members/{senate_member_bioguide}` shows "(Phase 3b)" placeholders for both new sections (relabeled, not removed).
+- [ ] `GET /about/methodology` returns 200; `#party-unity` section is present and explains denominator / numerator.
+- [ ] [CONTEXT.md](../../CONTEXT.md) has the new entity entries (Vote / Roll-call number / Session / Vote question / Vote position / Party Unity Score).
+- [ ] [docs/adr/0010-votes-phased-by-chamber.md](../adr/0010-votes-phased-by-chamber.md) exists.
+- [ ] [docs/adr/0011-party-unity-score-methodology.md](../adr/0011-party-unity-score-methodology.md) exists.
+- [ ] [docs/plans/.spike-votes-api.md](./.spike-votes-api.md) and [docs/plans/.spike-votes-api-findings.md](./.spike-votes-api-findings.md) deleted (their findings are baked into this plan and the ADRs).
+- [ ] `src/concord/scraper/votes.py` (exporting `scrape_house`), `src/concord/pipeline/{load,index}_votes.py` exist; no Phase 1 / 2a modules were moved or deleted.
+
+## Open questions
+
+None — all design decisions resolved during grilling. The party-unity stat scoping ([ADR 0011](../adr/0011-party-unity-score-methodology.md)) is the most likely to attract refinement requests post-ship; revisions should land as ADR amendments, not silent code changes.
+
+## Out-of-band work
+
+- **Tier 1 full 117–119 House backfill.** `concord run votes --congresses 117,118,119` (no `--limit`) is a ~2-hour command-line job. Run on the VPS once 3a's surface review is done.
+- **Phase 3b — Votes (Senate).** Sibling plan to be drafted via the `implementation-plan` skill immediately after 3a lands. Reads senate.gov LIS XML; builds a Bioguide↔LIS-ID mapping; populates the same `votes` + `vote_positions` tables for Senate rolls. Removes the `--chambers senate` no-op. Senate member pages get live Recent-votes + party-unity sections.
+- **Phase 4 — Amendments.** Will turn `votes.amendment_id` into a live link to an `/amendments/{...}` profile page. 3a stores the ID as bare TEXT; the link target arrives in Phase 4 with no schema change.
+- **Phase 7 — Universal search.** May add Votes to `/search` if a useful query pattern emerges; 3a deliberately defers FTS5.
+- **Daily refresh cadence.** A cron job invoking `concord run votes --congresses 119` daily — out of band, operator-configured on the VPS. Not part of this plan.

--- a/docs/plans/phase-3b-votes-senate.md
+++ b/docs/plans/phase-3b-votes-senate.md
@@ -1,0 +1,602 @@
+# Phase 3b — Votes (Senate) ingest
+
+> Ingest Senate roll-call votes — metadata, totals, bill/amendment subject, and full per-member positions — from senate.gov LIS XML feeds into Concord, populating the same `votes` / `vote_positions` / `member_party_unity` tables Phase 3a defined for the House. Removes the `--chambers senate` no-op from the CLI, turns the "(Phase 3b)" placeholder boxes on Senate Member profiles into live data, and refines the party-unity methodology to be chamber-scoped.
+
+## Source
+
+- Roadmap: [docs/plans/members-bills-votes-roadmap.md](./members-bills-votes-roadmap.md) (Phase 3 section)
+- Sibling plan (prerequisite): [docs/plans/phase-3a-votes-house.md](./phase-3a-votes-house.md) — defines the schema, scraper structure, indexer, and web surface this plan extends. **Phase 3a must be merged before 3b starts.**
+- Spike that informed this plan: [docs/plans/.spike-senate-votes.md](./.spike-senate-votes.md) and [docs/plans/.spike-senate-votes-findings.md](./.spike-senate-votes-findings.md). **Both files should be deleted once this plan is approved** — their findings are reflected below.
+
+## Context
+
+Phase 3a ingests U.S. House roll-call votes from `api.congress.gov`'s `/v3/house-vote/...` endpoints. Phase 3b ingests U.S. Senate roll-call votes from senate.gov's **LIS XML feeds** — `LIS` standing for *Legislative Information System*, the Senate's internal data interchange format, exposed publicly per-roll at predictable URLs under `https://www.senate.gov/legislative/LIS/`.
+
+The chamber-based split (Phase 3a House, Phase 3b Senate) is recorded in [ADR 0010 — Votes phased by chamber](../adr/0010-votes-phased-by-chamber.md). The driving fact is that `api.congress.gov` has no Senate vote endpoint at all (the API spike for 3a returned 404 on every `/senate-vote/...` variant tried) — so Phase 3b uses an entirely different source, parser, and HTTP client.
+
+A Senate **roll call** is one recorded vote, identified by `(congress, session, roll_number)` — same shape as a House roll call. Internal `vote_id` flattens to `"senate-{congress}-{session}-{roll}"`. The Senate's three vote-related XML feeds (confirmed by the spike) are:
+
+- **Menu XML** — `https://www.senate.gov/legislative/LIS/roll_call_lists/vote_menu_{congress}_{session}.xml`. One file per `(congress, session)` slot; lists every roll number plus a per-vote summary block. Used by Phase 3b only for **roll-number discovery** — not persisted.
+- **Detail XML** — `https://www.senate.gov/legislative/LIS/roll_call_votes/vote{congress}{session}/vote_{congress}_{session}_{roll_padded5}.xml`. One file per roll; contains chamber totals AND per-member positions in a single document. Senate timestamps in this file are in Eastern Time (ET, `America/New_York`) without an explicit timezone offset — the loader localizes. *Persisted as snapshots.*
+- **Roster XML** — `https://www.senate.gov/general/contact_information/senators_cfm.xml`. Current sitting Senate roster; needed for the **LIS↔Bioguide bridge** (see below). *Persisted as snapshots.*
+
+The detail XML keys members by `lis_member_id` (e.g., `"S428"`) — **not by Bioguide ID**. Concord's `vote_positions` table keys on `bioguide_id`. The bridge is the `member_full` field (e.g., `"Alsobrooks (D-MD)"`), which appears in both detail XML and the roster XML, and which Phase 1's [src/concord/scraper/members.py](../../src/concord/scraper/members.py) doesn't currently track. Bridge logic is load-time and in-memory (no new SQLite table) — see [Approach > Member bridge](#member-bridge).
+
+The party-unity methodology defined by [ADR 0011](../adr/0011-party-unity-score-methodology.md) was originally `(bioguide_id, congress)`-keyed. Phase 3b refines it to `(bioguide_id, congress, chamber)`-keyed: a Senate party-unity vote depends on Senate R-majority vs Senate D-majority and shouldn't pool with House votes from the same Congress. The ADR is **amended in place** to capture this refinement; no new ADR is created — see [Approach > Party-unity refinement](#party-unity-refinement).
+
+The roadmap risks Phase 3 carries forward are unchanged from 3a:
+
+- **Editorial neutrality** — already addressed by the chamber-scoped Party Unity Score; 3b just brings the Senate side online.
+- **Staleness** — daily-cadence operator-driven `concord run votes` job, same stance as Phase 3a.
+
+## Goals
+
+1. The Tier 1 scraper fetches, for every Senate roll-call vote in Congresses 117, 118, and 119:
+   - The menu XML for each `(congress, session)` slot, used in-process for roll-number discovery — **not persisted**.
+   - The per-roll detail XML for each roll — appended to `data/senate_votes.jsonl` as one [ADR 0006](../adr/0006-snapshot-on-fetch-for-mutable-entities.md) snapshot envelope per fetch, payload = the raw XML bytes as a UTF-8 string.
+   - The Senate roster XML (`senators_cfm.xml`) once per scrape run — appended to `data/senate_roster.jsonl` as one snapshot envelope per fetch.
+2. The loader projects the latest detail-XML snapshot per `(chamber, congress, session, roll_number)` into the `votes` SQLite table and the latest per-position into `vote_positions`. Loader resolves each XML member entry's `member_full` to a Bioguide ID via the in-memory bridge built from the latest `senators_cfm.xml` snapshot plus Phase 1's `members` table.
+3. The indexer (Stage 2) recomputes `votes.is_party_unity` and `member_party_unity` against the new chamber-scoped methodology — rebuilds `member_party_unity` from scratch with the new schema, covering both House and Senate.
+4. The CLI's `concord scrape votes` default for `--chambers` becomes `house,senate`; the Senate no-op message and short-circuit logic added in 3a are removed.
+5. The web app surfaces:
+   - `GET /votes/senate/{congress}/{session}/{roll}` — Senate Vote profile (header, result block, subject branch, full position roster). Renders identically to the House version per the shared `votes/profile.html` template — no chamber-specific branches.
+   - Member profile page: Senate members' "Recent votes" and "Party-unity score" sections now render live data; the "(Phase 3b)" placeholder body is removed.
+   - Bill page Vote history sections include Senate votes alongside House votes (already wired in 3a — query is `WHERE bill_id = ?`, chamber-agnostic).
+6. ADR 0011 (Party Unity Score) is amended in place with a Phase 3b refinement section documenting the `chamber` PK addition to `member_party_unity`.
+7. CONTEXT.md gains entries for **LIS member ID** and **`member_full`** so the bridge concept is documented for future maintainers.
+8. The two spike files (`.spike-senate-votes.md`, `.spike-senate-votes-findings.md`) are deleted; their findings live in this plan.
+9. All existing tests (Phase 1, 2a, 3a) continue to pass.
+
+## Non-goals
+
+1. **`vote_matters` side table for en-bloc votes.** *En bloc* is Senate procedure for voting on multiple matters in a single roll call — typically a batch of nominations confirmed together. Vote 655 in 119/1 rolls 96 nominations into one roll call. Phase 3b stores en-bloc rolls as a single `votes` row with `<vote_title>` as the `question` field and ignores the per-matter `<en_bloc><matter>` breakdown. Future v2 work can add a `vote_matters` table without migration pain (purely additive). See [Approach > En-bloc handling](#en-bloc-handling).
+2. **Persistent `senate_member_aliases` SQLite table.** The LIS↔Bioguide bridge is computed in memory at load time. No new table.
+3. **Surfacing the three-level amendment nesting** (`amendment_to_amendment_to_amendment_number`). Phase 3b captures only the immediate amendment in `votes.amendment_id`; the chain is preserved in the JSONL raw payload but not modeled in SQLite.
+4. **`vote_kind = 'trial'` for impeachment trials.** None present in 117–119. The `position` column is free TEXT and accepts `Guilty`/`Not Guilty` already; no new enum value.
+5. **Treaty entity table.** Treaties surface as `votes` rows with both `bill_id` and `amendment_id` NULL and the treaty identity in `question` only. Same stance as Phase 3a for nominations.
+6. **lxml or other non-stdlib XML parser.** Stdlib `xml.etree.ElementTree` is sufficient (no namespaces, no XPath complexity in the spike-captured fixtures).
+7. **HTTP caching of senate.gov resources.** No `Last-Modified` header per spike; each scrape run does fresh fetches. Snapshot-on-fetch provides de-facto history.
+8. **Senate vote text RAG.** Phase 5 territory.
+9. **Backfill before Congress 117.** Same scope as 3a.
+10. **A "live pair" / "announced for/against" UI affordance.** None observed in 119/1 sample per spike; if such position values appear in 117/118 historical data, the loader treats them as free-text positions and the party-unity computation drops them from the denominator (anything not in `{Yea, Nay}` is dropped).
+11. **Removing `chamber` from `votes.UNIQUE` constraint** or any other schema rewrite. Phase 3a's `votes` and `vote_positions` schemas are sufficient as-is.
+
+## Relevant prior decisions
+
+- [ADR 0001 — Python end-to-end for the web layer](../adr/0001-python-end-to-end-for-the-web-layer.md) — Senate Vote pages use the same FastAPI+Jinja2 templates as House.
+- [ADR 0002 — JSONL as canonical raw store](../adr/0002-jsonl-as-canonical-raw-store.md) — Senate data lands in `data/senate_votes.jsonl` and `data/senate_roster.jsonl`.
+- [ADR 0003 — SQLite as derived store](../adr/0003-sqlite-as-derived-store.md) — `member_party_unity` PK migration is "delete the SQLite file and re-index" per this ADR; no online migration needed.
+- [ADR 0006 — Snapshot-on-fetch for mutable entities](../adr/0006-snapshot-on-fetch-for-mutable-entities.md) — both Senate JSONL files carry the standard `{fetched_at, key, payload}` envelope; the Senate roster is treated as a mutable entity (senators leave / new ones arrive).
+- [ADR 0007 — Parallel pipelines per entity](../adr/0007-parallel-pipelines-per-entity.md) — `src/concord/senate_xml.py` is a *new HTTP client* sibling to `src/concord/api.py`; `scrape_senate` lands in `src/concord/scraper/votes.py` alongside `scrape_house`; loader / indexer / CLI all extend their Phase 3a modules in place.
+- [ADR 0009 — Multi-endpoint entities split JSONL by sub-endpoint](../adr/0009-multi-endpoint-entities-split-jsonl.md) — Senate writes two of the four eventual vote-files; together with 3a's two, the fanout matches the ADR's "one fetch = one snapshot" framing.
+- [ADR 0010 — Votes phased by chamber, not metadata-vs-positions](../adr/0010-votes-phased-by-chamber.md) — recorded in 3a; this plan is the 3b side it predicted.
+- **[ADR 0011 — Party Unity Score methodology](../adr/0011-party-unity-score-methodology.md)** — **amended in place** with this plan to capture the chamber-scoping refinement (the `member_party_unity` PK gains `chamber`).
+
+No new ADRs are created with this plan.
+
+## Relevant files and code
+
+Files to **read** for context:
+
+- [CONTEXT.md](../../CONTEXT.md) — new entries land in this plan: **LIS member ID**, **`member_full`**. Existing Vote / Roll-call number / Session / Vote question / Vote position / Party Unity Score entries (added in 3a) stay unchanged.
+- [docs/adr/0011-party-unity-score-methodology.md](../adr/0011-party-unity-score-methodology.md) — gets a Phase 3b refinement section appended.
+- [src/concord/api.py](../../src/concord/api.py) — the `USER_AGENT` constant and the retry-with-backoff pattern (lines ~10–22) are the template for `senate_xml.py`. Do not extend this client with Senate methods; create a new module.
+- [src/concord/scraper/votes.py](../../src/concord/scraper/votes.py) — Phase 3a's `scrape_house` is the structural template. `scrape_senate` lands alongside it in the same file.
+- [src/concord/pipeline/load_votes.py](../../src/concord/pipeline/load_votes.py) — Phase 3a's `load(...)` function. Gets a Senate branch that handles XML payloads and the in-memory member bridge.
+- [src/concord/pipeline/index_votes.py](../../src/concord/pipeline/index_votes.py) — Phase 3a's indexer. The `member_party_unity` rebuild query is generalized to group by `(bioguide_id, congress, chamber)`.
+- [src/concord/storage/sqlite.py](../../src/concord/storage/sqlite.py) — `_BASE_SCHEMA` (line 59); the `member_party_unity` CREATE TABLE statement gains a `chamber` column and the PK changes. `upsert_vote` / `upsert_vote_positions` (added in 3a) are reused.
+- [src/concord/scraper/members.py](../../src/concord/scraper/members.py) — Phase 1 scraper; its output (`data/members.jsonl` projected to `members` table) is consulted by the load-time bridge for historical senators.
+- [src/concord/cli.py](../../src/concord/cli.py) — the Phase 3a `scrape_votes_command` carries the `--chambers house` default and the Senate skip message; both change in this plan.
+- [src/concord/web/templates/members/profile.html](../../src/concord/web/templates/members/profile.html) — "(Phase 3b)" placeholder boxes get removed; the live Recent-votes + Party-unity sections become chamber-agnostic.
+- [src/concord/web/templates/votes/profile.html](../../src/concord/web/templates/votes/profile.html) — the senate-chamber Phase-3b body branch gets removed; one shared template for both chambers.
+- [src/concord/web/app.py](../../src/concord/web/app.py) — the `/votes/{chamber}/{congress}/{session}/{roll}` handler (registered per Phase 3a plan, Section 7 step 20) drops its senate-placeholder branch; the `/members/{bioguide_id}` handler (already at line 320 pre-3a; gains vote-related calls per Phase 3a step 25) drops its chamber check.
+- [tests/fixtures/senate/](../../tests/fixtures/senate/) — already populated by the spike: `vote_menu_119_1.xml`, `detail_119_1_00001_cloture.xml`, `detail_119_1_00002_motion.xml`, `detail_119_1_00003_amendment.xml`, `detail_119_1_00007_bill.xml`, `detail_119_1_00008_nomination.xml`, `senators_cfm.xml`.
+- [tests/test_pipeline_votes.py](../../tests/test_pipeline_votes.py), [tests/test_index_votes.py](../../tests/test_index_votes.py), [tests/test_web_votes.py](../../tests/test_web_votes.py) — Phase 3a's test files; Phase 3b adds parallel Senate cases.
+
+Files to **create**:
+
+- `src/concord/senate_xml.py` — new HTTP client (`SenateClient`) + XML parsing helpers. Exposes `list_roll_call_numbers`, `get_roll_call_xml`, `get_current_senators_xml`, plus parsing functions `parse_vote_menu`, `parse_vote_detail`, `parse_senate_roster`.
+- `tests/test_senate_xml.py` — unit tests for the new module, exercising the spike-captured fixtures.
+
+Files to **modify**:
+
+- `src/concord/scraper/votes.py` — add `scrape_senate(client_xml, congresses, storage_dir, *, fetched_at, sessions=(1,2), limit=None, progress=None) -> ScrapeStats`.
+- `src/concord/pipeline/load_votes.py` — add a Senate branch reading both Senate JSONL files; add `_build_member_bridge(...)` helper; integrate into the `load(...)` driver.
+- `src/concord/pipeline/index_votes.py` — change `member_party_unity` rebuild to group by `(bioguide_id, congress, chamber)`.
+- `src/concord/storage/sqlite.py` — update `member_party_unity` schema in `_BASE_SCHEMA` (add `chamber` column, change PK); update `_MEMBER_PARTY_UNITY_COLUMNS` and `_MEMBER_PARTY_UNITY_UPSERT_SQL` accordingly; update `get_party_unity_for_member` to return rows ordered by `(congress DESC, chamber)`.
+- `src/concord/cli.py` — change `DEFAULT_VOTES_CHAMBERS` from `("house",)` to `("house", "senate")`; remove the "Senate ingest lands in Phase 3b — skipping." log path; wire `scrape_senate` into the senate slice of `scrape_votes_command` and `run_votes_command`.
+- `src/concord/web/templates/members/profile.html` — remove the chamber-based template branch for the Recent-votes and Party-unity sections; both sections render uniformly. Remove "(Phase 3b)" labels.
+- `src/concord/web/templates/votes/profile.html` — remove the senate-chamber Phase-3b body branch; one template path for both chambers.
+- `src/concord/web/app.py` — drop the senate Phase-3b placeholder branch in the vote-profile handler; drop the chamber check in the member-profile handler that gated Recent-votes / Party-unity display.
+- `docs/adr/0011-party-unity-score-methodology.md` — append a "Phase 3b refinement" section explaining the `chamber` PK addition. Update front-matter Status line: `Status: Accepted 2026-05-25; refined 2026-05-26 (Phase 3b)`.
+- `CONTEXT.md` — add **LIS member ID** and **`member_full`** entries under the Entities section.
+
+Files to **delete**:
+
+- `docs/plans/.spike-senate-votes.md`
+- `docs/plans/.spike-senate-votes-findings.md`
+
+## Approach
+
+### Source overview
+
+Senate vote data lives at three URLs under senate.gov:
+
+```
+https://www.senate.gov/legislative/LIS/roll_call_lists/vote_menu_{congress}_{session}.xml   ← discovery
+https://www.senate.gov/legislative/LIS/roll_call_votes/vote{congress}{session}/vote_{congress}_{session}_{roll5}.xml   ← detail (positions + totals)
+https://www.senate.gov/general/contact_information/senators_cfm.xml   ← roster (LIS↔Bioguide bridge)
+```
+
+All three return XML. No auth. No documented rate limit (the spike observed clean responses at ~25 requests with no 429s; the scraper uses a 0.1s inter-request sleep as defensive padding). User-Agent is `concord/{version} (+https://github.com/johnmarcampbell/concord)` — same as the existing `api.py` client.
+
+The menu XML lists every roll in a `(congress, session)` slot with summary fields. Phase 3b uses it **only for roll-number discovery** — not persisted. The roll numbers in `<vote_number>` come back zero-padded (`"00007"`); the detail-XML URLs need them zero-padded (`"00007"`); the detail XML itself unpads (`"7"`). The scraper preserves the menu's padded form for URL construction.
+
+### Storage shape
+
+**Phase 3b writes two JSONL files**, both following [ADR 0006](../adr/0006-snapshot-on-fetch-for-mutable-entities.md):
+
+- `data/senate_votes.jsonl` — one snapshot per detail-XML fetch. `key`: `{"chamber": "senate", "congress": 119, "session": 1, "roll_number": 7}`. `payload`: the raw XML bytes decoded as UTF-8 string, stored verbatim. (Unlike House where `payload` is the parsed JSON object, here `payload` is the raw XML — see [Approach > Why XML is stored raw](#why-xml-is-stored-raw).)
+- `data/senate_roster.jsonl` — one snapshot per `senators_cfm.xml` fetch. `key`: `{"source": "senators_cfm"}`. `payload`: raw XML string. The Senate roster doesn't have a natural primary key beyond "the current snapshot" — `key.source` is a constant disambiguator.
+
+**No SQLite schema changes other than `member_party_unity`.** The Phase 3a `votes` and `vote_positions` tables accept Senate rows as-is. The `member_party_unity` table schema becomes:
+
+```sql
+CREATE TABLE IF NOT EXISTS member_party_unity (
+  bioguide_id              TEXT NOT NULL,
+  congress                 INTEGER NOT NULL,
+  chamber                  TEXT NOT NULL
+    CHECK (chamber IN ('house', 'senate')),
+  party                    TEXT NOT NULL
+    CHECK (party IN ('R', 'D')),
+  party_unity_votes_cast   INTEGER NOT NULL,
+  party_line_votes         INTEGER NOT NULL,
+  PRIMARY KEY (bioguide_id, congress, chamber)
+);
+```
+
+The PK gains `chamber`. Existing 3a rows are dropped during the schema rebuild. Per [ADR 0003](../adr/0003-sqlite-as-derived-store.md), the SQLite file is regenerable — the migration is "delete the SQLite file and re-load + re-index everything" (`rm data/proceedings.db && concord load proceedings && concord load members && concord load bills && concord load votes && concord index votes`). Operators do this once when 3b lands; no online migration code is written.
+
+### Why XML is stored raw
+
+Phase 3a stores parsed JSON as the snapshot `payload` because the api.congress.gov client returns parsed dicts. Phase 3b stores raw XML as the snapshot `payload` because the Senate XML parser is part of the load step, not the scrape step. Two reasons:
+
+1. **Robustness to schema changes.** If senate.gov adds a new element next year, the JSONL still loads (raw XML is forward-compatible); re-parsing is a load-step change, not a re-scrape.
+2. **Loader symmetry across data shapes.** The Phase 3a House loader unpacks `payload` as a dict; the 3b Senate loader unpacks `payload` as an XML string and parses it. Each has one shape; neither file mixes.
+
+Round-trip cost: storing XML as a string adds ~5% to the file size vs JSON. Trivial at v1 scale (~700 rolls × 28 KB × 3 Congresses = ~60 MB).
+
+### HTTP client structure
+
+A new module `src/concord/senate_xml.py` houses `SenateClient` and the parsing functions. The client class:
+
+```python
+class SenateClient:
+    def __init__(self, *, user_agent: str = USER_AGENT) -> None: ...
+    def list_roll_call_numbers(self, congress: int, session: int) -> list[int]: ...
+    def get_roll_call_xml(self, congress: int, session: int, roll_number: int) -> bytes: ...
+    def get_current_senators_xml(self) -> bytes: ...
+```
+
+Implementation notes:
+
+- Uses `httpx.Client(timeout=30.0)` directly — no auth, no API key. User-Agent in headers.
+- **Retry policy**: 3 retries on transport errors (DNS, connection reset, read timeout), with exponential backoff (1s, 2s, 4s). No special 429 handling — senate.gov hasn't shown rate limits in the spike, but the standard backoff covers transient 5xx.
+- **HTML-404-disguised-as-200 detection**: after each fetch, check `Content-Type`. If it's `text/html`, raise `SenateXmlError(f"Got HTML response, expected XML, at {url}")` — the spike found `senators_cfm_historical.xml` returns this trap.
+- **Inter-request padding**: 0.1s sleep between detail-XML fetches. Defensive; senate.gov hasn't rate-limited, but a Senate-only backfill is ~700 requests × 3 Congresses × 2 sessions = ~4200 detail fetches, and the padding keeps load gentle.
+
+Parsing functions (also in `senate_xml.py`):
+
+```python
+def parse_vote_menu(xml_bytes: bytes) -> list[int]:
+    """Return roll numbers from vote_menu_{c}_{s}.xml, oldest-first."""
+
+def parse_vote_detail(xml_bytes: bytes) -> ParsedVoteDetail:
+    """Parse vote_{c}_{s}_{rrrrr}.xml. Returns a typed object with chamber
+    totals, subject (bill_id / amendment_id / question), threshold, vote_kind,
+    start_date (ISO8601 with ET offset), and a list of ParsedVotePosition records."""
+
+def parse_senate_roster(xml_bytes: bytes) -> dict[str, str]:
+    """Parse senators_cfm.xml. Returns dict mapping member_full -> bioguide_id."""
+```
+
+`ParsedVoteDetail` and `ParsedVotePosition` are pydantic models in [src/concord/models.py](../../src/concord/models.py), added alongside the 3a `Vote` and `VotePosition`.
+
+Stdlib `xml.etree.ElementTree` is the parser. No namespaces in the Senate XML files; `.findtext()`, `.findall()`, `.iter()` are sufficient.
+
+### Scraper structure
+
+`src/concord/scraper/votes.py` gains a second entry point alongside 3a's `scrape_house`:
+
+```python
+def scrape_senate(
+    client_xml: SenateClient,
+    congresses: Iterable[int],
+    storage_dir: Path,
+    *,
+    fetched_at: datetime,
+    sessions: Iterable[int] = (1, 2),
+    limit: int | None = None,
+    progress: Callable[[ScrapeProgressEvent], None] | None = None,
+) -> ScrapeStats: ...
+```
+
+Driver behavior:
+
+1. Fetch `senators_cfm.xml` **once** at the start; append one snapshot envelope to `data/senate_roster.jsonl` with `key={"source": "senators_cfm"}`.
+2. For each `(congress, session)` pair:
+   a. Fetch the menu XML; parse into roll numbers.
+   b. For each roll, fetch the detail XML; append one snapshot envelope to `data/senate_votes.jsonl` with `key={"chamber": "senate", "congress": c, "session": s, "roll_number": n}`.
+   c. Sleep 0.1s between detail fetches.
+   d. Emit `ScrapeProgressEvent(chamber='senate', congress, session, votes_seen, votes_written)` once per `(congress, session)` after all rolls in that pair complete.
+3. **Stop after `limit` detail fetches**, if set. The roster is always fetched regardless of `--limit`.
+
+Cost envelope: 3 Congresses × 2 sessions × ~600 rolls/session ≈ 3600 detail fetches × 0.4s = ~25 min. Plus 1 roster fetch + 6 menu fetches. ~60 MB JSONL total.
+
+### Loader
+
+`src/concord/pipeline/load_votes.py`'s existing `load(...)` driver gains a Senate branch:
+
+```python
+def load(storage_dir: Path, db_path: Path, *, limit: int | None = None) -> LoadStats:
+    # Existing 3a flow for House — unchanged
+    _load_house(storage_dir, db_path, limit=limit)
+    # New 3b flow for Senate
+    _load_senate(storage_dir, db_path, limit=limit)
+```
+
+The Senate branch:
+
+1. Read `data/senate_roster.jsonl`; build the in-memory `roster_bridge: dict[str, str]` (member_full → bioguide_id) from the latest snapshot.
+2. Read `data/senate_votes.jsonl`; group by `(chamber, congress, session, roll_number)`; keep latest by `fetched_at`.
+3. For each latest snapshot:
+   - Parse the XML payload via `parse_vote_detail`.
+   - Build the `Vote` model from the parsed detail.
+   - Upsert into `votes`.
+   - For each position in the parsed detail:
+     - Resolve `member_full` → `bioguide_id` via `_resolve_bioguide(member_full, vote_date, roster_bridge, members_table_conn)`.
+     - If resolved: upsert into `vote_positions`.
+     - If not resolved: log a structured warning (`unresolved_member`) and skip the position. The vote totals still load.
+4. Idempotent. Re-running over unchanged JSONL is a no-op.
+
+### Member bridge
+
+The `_resolve_bioguide(member_full, vote_date, roster_bridge, db_conn)` helper:
+
+1. **Direct hit in roster:** if `member_full` is in `roster_bridge`, return that Bioguide ID. Covers current senators.
+2. **Historical fallback:** parse `member_full` into `last_name` + `state` + `party`:
+   - Regex `^(?P<last>[^\(]+?)\s+\((?P<party>[RDI])-(?P<state>[A-Z]{2})\)$` (handles `"Blunt Rochester (D-DE)"`, `"Van Hollen (D-MD)"`, `"Hyde-Smith (R-MS)"`).
+   - Query Phase 1's `members` table: `SELECT bioguide_id FROM members m JOIN member_terms t ON m.bioguide_id = t.bioguide_id WHERE t.chamber = 'senate' AND m.last_name = ? AND t.state = ? AND t.start_date <= ? AND (t.end_date IS NULL OR t.end_date >= ?)`. The double-date guard handles term-overlap with the vote date.
+   - If exactly one match: return it. If zero or multiple: bridge fails.
+3. **Failure:** return `None`; caller logs and skips.
+
+Tolerance for mid-Congress party-switch: the regex captures party but the historical query doesn't filter on it — `(last_name, state, date-overlap)` is sufficient. If a member's `(D-XX)` flips to `(I-XX)` mid-term, the bridge still resolves.
+
+Multi-word surnames: the regex's `[^\(]+?` non-greedy match against `\s+\(`-prefix handles spaces in surnames. The bridge does not parse `member_full` itself for "last name" — Phase 1's `members.last_name` is the authoritative split.
+
+### Vote-detail XML parsing
+
+`parse_vote_detail` returns a `ParsedVoteDetail` with these fields ready for the loader:
+
+- `congress`, `session`, `roll_number` — from `<congress>`, `<session>`, `<vote_number>` (unpadded in detail XML).
+- `start_date` — from `<vote_date>` (`"January 20, 2025,  06:12 PM"`), parsed via `datetime.strptime(s.strip().replace("  ", " "), "%B %d, %Y, %I:%M %p")` and localized via `zoneinfo.ZoneInfo("America/New_York")`. Formatted as ISO8601 with offset.
+- `update_date` — from `<modify_date>`, same parser.
+- `vote_question` — from `<vote_question_text>`.
+- `vote_type` — from `<question>` (short label).
+- `threshold` — from `<majority_requirement>`: `"1/2"` → `simple_majority`, `"3/5"` → `three_fifths`, `"2/3"` → `two_thirds`. Unknown values → `None` and a structured warning.
+- `result` — from `<vote_result>` (short form without count).
+- `vote_kind` — always `'standard'` for Senate in 3b. The detail XML has no election-vote analog.
+- `yea_count`, `nay_count`, `present_count` — from `<count><yeas>`, `<nays>`, `<present>`.
+- `not_voting_count` — from `<count><absent>` (vocabulary mapping: senate calls it "absent", Phase 3a's column is "not voting").
+- `bill_id` — see subject branching below.
+- `amendment_id` — see subject branching below.
+- `positions: list[ParsedVotePosition]` — one entry per `<member>` child, with `member_full`, `last_name`, `first_name`, `party`, `state`, `vote_cast`, `lis_member_id`.
+
+**Subject branching** (in `parse_vote_detail`, mirroring the House "amendment trap" logic but for the Senate XML schema):
+
+```python
+amendment_number = root.findtext("amendment/amendment_number") or ""
+if amendment_number.strip():
+    # Amendment vote: amendment_id from <amendment>, bill_id from <amendment_to_document_*>
+    amendment_id = _build_amendment_id(congress, amendment_number)
+    bill_id = _build_bill_id(
+        congress,
+        root.findtext("amendment/amendment_to_document_type"),
+        root.findtext("amendment/amendment_to_document_number"),
+    )
+else:
+    amendment_id = None
+    doc_type = (root.findtext("document/document_type") or "").strip()
+    if doc_type in BILL_TYPES_SENATE:  # see below
+        bill_id = _build_bill_id(congress, doc_type, root.findtext("document/document_number"))
+    else:
+        # Nomination (doc_type="PN"), treaty, or empty — both FKs NULL
+        bill_id = None
+```
+
+`BILL_TYPES_SENATE` is the set of document-type codes that map to Concord's bill types. From spike: `{"S.", "S.J.Res.", "S.Res.", "S.Con.Res.", "H.R.", "H.J.Res.", "H.Res.", "H.Con.Res."}`. The mapping function lowercases and strips dots/spaces: `"S.J.Res."` → `"sjres"`, `"H.R."` → `"hr"`, etc. Same canonical form as Phase 2a's `bills.bill_type`. Codes outside this set (notably `"PN"` for nominations — *Presidential Nomination* — and treaty types) intentionally return `None` so those votes get NULL FK columns and carry their identity in `question` text only.
+
+`_build_amendment_id(congress, amendment_number)` parses the XML form `"S.Amdt. 14"` into `"119-samdt-14"`. House amendment IDs use `hamdt`; Senate uses `samdt`. The amendment number is always extracted from `<amendment><amendment_number>` — the higher-degree nesting (`amendment_to_amendment_number`, etc.) is preserved in JSONL but not parsed into SQLite columns.
+
+### En-bloc handling
+
+Detection: if `<en_bloc>` is present AND `<question>` is empty:
+
+- `question` field on the `votes` row = `<vote_title>` (e.g., `"Confirmation of 96 Nominations en bloc"`).
+- `bill_id` = NULL, `amendment_id` = NULL.
+- Position roster loaded normally.
+- The `<en_bloc><matter>` children are present in the raw XML payload (preserved in JSONL) but not surfaced in SQLite for v1. A future `vote_matters` table can be added purely-additively.
+
+### Party-unity refinement
+
+[ADR 0011](../adr/0011-party-unity-score-methodology.md) is **amended in place** with a "Phase 3b refinement (2026-05-26)" section that documents:
+
+- The `member_party_unity` PK gains `chamber TEXT NOT NULL CHECK (chamber IN ('house', 'senate'))`.
+- The score is now per `(bioguide_id, congress, chamber)`.
+- Rationale: a Senate party-unity vote's R-majority-vs-D-majority is computed over Senate positions only; pooling with House votes from the same Congress would mix two different denominators and dilute the score's meaning.
+- Members who served in both chambers within one Congress (rare chamber-switchers like a House member appointed to fill a Senate vacancy) get two rows. UI renders both labeled.
+- Members in one chamber per Congress (~99% case) see no visible change.
+
+The amendment block carries its own date; the ADR's original "Accepted, 2026-05-25" line is preserved with a "; refined 2026-05-26 (Phase 3b)" suffix.
+
+### Indexer changes
+
+[src/concord/pipeline/index_votes.py](../../src/concord/pipeline/index_votes.py) — the `member_party_unity` rebuild CTE generalizes:
+
+```sql
+-- Phase 3a (current)
+GROUP BY vp.bioguide_id, v.congress
+
+-- Phase 3b (new)
+GROUP BY vp.bioguide_id, v.congress, v.chamber
+```
+
+The `votes.is_party_unity` UPDATE is unchanged — it's already per-vote (chamber-implicit via the `vote_positions` JOIN).
+
+### CLI changes
+
+`src/concord/cli.py`:
+
+- `DEFAULT_VOTES_CHAMBERS = ("house", "senate")` (was `("house",)`).
+- The Senate skip-message branch in `scrape_votes_command` is removed.
+- The senate slice now calls `scrape_senate(client_xml=SenateClient(), ...)` where the 3a code had a no-op log.
+- `run_votes_command` is updated to construct both `Client` (api.congress.gov) and `SenateClient` as needed.
+
+`concord scrape votes` (no args) now runs both chambers for the default congress set. `concord scrape votes --chambers house` still works for House-only scrapes; `--chambers senate` for Senate-only.
+
+### Web surface changes
+
+**Vote profile.** `votes/profile.html` already handles both chambers in 3a — Phase 3b just removes the senate-chamber "(Phase 3b)" body branch. The shared template renders header / result / subject / position roster identically for both chambers.
+
+**Member profile.** `members/profile.html` had chamber-based template branches in 3a (House members got live sections; Senate members got "(Phase 3b)" placeholders). Phase 3b removes those branches — both chambers render the same live sections.
+
+The `/members/{bioguide_id}` handler in `app.py` no longer needs to look up the member's chamber to decide template behavior. The handler simply queries `recent_votes_for_member(bioguide_id)` and `party_unity_for_member(bioguide_id)`; the templates iterate whatever returns.
+
+**Party-unity display for chamber-switchers.** The handler returns one row per Congress per chamber the member served in. Template iterates and renders each as its own labeled stat ("Senate: voted with Democratic majority on …", "House: voted with Democratic majority on …"). For the ~99% of members who served in one chamber per Congress, the layout is visually identical to Phase 3a's single-row display.
+
+**Bill profile Vote history.** Already chamber-agnostic in 3a — query is `WHERE bill_id = ?`. Senate votes appear alongside House votes automatically once they load. No template change.
+
+**`/about/methodology` page.** Reflects the chamber-scoping refinement. Update the `#party-unity` section to note: "Each chamber's score is computed independently from positions cast in that chamber. Members who served in both chambers in a single Congress see two scores per Congress, one per chamber."
+
+## Step-by-step plan
+
+Eight sections — **ADR amendment & CONTEXT.md**, **HTTP client & parsing**, **Models**, **Storage**, **Scraper**, **Loader**, **Indexer**, **CLI**, **Web**, **Verification**.
+
+### Section 1 — ADR amendment & CONTEXT.md
+
+1. **Amend ADR 0011 with the Phase 3b chamber refinement.** Append a "Phase 3b refinement (2026-05-26)" section to [docs/adr/0011-party-unity-score-methodology.md](../adr/0011-party-unity-score-methodology.md). Document the PK change to `(bioguide_id, congress, chamber)`, the rationale (chamber-specific majorities), and the UI implication (chamber-switchers see two rows per Congress). Update Status line: `Status: Accepted 2026-05-25; refined 2026-05-26 (Phase 3b)`.
+
+2. **Add LIS member ID + member_full entries to CONTEXT.md.** In the Entities section of [CONTEXT.md](../../CONTEXT.md), add:
+   - **LIS member ID** — Senate-internal stable identifier for a senator, used in senate.gov LIS XML feeds. Format `"S\d+"` (e.g., `"S428"`). Concord does not store LIS IDs in SQLite; they are used only as a transient join key inside the Senate vote loader.
+   - **`member_full`** — Senate display string in the form `"Surname (Party-State)"` (e.g., `"Alsobrooks (D-MD)"`). Appears in both senate.gov vote-detail XML and `senators_cfm.xml`. Concord uses it as the bridge string for LIS↔Bioguide resolution at vote-load time.
+
+### Section 2 — HTTP client & parsing
+
+3. **Create `src/concord/senate_xml.py` skeleton.** Create the module with the `USER_AGENT` import, `SenateClient` class skeleton (init + three method signatures stubs), and `SenateXmlError` exception. No fetch logic yet. Confirm import works: `python -c "from concord.senate_xml import SenateClient"`.
+
+4. **Implement `SenateClient.get_current_senators_xml()`.** Single GET to `https://www.senate.gov/general/contact_information/senators_cfm.xml`. User-Agent set; 30s timeout. Detect Content-Type mismatch (raise `SenateXmlError` if `text/html`). Return raw bytes.
+
+5. **Implement `SenateClient.list_roll_call_numbers(congress, session)`.** GET the menu URL; parse with stdlib `xml.etree.ElementTree`. Iterate `<vote>` children; extract `<vote_number>` (zero-padded string); convert to int; return sorted ascending. Skip entries with empty/missing `<vote_number>` and log a warning. (Note: the menu XML returns newest-first per spike; sort ascending for stable scrape order.)
+
+6. **Implement `SenateClient.get_roll_call_xml(congress, session, roll_number)`.** Build URL with zero-padded 5-digit roll number; GET; detect HTML 404 trap; return raw bytes.
+
+7. **Implement `parse_senate_roster(xml_bytes)`.** Parse `senators_cfm.xml`; iterate `<member>` children; extract `member_full` from constructed `f"{last_name} ({party}-{state})"` (the spike found this XML carries last_name / first_name / party / state / bioguide_id separately — reconstruct `member_full` to match the format used in vote XML); return `dict[member_full, bioguide_id]`. Skip entries missing bioguide_id and log.
+
+8. **Implement `parse_vote_menu(xml_bytes)`.** Return list of int roll numbers sorted ascending.
+
+9. **Implement `parse_vote_detail(xml_bytes)`.** Returns a `ParsedVoteDetail` model (added in Section 3). The function:
+   - Extracts top-level scalars (`congress`, `session`, `vote_number` — convert to int).
+   - Parses `<vote_date>` and `<modify_date>` via ET-timezone helper.
+   - Maps `<majority_requirement>` to threshold enum.
+   - Sets `vote_kind='standard'`.
+   - Runs subject branching: amendment-vote precedence, then bill-vote, then NULL FKs.
+   - Iterates `<members><member>` children into `ParsedVotePosition` list.
+   - Maps `<count><absent>` to `not_voting_count`.
+   - Detects `<en_bloc>` + empty `<question>`: sets `question = vote_title`, both FKs NULL.
+
+10. **Helper: `_parse_senate_date(text)`.** Parses `"January 20, 2025,  06:12 PM"` (note double space). Localize via `zoneinfo.ZoneInfo("America/New_York")`. Return ISO8601 string with offset. Handle None/empty input gracefully (return None).
+
+11. **Helper: `_build_amendment_id_from_xml(congress, amendment_number_text)`.** Parses `"S.Amdt. 14"` → `"119-samdt-14"`. Handles whitespace variation.
+
+12. **Helper: `_build_bill_id_from_xml(congress, document_type, document_number)`.** Canonicalizes the senate.gov XML type forms (`"S."`, `"S.J.Res."`, `"H.R."`, etc.) to the Concord bill-type codes (`"s"`, `"sjres"`, `"hr"`, etc.). Returns `None` if `document_type` is `"PN"`, treaty type, or unrecognized.
+
+13. **Test the senate_xml module.** Create `tests/test_senate_xml.py`. Cover with the spike-captured fixtures:
+    - `parse_vote_menu(vote_menu_119_1.xml)` returns 659 entries ascending.
+    - `parse_senate_roster(senators_cfm.xml)` returns a non-empty dict with sample senators present.
+    - `parse_vote_detail(detail_119_1_00007_bill.xml)` returns: `bill_id="119-s-5"`, `amendment_id=None`, `threshold="simple_majority"`, `yea_count=64`, `nay_count=35`, `vote_kind="standard"`, positions list with 99+ entries including `member_full="Alsobrooks (D-MD)"`, `lis_member_id="S428"`.
+    - `parse_vote_detail(detail_119_1_00003_amendment.xml)` returns: `amendment_id="119-samdt-14"`, `bill_id="119-s-5"` (the underlying), `threshold` per fixture.
+    - `parse_vote_detail(detail_119_1_00008_nomination.xml)` returns: both `bill_id` and `amendment_id` NULL, `question` carrying the nomination text.
+    - `parse_vote_detail(detail_119_1_00001_cloture.xml)` returns: `threshold="three_fifths"`, `bill_id="119-s-5"`, `amendment_id=None`, `vote_type="On the Cloture Motion"`.
+    - `_parse_senate_date("January 20, 2025,  06:12 PM")` returns `"2025-01-20T18:12:00-05:00"`.
+    - `SenateClient.list_roll_call_numbers` against a mock transport returns the expected list.
+    - `SenateClient.get_roll_call_xml` raises `SenateXmlError` when the mock transport returns `Content-Type: text/html`.
+
+### Section 3 — Models
+
+14. **Add `ParsedVoteDetail` and `ParsedVotePosition` pydantic models** to [src/concord/models.py](../../src/concord/models.py). These mirror Phase 3a's `Vote` and `VotePosition` shape but carry an unresolved `member_full` instead of `bioguide_id` (the loader resolves later).
+
+### Section 4 — Storage
+
+15. **Update `member_party_unity` schema in `_BASE_SCHEMA`.** In [src/concord/storage/sqlite.py](../../src/concord/storage/sqlite.py), change the CREATE TABLE block to add `chamber TEXT NOT NULL CHECK (chamber IN ('house', 'senate'))` and update the PK to `(bioguide_id, congress, chamber)`.
+
+16. **Update `_MEMBER_PARTY_UNITY_COLUMNS` and `_MEMBER_PARTY_UNITY_UPSERT_SQL`** to include the new column.
+
+17. **Update `get_party_unity_for_member`** to return rows ordered by `congress DESC, chamber`.
+
+18. **Test storage changes.** Extend [tests/test_storage_votes_sqlite.py](../../tests/test_storage_votes_sqlite.py) with:
+    - Schema CHECK rejects rows with invalid `chamber`.
+    - PK accepts the same `(bioguide_id, congress)` with different `chamber`.
+    - `get_party_unity_for_member` returns ordered rows correctly when both chambers present.
+
+### Section 5 — Scraper
+
+19. **Add `scrape_senate` to `src/concord/scraper/votes.py`.** Function signature in [Approach > Scraper structure](#scraper-structure). Driver: fetch roster once at start; for each `(c, s)` pair fetch the menu; for each roll fetch the detail XML; sleep 0.1s between detail fetches; append envelopes to the two JSONL files; emit `ScrapeProgressEvent(chamber='senate', ...)`.
+
+20. **Verify in `tests/test_scraper_votes.py`** (extended from 3a). Cases:
+    - Senate scrape writes exactly one roster envelope and N detail envelopes for N rolls.
+    - `--limit N` honored on detail fetches; roster always fetched.
+    - `chamber='senate'` in every detail-envelope key.
+    - Mock transport simulates a roll that returns HTML 404 — the scraper raises `SenateXmlError` and does not corrupt the JSONL files (no partial line).
+
+### Section 6 — Loader
+
+21. **Add `_build_member_bridge(storage_dir, db_conn)` helper to `src/concord/pipeline/load_votes.py`.** Reads `data/senate_roster.jsonl` latest snapshot, parses, builds the `member_full → bioguide_id` dict.
+
+22. **Add `_resolve_bioguide(member_full, vote_date, roster_bridge, db_conn)` helper.** Per [Approach > Member bridge](#member-bridge). Returns Bioguide ID or None.
+
+23. **Add `_load_senate(storage_dir, db_path, limit)` driver.** Reads `data/senate_votes.jsonl`, groups by key, keeps latest, parses XML, upserts `votes` row, resolves positions, upserts `vote_positions` rows. Logs structured warnings on unresolved members. Returns sub-counts merged into the overall `LoadStats`.
+
+24. **Wire `_load_senate` into the main `load(...)` function.** Calls happen after the House branch. Both branches share the same `LoadStats` accumulator.
+
+25. **Test the loader with Senate fixtures.** Extend [tests/test_pipeline_votes.py](../../tests/test_pipeline_votes.py). Use the spike fixtures + a synthetic `senators_cfm.xml`-shaped JSONL snapshot:
+    - Bill vote (roll 7) loads with `bill_id="119-s-5"`.
+    - Amendment vote (roll 3) loads with both FKs populated.
+    - Nomination vote (roll 8) loads with both FKs NULL.
+    - Cloture vote (roll 1) loads with threshold `three_fifths`.
+    - Position resolution succeeds for a senator in the roster.
+    - Position resolution falls back to `members`-table query for a synthetic "former senator" not in the roster but present in `members`.
+    - Position resolution fails gracefully for a senator missing from both — vote loads, position is skipped, warning logged.
+    - Re-running `load()` over unchanged JSONL is idempotent.
+
+### Section 7 — Indexer
+
+26. **Update `index_votes.py` to group party-unity computation by chamber.** Change the `member_party_unity` rebuild CTE: `GROUP BY vp.bioguide_id, v.congress, v.chamber`. Insert into the new 4-column table.
+
+27. **Test the indexer with mixed-chamber data.** Extend [tests/test_index_votes.py](../../tests/test_index_votes.py):
+    - Synthetic data: one House party-unity vote + one Senate party-unity vote + members in each chamber.
+    - After index: `member_party_unity` rows exist for both chambers; each row's numerator/denominator reflects only their chamber's votes.
+    - Synthetic chamber-switcher (rare case): same `bioguide_id` has positions in both chambers in one Congress → two rows post-index.
+
+### Section 8 — CLI
+
+28. **Update CLI defaults and remove the no-op.** In [src/concord/cli.py](../../src/concord/cli.py): change `DEFAULT_VOTES_CHAMBERS` to `("house", "senate")`; remove the "Senate ingest lands in Phase 3b — skipping." log path; wire `scrape_senate(client_xml=SenateClient(), ...)` into the senate slice; update `run_votes_command` to construct both `Client` and `SenateClient` as needed.
+
+29. **Test the CLI changes.** Extend [tests/test_cli.py](../../tests/test_cli.py):
+    - `concord scrape votes --congresses 119 --sessions 1 --limit 2` (no `--chambers` flag) hits both api.congress.gov and senate.gov (verified via mocked transports), writing to `data/house_votes.jsonl`, `data/house_vote_positions.jsonl`, `data/senate_votes.jsonl`, `data/senate_roster.jsonl`.
+    - `concord scrape votes --chambers house` only writes House files.
+    - `concord scrape votes --chambers senate` only writes Senate files.
+
+### Section 9 — Web
+
+30. **Remove the senate-chamber Phase-3b body branch in `votes/profile.html`.** The template now renders both chambers identically.
+
+31. **Remove the chamber-based template branches in `members/profile.html`.** Both Recent-votes and Party-unity-score sections render uniformly. Drop all "(Phase 3b)" labels.
+
+32. **Update the route handlers in `app.py`.** Drop the senate-placeholder branch in the vote-profile handler; drop the chamber check in the member-profile handler that gated Recent-votes / Party-unity display.
+
+33. **Render multiple party-unity rows per Congress** (one per chamber the member served in). Template iterates the list returned by `get_party_unity_for_member`. Labels: "House: voted with…" or "Senate: voted with…" per row. For members in one chamber per Congress, looks identical to Phase 3a.
+
+34. **Update `/about/methodology` page.** Add a paragraph explaining the chamber-scoping refinement: each chamber's score is computed independently; chamber-switchers see two scores per Congress.
+
+35. **Web tests.** Extend [tests/test_web_votes.py](../../tests/test_web_votes.py):
+    - `/votes/senate/119/1/7` returns 200, renders subject + positions (no more "(Phase 3b)" body).
+    - `/members/{senator_bioguide}` shows live Recent votes + Party-unity sections (no more placeholder).
+    - `/about/methodology` mentions chamber-scoping.
+
+### Section 10 — Verification
+
+36. **End-to-end smoke test.** Extend `tests/test_smoke.py`. Synthesize one Senate vote + one House vote + a synthetic roster, run load + index, open the web app via `TestClient`, hit `/votes`, `/votes/senate/119/1/7`, `/votes/house/119/1/240`, `/members/{senator_bioguide}`, `/bills/119/s/5` (vote history should now include the Senate vote).
+
+37. **Manual smoke against live data.** Delete `data/proceedings.db`; run `concord load proceedings && concord load members && concord load bills && concord load votes && concord index votes`. Then `concord run votes --congresses 119 --sessions 1 --limit 50` (now hits both chambers by default). Then `concord serve`. Click through: a Senate Vote profile, a senator's Member profile (verify Recent votes + Party-unity render), a bill that had Senate votes (verify Vote history includes them).
+
+38. **Delete the spike files.** `rm docs/plans/.spike-senate-votes.md docs/plans/.spike-senate-votes-findings.md`.
+
+39. **Run the full test suite.** `pytest` clean. `uv run ruff check`. `uv run ruff format --check`. **Phase 1, 2a, and 3a tests must continue to pass** — especially `tests/test_web_members.py` (Senate-member placeholder branch is gone), `tests/test_web_votes.py` (senate-chamber Phase-3b body branch is gone), and `tests/test_index_votes.py` (`member_party_unity` rows now have a `chamber` column).
+
+40. **Update CONTEXT.md and ADR 0011 final pass.** Verify the new CONTEXT.md entries are present; verify ADR 0011 has its refinement section.
+
+## Demo seed data
+
+Concord's demo derives from `data/*.jsonl`. After step 39 lands, the operator runs `concord run votes --congresses 119 --sessions 1 --limit 100` once locally — now hits both House (via the API) and Senate (via senate.gov). Populates `data/house_votes.jsonl`, `data/house_vote_positions.jsonl`, `data/senate_votes.jsonl`, `data/senate_roster.jsonl`, and the three SQLite tables. Demo mode now illustrates: a Senate Vote profile with a full 100-row position roster, a Bill page with both House and Senate vote history, a Senate Member page with live Recent votes and a chamber-labeled Party-unity score.
+
+## Testing strategy
+
+**Unit tests:**
+
+- [tests/test_senate_xml.py](../../tests/test_senate_xml.py) (new) — every parsing function exercised against spike fixtures; every position value across captured fixtures present in `parse_vote_detail` output; date parser handles the double-space format; XML/HTML content-type detection.
+- [tests/test_storage_votes_sqlite.py](../../tests/test_storage_votes_sqlite.py) (extended) — new `chamber` CHECK constraint; PK uniqueness across chambers.
+
+**Integration tests:**
+
+- [tests/test_scraper_votes.py](../../tests/test_scraper_votes.py) (extended) — `scrape_senate(...)` writes exactly two files (roster + votes); `--limit` honored on detail fetches but roster always written; chamber='senate' in keys; HTML-404 trap raises cleanly.
+- [tests/test_pipeline_votes.py](../../tests/test_pipeline_votes.py) (extended) — Senate bill / amendment / nomination / cloture / en-bloc loads; member-bridge resolution (current via roster, historical via members table, unresolved skip-and-warn); idempotency.
+- [tests/test_index_votes.py](../../tests/test_index_votes.py) (extended) — chamber-scoped `member_party_unity`; chamber-switcher case.
+- [tests/test_cli.py](../../tests/test_cli.py) (extended) — both chambers run by default; `--chambers house` / `--chambers senate` work independently.
+- [tests/test_web_votes.py](../../tests/test_web_votes.py) (extended) — Senate Vote profile renders; Senate Member profile renders; methodology page updated.
+
+**Smoke test:** [tests/test_smoke.py](../../tests/test_smoke.py) extended per step 36.
+
+**Manual checks** (per [ADR 0001](../adr/0001-python-end-to-end-for-the-web-layer.md)):
+
+- `/votes/senate/119/1/7` shows full position roster, correct totals (64-35), threshold "simple majority", subject linking to S. 5.
+- `/votes/senate/119/1/3` shows amendment chip "Amendment SAMDT 14" + link to S. 5.
+- `/votes/senate/119/1/1` shows threshold "3/5" (cloture).
+- `/votes/senate/119/1/8` shows nomination — no Bill link.
+- A senator's `/members/{bioguide_id}` profile shows live Recent votes + Party-unity score.
+- A chamber-switcher's profile shows two party-unity rows per Congress they served in both.
+- `/bills/119/s/5` shows Senate votes in the Vote history section alongside any related amendment / motion votes.
+- `/about/methodology` mentions the chamber-scoping.
+
+**Regression risk:**
+
+- Phase 3a tests must all pass. The `member_party_unity` schema rebuild means existing House-only rows are dropped and re-indexed on first 3b load+index — operators run the full re-index once when 3b lands.
+- The `/votes/{chamber}/{congress}/{session}/{roll}` route no longer has a senate-chamber Phase-3b body branch. A test that asserted "GET /votes/senate/... shows the Phase 3b placeholder" must be updated to assert real rendering or be removed.
+- Member-profile templates: tests asserting "(Phase 3b)" markers on Senate-member profiles must be updated.
+
+## Acceptance criteria
+
+- [ ] `concord scrape votes --congresses 119 --sessions 1 --limit 5 --storage-dir /tmp/concord` writes 5 detail envelopes to `data/senate_votes.jsonl`, 1 roster envelope to `data/senate_roster.jsonl`, AND (because the default is now both chambers) 5 detail+positions envelopes for House too.
+- [ ] `concord scrape votes --chambers senate --congresses 119 --sessions 1 --limit 5` writes only the two Senate files; no House files.
+- [ ] `concord scrape votes --chambers house --congresses 119 --sessions 1 --limit 5` writes only House files; no Senate files.
+- [ ] `concord load votes --storage-dir /tmp/concord --db /tmp/test.db` populates `votes` with mixed-chamber rows and `vote_positions` with bioguide_id-keyed rows (verify a sample senator's bioguide_id is correctly resolved via the member bridge).
+- [ ] `concord index votes --db /tmp/test.db` populates `votes.is_party_unity` for both chambers' votes and writes `member_party_unity` rows with the `chamber` column distinguishing senate and house entries for any chamber-switcher in the synthetic data.
+- [ ] `concord run votes --congresses 119 --sessions 1 --limit 5` does scrape + load + index for both chambers in one shot.
+- [ ] `concord scrape bills`, `concord scrape members`, `concord run proceedings` still work (Phase 1, 2a regression).
+- [ ] `pytest` passes (full suite + new tests).
+- [ ] `uv run ruff check` clean. `uv run ruff format --check` clean.
+- [ ] `GET /votes/senate/119/1/7` returns 200 and renders subject (`S. 5`), totals (64-35), threshold (simple majority), full position roster (~100 senators), no "(Phase 3b)" placeholder body.
+- [ ] `GET /votes/senate/119/1/3` returns 200 with amendment subject chip and Bill link.
+- [ ] `GET /votes/senate/119/1/1` returns 200 with threshold "3/5".
+- [ ] `GET /votes/senate/119/1/8` returns 200 for the nomination, with no Bill subject link, `question` carries the nominee.
+- [ ] `GET /members/{senator_bioguide}` shows live Recent votes and a Party-unity score block; no "(Phase 3b)" placeholder.
+- [ ] `GET /bills/119/s/5` Vote history section includes the Senate votes (rolls 1, 2, 3, 7 from the spike fixtures all linking back to S. 5).
+- [ ] `GET /about/methodology` mentions chamber-scoping in the party-unity section.
+- [ ] [CONTEXT.md](../../CONTEXT.md) has new entries for **LIS member ID** and **`member_full`**.
+- [ ] [docs/adr/0011-party-unity-score-methodology.md](../adr/0011-party-unity-score-methodology.md) has a Phase 3b refinement section and an updated Status line.
+- [ ] [docs/plans/.spike-senate-votes.md](./.spike-senate-votes.md) and [docs/plans/.spike-senate-votes-findings.md](./.spike-senate-votes-findings.md) deleted.
+- [ ] `src/concord/senate_xml.py` exists with `SenateClient` + three parsing functions; no Phase 1 / 2a / 3a modules were moved or deleted.
+
+## Open questions
+
+None — all design decisions resolved during grilling.
+
+The party-unity computation for **chamber-switchers within a Congress** (rare case: a House member appointed mid-term to fill a Senate vacancy) is handled by the schema (two `member_party_unity` rows, one per chamber) and the UI (two stat lines). This case is bookkeeping-correct but may need a UX revisit if it produces visually confusing profile pages — track as a UX nice-to-have, not a blocker.
+
+## Out-of-band work
+
+- **Full 117–119 Senate backfill.** `concord run votes --congresses 117,118,119 --chambers senate` (no `--limit`) is a ~30-minute command-line job (3600 detail fetches at ~0.4s). Run on the VPS once 3b's surface review is done.
+- **Combined Senate + House backfill.** `concord run votes --congresses 117,118,119` (default chambers, no `--limit`) is the ~12.5h job (~12h House from 3a + ~0.5h Senate). One operator command.
+- **SQLite re-index on 3b deploy.** Operators must delete `data/proceedings.db` and re-run all `concord load *` + `concord index *` commands once when 3b lands, to pick up the new `member_party_unity` schema. Document in the deploy checklist.
+- **`vote_matters` side table for en-bloc votes.** Deferred to v2; purely additive when it lands.
+- **Phase 4 — Committees + Amendments.** Will turn `votes.amendment_id` into a live link to an `/amendments/{...}` profile page. Senate amendment IDs (`samdt`) and House amendment IDs (`hamdt`) both resolve through that surface.
+- **Daily refresh cadence.** A cron job invoking `concord run votes --congresses 119` daily — out of band, operator-configured on the VPS. Not part of this plan.

--- a/tests/fixtures/api/votes/detail_house_119_1_240.json
+++ b/tests/fixtures/api/votes/detail_house_119_1_240.json
@@ -1,0 +1,58 @@
+{
+    "houseRollCallVote": {
+        "congress": 119,
+        "identifier": 11912025240,
+        "legislationNumber": "3424",
+        "legislationType": "HR",
+        "legislationUrl": "https://www.congress.gov/bill/119/house-bill/3424",
+        "result": "Passed",
+        "rollCallNumber": 240,
+        "sessionNumber": 1,
+        "sourceDataURL": "https://clerk.house.gov/evs/2025/roll240.xml",
+        "startDate": "2025-09-08T18:56:00-04:00",
+        "updateDate": "2025-09-09T18:53:19-04:00",
+        "votePartyTotal": [
+            {
+                "nayTotal": 0,
+                "notVotingTotal": 16,
+                "party": {
+                    "name": "Republican",
+                    "type": "R"
+                },
+                "presentTotal": 0,
+                "voteParty": "R",
+                "yeaTotal": 202
+            },
+            {
+                "nayTotal": 1,
+                "notVotingTotal": 16,
+                "party": {
+                    "name": "Democrat",
+                    "type": "D"
+                },
+                "presentTotal": 0,
+                "voteParty": "D",
+                "yeaTotal": 195
+            },
+            {
+                "nayTotal": 0,
+                "notVotingTotal": 0,
+                "party": {
+                    "name": "Independent",
+                    "type": "I"
+                },
+                "presentTotal": 0,
+                "voteParty": "I",
+                "yeaTotal": 0
+            }
+        ],
+        "voteQuestion": "On Motion to Suspend the Rules and Pass",
+        "voteType": "2/3 Yea-And-Nay"
+    },
+    "request": {
+        "congress": "119",
+        "contentType": "application/json",
+        "format": "json",
+        "session": "1"
+    }
+}

--- a/tests/fixtures/api/votes/detail_house_119_1_subject_amendment.json
+++ b/tests/fixtures/api/votes/detail_house_119_1_subject_amendment.json
@@ -1,0 +1,61 @@
+{
+    "houseRollCallVote": {
+        "amendmentAuthor": "Norman of South Carolina Part A Amendment No. 13",
+        "amendmentNumber": "85",
+        "amendmentType": "HAMDT",
+        "congress": 119,
+        "identifier": 11912025245,
+        "legislationNumber": "3838",
+        "legislationType": "HR",
+        "legislationUrl": "https://www.congress.gov/amendment/119/house-amendment/85",
+        "result": "Agreed to",
+        "rollCallNumber": 245,
+        "sessionNumber": 1,
+        "sourceDataURL": "https://clerk.house.gov/evs/2025/roll245.xml",
+        "startDate": "2025-09-10T16:50:00-04:00",
+        "updateDate": "2025-09-11T16:38:20-04:00",
+        "votePartyTotal": [
+            {
+                "nayTotal": 1,
+                "notVotingTotal": 3,
+                "party": {
+                    "name": "Republican",
+                    "type": "R"
+                },
+                "presentTotal": 0,
+                "voteParty": "R",
+                "yeaTotal": 217
+            },
+            {
+                "nayTotal": 209,
+                "notVotingTotal": 3,
+                "party": {
+                    "name": "Democrat",
+                    "type": "D"
+                },
+                "presentTotal": 0,
+                "voteParty": "D",
+                "yeaTotal": 4
+            },
+            {
+                "nayTotal": 0,
+                "notVotingTotal": 0,
+                "party": {
+                    "name": "Independent",
+                    "type": "I"
+                },
+                "presentTotal": 0,
+                "voteParty": "I",
+                "yeaTotal": 0
+            }
+        ],
+        "voteQuestion": "On Agreeing to the Amendment",
+        "voteType": "Recorded Vote"
+    },
+    "request": {
+        "congress": "119",
+        "contentType": "application/json",
+        "format": "json",
+        "session": "1"
+    }
+}

--- a/tests/fixtures/api/votes/detail_house_119_1_subject_procedural.json
+++ b/tests/fixtures/api/votes/detail_house_119_1_subject_procedural.json
@@ -1,0 +1,34 @@
+{
+    "houseRollCallVote": {
+        "congress": 119,
+        "identifier": 119120252,
+        "result": "Johnson (LA)",
+        "rollCallNumber": 2,
+        "sessionNumber": 1,
+        "sourceDataURL": "https://clerk.house.gov/evs/2025/roll002.xml",
+        "startDate": "2025-01-03T14:33:00-05:00",
+        "updateDate": "2025-06-24T08:44:27-04:00",
+        "votePartyTotal": [
+            {
+                "candidate": "Jeffries",
+                "total": 215
+            },
+            {
+                "candidate": "Emmer",
+                "total": 1
+            },
+            {
+                "candidate": "Johnson (LA)",
+                "total": 218
+            }
+        ],
+        "voteQuestion": "Election of the Speaker",
+        "voteType": "Yea-and-Nay"
+    },
+    "request": {
+        "congress": "119",
+        "contentType": "application/json",
+        "format": "json",
+        "session": "1"
+    }
+}

--- a/tests/fixtures/api/votes/list_house_119_1.json
+++ b/tests/fixtures/api/votes/list_house_119_1.json
@@ -1,0 +1,44 @@
+{
+    "houseRollCallVotes": [
+        {
+            "congress": 119,
+            "identifier": 11912025240,
+            "legislationNumber": "3424",
+            "legislationType": "HR",
+            "legislationUrl": "https://www.congress.gov/bill/119/house-bill/3424",
+            "result": "Passed",
+            "rollCallNumber": 240,
+            "sessionNumber": 1,
+            "sourceDataURL": "https://clerk.house.gov/evs/2025/roll240.xml",
+            "startDate": "2025-09-08T18:56:00-04:00",
+            "updateDate": "2025-09-09T18:53:19-04:00",
+            "url": "https://api.congress.gov/v3/house-vote/119/1/240",
+            "voteType": "2/3 Yea-And-Nay"
+        },
+        {
+            "congress": 119,
+            "identifier": 11912025306,
+            "legislationNumber": "5348",
+            "legislationType": "HR",
+            "legislationUrl": "https://www.congress.gov/bill/119/house-bill/5348",
+            "result": "Passed",
+            "rollCallNumber": 306,
+            "sessionNumber": 1,
+            "sourceDataURL": "https://clerk.house.gov/evs/2025/roll306.xml",
+            "startDate": "2025-12-01T18:57:00-05:00",
+            "updateDate": "2025-12-19T09:53:45-05:00",
+            "url": "https://api.congress.gov/v3/house-vote/119/1/306",
+            "voteType": "2/3 Yea-And-Nay"
+        }
+    ],
+    "pagination": {
+        "count": 362,
+        "next": "https://api.congress.gov/v3/house-vote/119/1?offset=2&limit=2&format=json"
+    },
+    "request": {
+        "congress": "119",
+        "contentType": "application/json",
+        "format": "json",
+        "session": "1"
+    }
+}

--- a/tests/fixtures/api/votes/list_senate_119_1.json
+++ b/tests/fixtures/api/votes/list_senate_119_1.json
@@ -1,0 +1,3 @@
+{
+    "error": "Unknown resource: senate-vote/119/1"
+}

--- a/tests/fixtures/api/votes/members_house_119_1_240.json
+++ b/tests/fixtures/api/votes/members_house_119_1_240.json
@@ -1,0 +1,3465 @@
+{
+    "houseRollCallVoteMemberVotes": {
+        "congress": 119,
+        "identifier": 11912025240,
+        "legislationNumber": "3424",
+        "legislationType": "HR",
+        "legislationUrl": "https://www.congress.gov/bill/119/house-bill/3424",
+        "result": "Passed",
+        "results": [
+            {
+                "bioguideID": "A000055",
+                "firstName": "Robert",
+                "lastName": "Aderholt",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AL"
+            },
+            {
+                "bioguideID": "A000148",
+                "firstName": "Jake",
+                "lastName": "Auchincloss",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MA"
+            },
+            {
+                "bioguideID": "A000369",
+                "firstName": "Mark",
+                "lastName": "Amodei",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NV"
+            },
+            {
+                "bioguideID": "A000370",
+                "firstName": "Alma",
+                "lastName": "Adams",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "A000371",
+                "firstName": "Pete",
+                "lastName": "Aguilar",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "A000372",
+                "firstName": "Rick",
+                "lastName": "Allen",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "A000375",
+                "firstName": "Jodey",
+                "lastName": "Arrington",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "A000379",
+                "firstName": "Mark",
+                "lastName": "Alford",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MO"
+            },
+            {
+                "bioguideID": "A000380",
+                "firstName": "Gabe",
+                "lastName": "Amo",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "RI"
+            },
+            {
+                "bioguideID": "A000381",
+                "firstName": "Yassamin",
+                "lastName": "Ansari",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "AZ"
+            },
+            {
+                "bioguideID": "B000490",
+                "firstName": "Sanford",
+                "lastName": "Bishop",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "B000668",
+                "firstName": "Cliff",
+                "lastName": "Bentz",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OR"
+            },
+            {
+                "bioguideID": "B000740",
+                "firstName": "Stephanie",
+                "lastName": "Bice",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OK"
+            },
+            {
+                "bioguideID": "B000825",
+                "firstName": "Lauren",
+                "lastName": "Boebert",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CO"
+            },
+            {
+                "bioguideID": "B001257",
+                "firstName": "Gus",
+                "lastName": "Bilirakis",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "B001260",
+                "firstName": "Vern",
+                "lastName": "Buchanan",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "B001278",
+                "firstName": "Suzanne",
+                "lastName": "Bonamici",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OR"
+            },
+            {
+                "bioguideID": "B001281",
+                "firstName": "Joyce",
+                "lastName": "Beatty",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "B001282",
+                "firstName": "Andy",
+                "lastName": "Barr",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "KY"
+            },
+            {
+                "bioguideID": "B001285",
+                "firstName": "Julia",
+                "lastName": "Brownley",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "B001287",
+                "firstName": "Ami",
+                "lastName": "Bera",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "B001291",
+                "firstName": "Brian",
+                "lastName": "Babin",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "B001292",
+                "firstName": "Donald",
+                "lastName": "Beyer",
+                "voteCast": "Nay",
+                "voteParty": "D",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "B001295",
+                "firstName": "Mike",
+                "lastName": "Bost",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "B001296",
+                "firstName": "Brendan",
+                "lastName": "Boyle",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "B001298",
+                "firstName": "Don",
+                "lastName": "Bacon",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NE"
+            },
+            {
+                "bioguideID": "B001300",
+                "firstName": "Nanette",
+                "lastName": "Barragán",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "B001301",
+                "firstName": "Jack",
+                "lastName": "Bergman",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "B001302",
+                "firstName": "Andy",
+                "lastName": "Biggs",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AZ"
+            },
+            {
+                "bioguideID": "B001306",
+                "firstName": "Troy",
+                "lastName": "Balderson",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "B001307",
+                "firstName": "James",
+                "lastName": "Baird",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IN"
+            },
+            {
+                "bioguideID": "B001309",
+                "firstName": "Tim",
+                "lastName": "Burchett",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TN"
+            },
+            {
+                "bioguideID": "B001313",
+                "firstName": "Shontel",
+                "lastName": "Brown",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "B001314",
+                "firstName": "Aaron",
+                "lastName": "Bean",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "B001315",
+                "firstName": "Nikki",
+                "lastName": "Budzinski",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "B001316",
+                "firstName": "Eric",
+                "lastName": "Burlison",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MO"
+            },
+            {
+                "bioguideID": "B001317",
+                "firstName": "Josh",
+                "lastName": "Brecheen",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OK"
+            },
+            {
+                "bioguideID": "B001318",
+                "firstName": "Becca",
+                "lastName": "Balint",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "VT"
+            },
+            {
+                "bioguideID": "B001321",
+                "firstName": "Tom",
+                "lastName": "Barrett",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "B001322",
+                "firstName": "Michael",
+                "lastName": "Baumgartner",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "B001323",
+                "firstName": "Nicholas",
+                "lastName": "Begich",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AK"
+            },
+            {
+                "bioguideID": "B001324",
+                "firstName": "Wesley",
+                "lastName": "Bell",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MO"
+            },
+            {
+                "bioguideID": "B001325",
+                "firstName": "Sheri",
+                "lastName": "Biggs",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "SC"
+            },
+            {
+                "bioguideID": "B001326",
+                "firstName": "Janelle",
+                "lastName": "Bynum",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OR"
+            },
+            {
+                "bioguideID": "B001327",
+                "firstName": "Robert",
+                "lastName": "Bresnahan",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "C000059",
+                "firstName": "Ken",
+                "lastName": "Calvert",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "C000537",
+                "firstName": "James",
+                "lastName": "Clyburn",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "SC"
+            },
+            {
+                "bioguideID": "C001039",
+                "firstName": "Kat",
+                "lastName": "Cammack",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "C001051",
+                "firstName": "John",
+                "lastName": "Carter",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "C001053",
+                "firstName": "Tom",
+                "lastName": "Cole",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OK"
+            },
+            {
+                "bioguideID": "C001055",
+                "firstName": "Ed",
+                "lastName": "Case",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "HI"
+            },
+            {
+                "bioguideID": "C001059",
+                "firstName": "Jim",
+                "lastName": "Costa",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "C001061",
+                "firstName": "Emanuel",
+                "lastName": "Cleaver",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MO"
+            },
+            {
+                "bioguideID": "C001063",
+                "firstName": "Henry",
+                "lastName": "Cuellar",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "C001066",
+                "firstName": "Kathy",
+                "lastName": "Castor",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "C001067",
+                "firstName": "Yvette",
+                "lastName": "Clarke",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "C001068",
+                "firstName": "Steve",
+                "lastName": "Cohen",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TN"
+            },
+            {
+                "bioguideID": "C001069",
+                "firstName": "Joe",
+                "lastName": "Courtney",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CT"
+            },
+            {
+                "bioguideID": "C001072",
+                "firstName": "André",
+                "lastName": "Carson",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IN"
+            },
+            {
+                "bioguideID": "C001080",
+                "firstName": "Judy",
+                "lastName": "Chu",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "C001087",
+                "firstName": "Eric",
+                "lastName": "Crawford",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "AR"
+            },
+            {
+                "bioguideID": "C001091",
+                "firstName": "Joaquin",
+                "lastName": "Castro",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "C001101",
+                "firstName": "Katherine",
+                "lastName": "Clark",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MA"
+            },
+            {
+                "bioguideID": "C001103",
+                "firstName": "Earl",
+                "lastName": "Carter",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "C001108",
+                "firstName": "James",
+                "lastName": "Comer",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "KY"
+            },
+            {
+                "bioguideID": "C001110",
+                "firstName": "J.",
+                "lastName": "Correa",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "C001112",
+                "firstName": "Salud",
+                "lastName": "Carbajal",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "C001115",
+                "firstName": "Michael",
+                "lastName": "Cloud",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "C001116",
+                "firstName": "Andrew",
+                "lastName": "Clyde",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "C001117",
+                "firstName": "Sean",
+                "lastName": "Casten",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "C001118",
+                "firstName": "Ben",
+                "lastName": "Cline",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "C001119",
+                "firstName": "Angie",
+                "lastName": "Craig",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MN"
+            },
+            {
+                "bioguideID": "C001120",
+                "firstName": "Dan",
+                "lastName": "Crenshaw",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "C001121",
+                "firstName": "Jason",
+                "lastName": "Crow",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CO"
+            },
+            {
+                "bioguideID": "C001123",
+                "firstName": "Gilbert",
+                "lastName": "Cisneros",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "C001125",
+                "firstName": "Troy",
+                "lastName": "Carter",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "LA"
+            },
+            {
+                "bioguideID": "C001126",
+                "firstName": "Mike",
+                "lastName": "Carey",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "C001127",
+                "firstName": "Sheila",
+                "lastName": "Cherfilus-McCormick",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "C001129",
+                "firstName": "Mike",
+                "lastName": "Collins",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "C001130",
+                "firstName": "Jasmine",
+                "lastName": "Crockett",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "C001131",
+                "firstName": "Greg",
+                "lastName": "Casar",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "C001132",
+                "firstName": "Elijah",
+                "lastName": "Crane",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AZ"
+            },
+            {
+                "bioguideID": "C001133",
+                "firstName": "Juan",
+                "lastName": "Ciscomani",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AZ"
+            },
+            {
+                "bioguideID": "C001136",
+                "firstName": "Herbert",
+                "lastName": "Conaway",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "C001137",
+                "firstName": "Jeff",
+                "lastName": "Crank",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CO"
+            },
+            {
+                "bioguideID": "D000032",
+                "firstName": "Byron",
+                "lastName": "Donalds",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "D000096",
+                "firstName": "Danny",
+                "lastName": "Davis",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "D000197",
+                "firstName": "Diana",
+                "lastName": "DeGette",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CO"
+            },
+            {
+                "bioguideID": "D000216",
+                "firstName": "Rosa",
+                "lastName": "DeLauro",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CT"
+            },
+            {
+                "bioguideID": "D000230",
+                "firstName": "Donald",
+                "lastName": "Davis",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "D000399",
+                "firstName": "Lloyd",
+                "lastName": "Doggett",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "D000530",
+                "firstName": "Christopher",
+                "lastName": "Deluzio",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "D000594",
+                "firstName": "Monica",
+                "lastName": "De La Cruz",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "D000600",
+                "firstName": "Mario",
+                "lastName": "Diaz-Balart",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "D000616",
+                "firstName": "Scott",
+                "lastName": "DesJarlais",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TN"
+            },
+            {
+                "bioguideID": "D000617",
+                "firstName": "Suzan",
+                "lastName": "DelBene",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "D000623",
+                "firstName": "Mark",
+                "lastName": "DeSaulnier",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "D000624",
+                "firstName": "Debbie",
+                "lastName": "Dingell",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "D000626",
+                "firstName": "Warren",
+                "lastName": "Davidson",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "D000628",
+                "firstName": "Neal",
+                "lastName": "Dunn",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "D000629",
+                "firstName": "Sharice",
+                "lastName": "Davids",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "KS"
+            },
+            {
+                "bioguideID": "D000631",
+                "firstName": "Madeleine",
+                "lastName": "Dean",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "D000634",
+                "firstName": "Troy",
+                "lastName": "Downing",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MT"
+            },
+            {
+                "bioguideID": "D000635",
+                "firstName": "Maxine",
+                "lastName": "Dexter",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OR"
+            },
+            {
+                "bioguideID": "E000071",
+                "firstName": "Jake",
+                "lastName": "Ellzey",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "E000235",
+                "firstName": "Mike",
+                "lastName": "Ezell",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MS"
+            },
+            {
+                "bioguideID": "E000246",
+                "firstName": "Chuck",
+                "lastName": "Edwards",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "E000294",
+                "firstName": "Tom",
+                "lastName": "Emmer",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MN"
+            },
+            {
+                "bioguideID": "E000296",
+                "firstName": "Dwight",
+                "lastName": "Evans",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "E000297",
+                "firstName": "Adriano",
+                "lastName": "Espaillat",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "E000298",
+                "firstName": "Ron",
+                "lastName": "Estes",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "KS"
+            },
+            {
+                "bioguideID": "E000299",
+                "firstName": "Veronica",
+                "lastName": "Escobar",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "E000300",
+                "firstName": "Gabe",
+                "lastName": "Evans",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CO"
+            },
+            {
+                "bioguideID": "E000301",
+                "firstName": "Sarah",
+                "lastName": "Elfreth",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MD"
+            },
+            {
+                "bioguideID": "F000110",
+                "firstName": "Cleo",
+                "lastName": "Fields",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "LA"
+            },
+            {
+                "bioguideID": "F000246",
+                "firstName": "Pat",
+                "lastName": "Fallon",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "F000446",
+                "firstName": "Randy",
+                "lastName": "Feenstra",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IA"
+            },
+            {
+                "bioguideID": "F000450",
+                "firstName": "Virginia",
+                "lastName": "Foxx",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "F000454",
+                "firstName": "Bill",
+                "lastName": "Foster",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "F000459",
+                "firstName": "Charles",
+                "lastName": "Fleischmann",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TN"
+            },
+            {
+                "bioguideID": "F000462",
+                "firstName": "Lois",
+                "lastName": "Frankel",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "F000466",
+                "firstName": "Brian",
+                "lastName": "Fitzpatrick",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "F000468",
+                "firstName": "Lizzie",
+                "lastName": "Fletcher",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "F000469",
+                "firstName": "Russ",
+                "lastName": "Fulcher",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "ID"
+            },
+            {
+                "bioguideID": "F000470",
+                "firstName": "Michelle",
+                "lastName": "Fischbach",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MN"
+            },
+            {
+                "bioguideID": "F000471",
+                "firstName": "Scott",
+                "lastName": "Fitzgerald",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "WI"
+            },
+            {
+                "bioguideID": "F000472",
+                "firstName": "Scott",
+                "lastName": "Franklin",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "F000474",
+                "firstName": "Mike",
+                "lastName": "Flood",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NE"
+            },
+            {
+                "bioguideID": "F000475",
+                "firstName": "Brad",
+                "lastName": "Finstad",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MN"
+            },
+            {
+                "bioguideID": "F000476",
+                "firstName": "Maxwell",
+                "lastName": "Frost",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "F000477",
+                "firstName": "Valerie",
+                "lastName": "Foushee",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "F000478",
+                "firstName": "Russell",
+                "lastName": "Fry",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "SC"
+            },
+            {
+                "bioguideID": "F000480",
+                "firstName": "Vince",
+                "lastName": "Fong",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "F000481",
+                "firstName": "Shomari",
+                "lastName": "Figures",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "AL"
+            },
+            {
+                "bioguideID": "F000482",
+                "firstName": "Julie",
+                "lastName": "Fedorchak",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "ND"
+            },
+            {
+                "bioguideID": "F000483",
+                "firstName": "Laura",
+                "lastName": "Friedman",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "F000484",
+                "firstName": "Randy",
+                "lastName": "Fine",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "G000546",
+                "firstName": "Sam",
+                "lastName": "Graves",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MO"
+            },
+            {
+                "bioguideID": "G000553",
+                "firstName": "Al",
+                "lastName": "Green",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "G000558",
+                "firstName": "Brett",
+                "lastName": "Guthrie",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "KY"
+            },
+            {
+                "bioguideID": "G000559",
+                "firstName": "John",
+                "lastName": "Garamendi",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "G000565",
+                "firstName": "Paul",
+                "lastName": "Gosar",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AZ"
+            },
+            {
+                "bioguideID": "G000568",
+                "firstName": "H.",
+                "lastName": "Griffith",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "G000576",
+                "firstName": "Glenn",
+                "lastName": "Grothman",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "WI"
+            },
+            {
+                "bioguideID": "G000581",
+                "firstName": "Vicente",
+                "lastName": "Gonzalez",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "G000583",
+                "firstName": "Josh",
+                "lastName": "Gottheimer",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "G000585",
+                "firstName": "Jimmy",
+                "lastName": "Gomez",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "G000586",
+                "firstName": "Jesús",
+                "lastName": "García",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "G000587",
+                "firstName": "Sylvia",
+                "lastName": "Garcia",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "G000589",
+                "firstName": "Lance",
+                "lastName": "Gooden",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "G000591",
+                "firstName": "Michael",
+                "lastName": "Guest",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MS"
+            },
+            {
+                "bioguideID": "G000592",
+                "firstName": "Jared",
+                "lastName": "Golden",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "ME"
+            },
+            {
+                "bioguideID": "G000593",
+                "firstName": "Carlos",
+                "lastName": "Gimenez",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "G000594",
+                "firstName": "Tony",
+                "lastName": "Gonzales",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "G000596",
+                "firstName": "Marjorie",
+                "lastName": "Greene",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "G000597",
+                "firstName": "Andrew",
+                "lastName": "Garbarino",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "G000598",
+                "firstName": "Robert",
+                "lastName": "Garcia",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "G000599",
+                "firstName": "Daniel",
+                "lastName": "Goldman",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "G000600",
+                "firstName": "Marie",
+                "lastName": "Perez",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "G000601",
+                "firstName": "Craig",
+                "lastName": "Goldman",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "G000602",
+                "firstName": "Laura",
+                "lastName": "Gillen",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "G000603",
+                "firstName": "Brandon",
+                "lastName": "Gill",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "G000604",
+                "firstName": "Maggie",
+                "lastName": "Goodlander",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NH"
+            },
+            {
+                "bioguideID": "G000605",
+                "firstName": "Adam",
+                "lastName": "Gray",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "H000874",
+                "firstName": "Steny",
+                "lastName": "Hoyer",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MD"
+            },
+            {
+                "bioguideID": "H001047",
+                "firstName": "James",
+                "lastName": "Himes",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CT"
+            },
+            {
+                "bioguideID": "H001052",
+                "firstName": "Andy",
+                "lastName": "Harris",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MD"
+            },
+            {
+                "bioguideID": "H001058",
+                "firstName": "Bill",
+                "lastName": "Huizenga",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "H001066",
+                "firstName": "Steven",
+                "lastName": "Horsford",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NV"
+            },
+            {
+                "bioguideID": "H001067",
+                "firstName": "Richard",
+                "lastName": "Hudson",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "H001068",
+                "firstName": "Jared",
+                "lastName": "Huffman",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "H001072",
+                "firstName": "J.",
+                "lastName": "Hill",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AR"
+            },
+            {
+                "bioguideID": "H001077",
+                "firstName": "Clay",
+                "lastName": "Higgins",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "LA"
+            },
+            {
+                "bioguideID": "H001081",
+                "firstName": "Jahana",
+                "lastName": "Hayes",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CT"
+            },
+            {
+                "bioguideID": "H001082",
+                "firstName": "Kevin",
+                "lastName": "Hern",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OK"
+            },
+            {
+                "bioguideID": "H001085",
+                "firstName": "Chrissy",
+                "lastName": "Houlahan",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "H001086",
+                "firstName": "Diana",
+                "lastName": "Harshbarger",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TN"
+            },
+            {
+                "bioguideID": "H001090",
+                "firstName": "Josh",
+                "lastName": "Harder",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "H001091",
+                "firstName": "Ashley",
+                "lastName": "Hinson",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IA"
+            },
+            {
+                "bioguideID": "H001093",
+                "firstName": "Erin",
+                "lastName": "Houchin",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IN"
+            },
+            {
+                "bioguideID": "H001094",
+                "firstName": "Val",
+                "lastName": "Hoyle",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OR"
+            },
+            {
+                "bioguideID": "H001095",
+                "firstName": "Wesley",
+                "lastName": "Hunt",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "H001096",
+                "firstName": "Harriet",
+                "lastName": "Hageman",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "WY"
+            },
+            {
+                "bioguideID": "H001098",
+                "firstName": "Abraham",
+                "lastName": "Hamadeh",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AZ"
+            },
+            {
+                "bioguideID": "H001099",
+                "firstName": "Mike",
+                "lastName": "Haridopolos",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "H001100",
+                "firstName": "Jeff",
+                "lastName": "Hurd",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CO"
+            },
+            {
+                "bioguideID": "H001101",
+                "firstName": "Pat",
+                "lastName": "Harrigan",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "H001102",
+                "firstName": "Mark",
+                "lastName": "Harris",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "I000056",
+                "firstName": "Darrell",
+                "lastName": "Issa",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "I000058",
+                "firstName": "Glenn",
+                "lastName": "Ivey",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MD"
+            },
+            {
+                "bioguideID": "J000288",
+                "firstName": "Henry",
+                "lastName": "Johnson",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "J000289",
+                "firstName": "Jim",
+                "lastName": "Jordan",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "J000294",
+                "firstName": "Hakeem",
+                "lastName": "Jeffries",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "J000295",
+                "firstName": "David",
+                "lastName": "Joyce",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "J000298",
+                "firstName": "Pramila",
+                "lastName": "Jayapal",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "J000301",
+                "firstName": "Dusty",
+                "lastName": "Johnson",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "SD"
+            },
+            {
+                "bioguideID": "J000302",
+                "firstName": "John",
+                "lastName": "Joyce",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "J000304",
+                "firstName": "Ronny",
+                "lastName": "Jackson",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "J000305",
+                "firstName": "Sara",
+                "lastName": "Jacobs",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "J000307",
+                "firstName": "John",
+                "lastName": "James",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "J000309",
+                "firstName": "Jonathan",
+                "lastName": "Jackson",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "J000310",
+                "firstName": "Julie",
+                "lastName": "Johnson",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "J000311",
+                "firstName": "Brian",
+                "lastName": "Jack",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "K000009",
+                "firstName": "Marcy",
+                "lastName": "Kaptur",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "K000375",
+                "firstName": "William",
+                "lastName": "Keating",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MA"
+            },
+            {
+                "bioguideID": "K000376",
+                "firstName": "Mike",
+                "lastName": "Kelly",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "K000385",
+                "firstName": "Robin",
+                "lastName": "Kelly",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "K000388",
+                "firstName": "Trent",
+                "lastName": "Kelly",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MS"
+            },
+            {
+                "bioguideID": "K000389",
+                "firstName": "Ro",
+                "lastName": "Khanna",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "K000391",
+                "firstName": "Raja",
+                "lastName": "Krishnamoorthi",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "K000392",
+                "firstName": "David",
+                "lastName": "Kustoff",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TN"
+            },
+            {
+                "bioguideID": "K000397",
+                "firstName": "Young",
+                "lastName": "Kim",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "K000398",
+                "firstName": "Thomas",
+                "lastName": "Kean",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "K000399",
+                "firstName": "Jennifer",
+                "lastName": "Kiggans",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "K000400",
+                "firstName": "Sydney",
+                "lastName": "Kamlager-Dove",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "K000401",
+                "firstName": "Kevin",
+                "lastName": "Kiley",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "K000402",
+                "firstName": "Timothy",
+                "lastName": "Kennedy",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "K000403",
+                "firstName": "Mike",
+                "lastName": "Kennedy",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "UT"
+            },
+            {
+                "bioguideID": "K000405",
+                "firstName": "Brad",
+                "lastName": "Knott",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "L000273",
+                "firstName": "Teresa",
+                "lastName": "Leger Fernandez",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NM"
+            },
+            {
+                "bioguideID": "L000397",
+                "firstName": "Zoe",
+                "lastName": "Lofgren",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "L000491",
+                "firstName": "Frank",
+                "lastName": "Lucas",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OK"
+            },
+            {
+                "bioguideID": "L000557",
+                "firstName": "John",
+                "lastName": "Larson",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CT"
+            },
+            {
+                "bioguideID": "L000560",
+                "firstName": "Rick",
+                "lastName": "Larsen",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "L000562",
+                "firstName": "Stephen",
+                "lastName": "Lynch",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MA"
+            },
+            {
+                "bioguideID": "L000566",
+                "firstName": "Robert",
+                "lastName": "Latta",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "L000578",
+                "firstName": "Doug",
+                "lastName": "LaMalfa",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "L000582",
+                "firstName": "Ted",
+                "lastName": "Lieu",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "L000583",
+                "firstName": "Barry",
+                "lastName": "Loudermilk",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "L000585",
+                "firstName": "Darin",
+                "lastName": "LaHood",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "L000590",
+                "firstName": "Susie",
+                "lastName": "Lee",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NV"
+            },
+            {
+                "bioguideID": "L000593",
+                "firstName": "Mike",
+                "lastName": "Levin",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "L000595",
+                "firstName": "Julia",
+                "lastName": "Letlow",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "LA"
+            },
+            {
+                "bioguideID": "L000596",
+                "firstName": "Anna Paulina",
+                "lastName": "Luna",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "L000597",
+                "firstName": "Laurel",
+                "lastName": "Lee",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "L000598",
+                "firstName": "Nick",
+                "lastName": "LaLota",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "L000599",
+                "firstName": "Michael",
+                "lastName": "Lawler",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "L000600",
+                "firstName": "Nicholas",
+                "lastName": "Langworthy",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "L000601",
+                "firstName": "Greg",
+                "lastName": "Landsman",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "L000602",
+                "firstName": "Summer",
+                "lastName": "Lee",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "L000603",
+                "firstName": "Morgan",
+                "lastName": "Luttrell",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "L000606",
+                "firstName": "George",
+                "lastName": "Latimer",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "L000607",
+                "firstName": "Sam",
+                "lastName": "Liccardo",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "M000194",
+                "firstName": "Nancy",
+                "lastName": "Mace",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "SC"
+            },
+            {
+                "bioguideID": "M000312",
+                "firstName": "James",
+                "lastName": "McGovern",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MA"
+            },
+            {
+                "bioguideID": "M000317",
+                "firstName": "Nicole",
+                "lastName": "Malliotakis",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "M000687",
+                "firstName": "Kweisi",
+                "lastName": "Mfume",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MD"
+            },
+            {
+                "bioguideID": "M000871",
+                "firstName": "Tracey",
+                "lastName": "Mann",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "KS"
+            },
+            {
+                "bioguideID": "M001136",
+                "firstName": "Lisa",
+                "lastName": "McClain",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "M001137",
+                "firstName": "Gregory",
+                "lastName": "Meeks",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "M001143",
+                "firstName": "Betty",
+                "lastName": "McCollum",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MN"
+            },
+            {
+                "bioguideID": "M001157",
+                "firstName": "Michael",
+                "lastName": "McCaul",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "M001160",
+                "firstName": "Gwen",
+                "lastName": "Moore",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "WI"
+            },
+            {
+                "bioguideID": "M001163",
+                "firstName": "Doris",
+                "lastName": "Matsui",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "M001177",
+                "firstName": "Tom",
+                "lastName": "McClintock",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "M001184",
+                "firstName": "Thomas",
+                "lastName": "Massie",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "KY"
+            },
+            {
+                "bioguideID": "M001188",
+                "firstName": "Grace",
+                "lastName": "Meng",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "M001194",
+                "firstName": "John",
+                "lastName": "Moolenaar",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "M001196",
+                "firstName": "Seth",
+                "lastName": "Moulton",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MA"
+            },
+            {
+                "bioguideID": "M001199",
+                "firstName": "Brian",
+                "lastName": "Mast",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "M001204",
+                "firstName": "Daniel",
+                "lastName": "Meuser",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "M001205",
+                "firstName": "Carol",
+                "lastName": "Miller",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "WV"
+            },
+            {
+                "bioguideID": "M001206",
+                "firstName": "Joseph",
+                "lastName": "Morelle",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "M001208",
+                "firstName": "Lucy",
+                "lastName": "McBath",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "M001210",
+                "firstName": "Gregory",
+                "lastName": "Murphy",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "M001211",
+                "firstName": "Mary",
+                "lastName": "Miller",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "M001212",
+                "firstName": "Barry",
+                "lastName": "Moore",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AL"
+            },
+            {
+                "bioguideID": "M001213",
+                "firstName": "Blake",
+                "lastName": "Moore",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "UT"
+            },
+            {
+                "bioguideID": "M001214",
+                "firstName": "Frank",
+                "lastName": "Mrvan",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IN"
+            },
+            {
+                "bioguideID": "M001215",
+                "firstName": "Mariannette",
+                "lastName": "Miller-Meeks",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IA"
+            },
+            {
+                "bioguideID": "M001216",
+                "firstName": "Cory",
+                "lastName": "Mills",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "M001217",
+                "firstName": "Jared",
+                "lastName": "Moskowitz",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "M001218",
+                "firstName": "Richard",
+                "lastName": "McCormick",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "M001220",
+                "firstName": "Morgan",
+                "lastName": "McGarvey",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "KY"
+            },
+            {
+                "bioguideID": "M001222",
+                "firstName": "Max",
+                "lastName": "Miller",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "M001223",
+                "firstName": "Seth",
+                "lastName": "Magaziner",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "RI"
+            },
+            {
+                "bioguideID": "M001224",
+                "firstName": "Nathaniel",
+                "lastName": "Moran",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "M001225",
+                "firstName": "Kevin",
+                "lastName": "Mullin",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "M001226",
+                "firstName": "Robert",
+                "lastName": "Menendez",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "M001227",
+                "firstName": "Jennifer",
+                "lastName": "McClellan",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "M001228",
+                "firstName": "Celeste",
+                "lastName": "Maloy",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "UT"
+            },
+            {
+                "bioguideID": "M001229",
+                "firstName": "LaMonica",
+                "lastName": "McIver",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "M001230",
+                "firstName": "Ryan",
+                "lastName": "Mackenzie",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "M001231",
+                "firstName": "John",
+                "lastName": "Mannion",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "M001232",
+                "firstName": "April",
+                "lastName": "McClain Delaney",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MD"
+            },
+            {
+                "bioguideID": "M001233",
+                "firstName": "Mark",
+                "lastName": "Messmer",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IN"
+            },
+            {
+                "bioguideID": "M001234",
+                "firstName": "Kelly",
+                "lastName": "Morrison",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MN"
+            },
+            {
+                "bioguideID": "M001235",
+                "firstName": "Riley",
+                "lastName": "Moore",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "WV"
+            },
+            {
+                "bioguideID": "M001236",
+                "firstName": "Tim",
+                "lastName": "Moore",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "M001237",
+                "firstName": "Kristen",
+                "lastName": "McDonald Rivet",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "M001238",
+                "firstName": "Sarah",
+                "lastName": "McBride",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "DE"
+            },
+            {
+                "bioguideID": "M001239",
+                "firstName": "John",
+                "lastName": "McGuire",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "M001240",
+                "firstName": "Addison",
+                "lastName": "McDowell",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "M001241",
+                "firstName": "Dave",
+                "lastName": "Min",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "N000002",
+                "firstName": "Jerrold",
+                "lastName": "Nadler",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "N000015",
+                "firstName": "Richard",
+                "lastName": "Neal",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MA"
+            },
+            {
+                "bioguideID": "N000026",
+                "firstName": "Troy",
+                "lastName": "Nehls",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "N000188",
+                "firstName": "Donald",
+                "lastName": "Norcross",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "N000189",
+                "firstName": "Dan",
+                "lastName": "Newhouse",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "N000190",
+                "firstName": "Ralph",
+                "lastName": "Norman",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "SC"
+            },
+            {
+                "bioguideID": "N000191",
+                "firstName": "Joe",
+                "lastName": "Neguse",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CO"
+            },
+            {
+                "bioguideID": "N000193",
+                "firstName": "Zachary",
+                "lastName": "Nunn",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IA"
+            },
+            {
+                "bioguideID": "O000019",
+                "firstName": "Jay",
+                "lastName": "Obernolte",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "O000086",
+                "firstName": "Burgess",
+                "lastName": "Owens",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "UT"
+            },
+            {
+                "bioguideID": "O000172",
+                "firstName": "Alexandria",
+                "lastName": "Ocasio-Cortez",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "O000173",
+                "firstName": "Ilhan",
+                "lastName": "Omar",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MN"
+            },
+            {
+                "bioguideID": "O000175",
+                "firstName": "Andrew",
+                "lastName": "Ogles",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "TN"
+            },
+            {
+                "bioguideID": "O000176",
+                "firstName": "Johnny",
+                "lastName": "Olszewski",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MD"
+            },
+            {
+                "bioguideID": "O000177",
+                "firstName": "Robert",
+                "lastName": "Onder",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MO"
+            },
+            {
+                "bioguideID": "P000034",
+                "firstName": "Frank",
+                "lastName": "Pallone",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "P000048",
+                "firstName": "August",
+                "lastName": "Pfluger",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "P000197",
+                "firstName": "Nancy",
+                "lastName": "Pelosi",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "P000597",
+                "firstName": "Chellie",
+                "lastName": "Pingree",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "ME"
+            },
+            {
+                "bioguideID": "P000605",
+                "firstName": "Scott",
+                "lastName": "Perry",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "P000607",
+                "firstName": "Mark",
+                "lastName": "Pocan",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "WI"
+            },
+            {
+                "bioguideID": "P000608",
+                "firstName": "Scott",
+                "lastName": "Peters",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "P000609",
+                "firstName": "Gary",
+                "lastName": "Palmer",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AL"
+            },
+            {
+                "bioguideID": "P000613",
+                "firstName": "Jimmy",
+                "lastName": "Panetta",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "P000614",
+                "firstName": "Chris",
+                "lastName": "Pappas",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NH"
+            },
+            {
+                "bioguideID": "P000617",
+                "firstName": "Ayanna",
+                "lastName": "Pressley",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MA"
+            },
+            {
+                "bioguideID": "P000620",
+                "firstName": "Brittany",
+                "lastName": "Pettersen",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "CO"
+            },
+            {
+                "bioguideID": "P000621",
+                "firstName": "Nellie",
+                "lastName": "Pou",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "P000622",
+                "firstName": "Jimmy",
+                "lastName": "Patronis",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "Q000023",
+                "firstName": "Mike",
+                "lastName": "Quigley",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "R000305",
+                "firstName": "Deborah",
+                "lastName": "Ross",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "R000395",
+                "firstName": "Harold",
+                "lastName": "Rogers",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "KY"
+            },
+            {
+                "bioguideID": "R000575",
+                "firstName": "Mike",
+                "lastName": "Rogers",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AL"
+            },
+            {
+                "bioguideID": "R000579",
+                "firstName": "Patrick",
+                "lastName": "Ryan",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "R000599",
+                "firstName": "Raul",
+                "lastName": "Ruiz",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "R000603",
+                "firstName": "David",
+                "lastName": "Rouzer",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NC"
+            },
+            {
+                "bioguideID": "R000606",
+                "firstName": "Jamie",
+                "lastName": "Raskin",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MD"
+            },
+            {
+                "bioguideID": "R000609",
+                "firstName": "John",
+                "lastName": "Rutherford",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "R000610",
+                "firstName": "Guy",
+                "lastName": "Reschenthaler",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "R000612",
+                "firstName": "John",
+                "lastName": "Rose",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TN"
+            },
+            {
+                "bioguideID": "R000614",
+                "firstName": "Chip",
+                "lastName": "Roy",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "R000617",
+                "firstName": "Delia",
+                "lastName": "Ramirez",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "R000619",
+                "firstName": "Michael",
+                "lastName": "Rulli",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "R000620",
+                "firstName": "Luz",
+                "lastName": "Rivas",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "R000621",
+                "firstName": "Emily",
+                "lastName": "Randall",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "R000622",
+                "firstName": "Josh",
+                "lastName": "Riley",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "S000168",
+                "firstName": "Maria",
+                "lastName": "Salazar",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "S000185",
+                "firstName": "Robert",
+                "lastName": "Scott",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "S000250",
+                "firstName": "Pete",
+                "lastName": "Sessions",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "S000344",
+                "firstName": "Brad",
+                "lastName": "Sherman",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "S000510",
+                "firstName": "Adam",
+                "lastName": "Smith",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "S000522",
+                "firstName": "Christopher",
+                "lastName": "Smith",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "S000929",
+                "firstName": "Victoria",
+                "lastName": "Spartz",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IN"
+            },
+            {
+                "bioguideID": "S001145",
+                "firstName": "Janice",
+                "lastName": "Schakowsky",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "S001148",
+                "firstName": "Michael",
+                "lastName": "Simpson",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "ID"
+            },
+            {
+                "bioguideID": "S001156",
+                "firstName": "Linda",
+                "lastName": "Sánchez",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "S001157",
+                "firstName": "David",
+                "lastName": "Scott",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "S001159",
+                "firstName": "Marilyn",
+                "lastName": "Strickland",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "S001172",
+                "firstName": "Adrian",
+                "lastName": "Smith",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NE"
+            },
+            {
+                "bioguideID": "S001176",
+                "firstName": "Steve",
+                "lastName": "Scalise",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "LA"
+            },
+            {
+                "bioguideID": "S001183",
+                "firstName": "David",
+                "lastName": "Schweikert",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AZ"
+            },
+            {
+                "bioguideID": "S001185",
+                "firstName": "Terri",
+                "lastName": "Sewell",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "AL"
+            },
+            {
+                "bioguideID": "S001188",
+                "firstName": "Marlin",
+                "lastName": "Stutzman",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IN"
+            },
+            {
+                "bioguideID": "S001189",
+                "firstName": "Austin",
+                "lastName": "Scott",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "S001190",
+                "firstName": "Bradley",
+                "lastName": "Schneider",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "S001193",
+                "firstName": "Eric",
+                "lastName": "Swalwell",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "S001195",
+                "firstName": "Jason",
+                "lastName": "Smith",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MO"
+            },
+            {
+                "bioguideID": "S001196",
+                "firstName": "Elise",
+                "lastName": "Stefanik",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "S001199",
+                "firstName": "Lloyd",
+                "lastName": "Smucker",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "S001200",
+                "firstName": "Darren",
+                "lastName": "Soto",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "S001201",
+                "firstName": "Thomas",
+                "lastName": "Suozzi",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "S001205",
+                "firstName": "Mary Gay",
+                "lastName": "Scanlon",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "S001207",
+                "firstName": "Mikie",
+                "lastName": "Sherrill",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "S001211",
+                "firstName": "Greg",
+                "lastName": "Stanton",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "AZ"
+            },
+            {
+                "bioguideID": "S001212",
+                "firstName": "Pete",
+                "lastName": "Stauber",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MN"
+            },
+            {
+                "bioguideID": "S001213",
+                "firstName": "Bryan",
+                "lastName": "Steil",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "WI"
+            },
+            {
+                "bioguideID": "S001214",
+                "firstName": "W.",
+                "lastName": "Steube",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "S001215",
+                "firstName": "Haley",
+                "lastName": "Stevens",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "S001216",
+                "firstName": "Kim",
+                "lastName": "Schrier",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "WA"
+            },
+            {
+                "bioguideID": "S001218",
+                "firstName": "Melanie",
+                "lastName": "Stansbury",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NM"
+            },
+            {
+                "bioguideID": "S001220",
+                "firstName": "Dale",
+                "lastName": "Strong",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AL"
+            },
+            {
+                "bioguideID": "S001221",
+                "firstName": "Hillary",
+                "lastName": "Scholten",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "S001223",
+                "firstName": "Emilia",
+                "lastName": "Sykes",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "S001224",
+                "firstName": "Keith",
+                "lastName": "Self",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "S001225",
+                "firstName": "Eric",
+                "lastName": "Sorensen",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "S001226",
+                "firstName": "Andrea",
+                "lastName": "Salinas",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "OR"
+            },
+            {
+                "bioguideID": "S001228",
+                "firstName": "Derek",
+                "lastName": "Schmidt",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "KS"
+            },
+            {
+                "bioguideID": "S001229",
+                "firstName": "Jefferson",
+                "lastName": "Shreve",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IN"
+            },
+            {
+                "bioguideID": "S001230",
+                "firstName": "Suhas",
+                "lastName": "Subramanyam",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "S001231",
+                "firstName": "Lateefah",
+                "lastName": "Simon",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "T000165",
+                "firstName": "Thomas",
+                "lastName": "Tiffany",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "WI"
+            },
+            {
+                "bioguideID": "T000193",
+                "firstName": "Bennie",
+                "lastName": "Thompson",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MS"
+            },
+            {
+                "bioguideID": "T000460",
+                "firstName": "Mike",
+                "lastName": "Thompson",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "T000463",
+                "firstName": "Michael",
+                "lastName": "Turner",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "T000467",
+                "firstName": "Glenn",
+                "lastName": "Thompson",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "PA"
+            },
+            {
+                "bioguideID": "T000468",
+                "firstName": "Dina",
+                "lastName": "Titus",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "NV"
+            },
+            {
+                "bioguideID": "T000469",
+                "firstName": "Paul",
+                "lastName": "Tonko",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "T000472",
+                "firstName": "Mark",
+                "lastName": "Takano",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "T000474",
+                "firstName": "Norma",
+                "lastName": "Torres",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "T000478",
+                "firstName": "Claudia",
+                "lastName": "Tenney",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "T000480",
+                "firstName": "William",
+                "lastName": "Timmons",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "SC"
+            },
+            {
+                "bioguideID": "T000481",
+                "firstName": "Rashida",
+                "lastName": "Tlaib",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "T000482",
+                "firstName": "Lori",
+                "lastName": "Trahan",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MA"
+            },
+            {
+                "bioguideID": "T000486",
+                "firstName": "Ritchie",
+                "lastName": "Torres",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "T000487",
+                "firstName": "Jill",
+                "lastName": "Tokuda",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "HI"
+            },
+            {
+                "bioguideID": "T000488",
+                "firstName": "Shri",
+                "lastName": "Thanedar",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "T000490",
+                "firstName": "David",
+                "lastName": "Taylor",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "OH"
+            },
+            {
+                "bioguideID": "T000491",
+                "firstName": "Derek",
+                "lastName": "Tran",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "U000040",
+                "firstName": "Lauren",
+                "lastName": "Underwood",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "IL"
+            },
+            {
+                "bioguideID": "V000081",
+                "firstName": "Nydia",
+                "lastName": "Velázquez",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NY"
+            },
+            {
+                "bioguideID": "V000129",
+                "firstName": "David",
+                "lastName": "Valadao",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "V000130",
+                "firstName": "Juan",
+                "lastName": "Vargas",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "V000131",
+                "firstName": "Marc",
+                "lastName": "Veasey",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "V000133",
+                "firstName": "Jefferson",
+                "lastName": "Van Drew",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "V000134",
+                "firstName": "Beth",
+                "lastName": "Van Duyne",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "V000135",
+                "firstName": "Derrick",
+                "lastName": "Van Orden",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "WI"
+            },
+            {
+                "bioguideID": "V000136",
+                "firstName": "Gabe",
+                "lastName": "Vasquez",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NM"
+            },
+            {
+                "bioguideID": "V000138",
+                "firstName": "Eugene",
+                "lastName": "Vindman",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "W000187",
+                "firstName": "Maxine",
+                "lastName": "Waters",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "W000788",
+                "firstName": "Nikema",
+                "lastName": "Williams",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "GA"
+            },
+            {
+                "bioguideID": "W000795",
+                "firstName": "Joe",
+                "lastName": "Wilson",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "SC"
+            },
+            {
+                "bioguideID": "W000797",
+                "firstName": "Debbie",
+                "lastName": "Wasserman Schultz",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "W000798",
+                "firstName": "Tim",
+                "lastName": "Walberg",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MI"
+            },
+            {
+                "bioguideID": "W000804",
+                "firstName": "Robert",
+                "lastName": "Wittman",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "VA"
+            },
+            {
+                "bioguideID": "W000806",
+                "firstName": "Daniel",
+                "lastName": "Webster",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "W000808",
+                "firstName": "Frederica",
+                "lastName": "Wilson",
+                "voteCast": "Not Voting",
+                "voteParty": "D",
+                "voteState": "FL"
+            },
+            {
+                "bioguideID": "W000809",
+                "firstName": "Steve",
+                "lastName": "Womack",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AR"
+            },
+            {
+                "bioguideID": "W000812",
+                "firstName": "Ann",
+                "lastName": "Wagner",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "MO"
+            },
+            {
+                "bioguideID": "W000814",
+                "firstName": "Randy",
+                "lastName": "Weber",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "W000816",
+                "firstName": "Roger",
+                "lastName": "Williams",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "TX"
+            },
+            {
+                "bioguideID": "W000821",
+                "firstName": "Bruce",
+                "lastName": "Westerman",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "AR"
+            },
+            {
+                "bioguideID": "W000822",
+                "firstName": "Bonnie",
+                "lastName": "Watson Coleman",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "NJ"
+            },
+            {
+                "bioguideID": "W000829",
+                "firstName": "Tony",
+                "lastName": "Wied",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "WI"
+            },
+            {
+                "bioguideID": "W000830",
+                "firstName": "George",
+                "lastName": "Whitesides",
+                "voteCast": "Yea",
+                "voteParty": "D",
+                "voteState": "CA"
+            },
+            {
+                "bioguideID": "Y000067",
+                "firstName": "Rudy",
+                "lastName": "Yakym",
+                "voteCast": "Yea",
+                "voteParty": "R",
+                "voteState": "IN"
+            },
+            {
+                "bioguideID": "Z000018",
+                "firstName": "Ryan",
+                "lastName": "Zinke",
+                "voteCast": "Not Voting",
+                "voteParty": "R",
+                "voteState": "MT"
+            }
+        ],
+        "rollCallNumber": 240,
+        "sessionNumber": 1,
+        "sourceDataURL": "https://clerk.house.gov/evs/2025/roll240.xml",
+        "startDate": "2025-09-08T18:56:00-04:00",
+        "updateDate": "2025-09-09T18:53:19-04:00",
+        "voteQuestion": "On Motion to Suspend the Rules and Pass",
+        "voteType": "2/3 Yea-And-Nay"
+    },
+    "request": {
+        "congress": "119",
+        "contentType": "application/json",
+        "format": "json",
+        "session": "1"
+    }
+}

--- a/tests/fixtures/senate/detail_119_1_00001_cloture.xml
+++ b/tests/fixtures/senate/detail_119_1_00001_cloture.xml
@@ -1,0 +1,934 @@
+<?xml version="1.0" encoding="UTF-8"?><roll_call_vote>
+  <congress>119</congress>
+  <session>1</session>
+  <congress_year>2025</congress_year>
+  <vote_number>1</vote_number>
+  <vote_date>January 9, 2025,  02:54 PM</vote_date>
+  <modify_date>January 10, 2025,  02:57 PM</modify_date>
+  <vote_question_text>On Cloture on the Motion to Proceed S. 5</vote_question_text>
+  <vote_document_text>A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</vote_document_text>
+  <vote_result_text>Cloture on the Motion to Proceed Agreed to (84-9, 3/5 majority required)</vote_result_text>
+  <question>On Cloture on the Motion to Proceed</question>
+  <vote_title>Motion to Invoke Cloture: Motion to Proceed to S. 5</vote_title>
+  <majority_requirement>3/5</majority_requirement>
+  <vote_result>Cloture on the Motion to Proceed Agreed to</vote_result>
+  <document>
+    <document_congress>119</document_congress>
+    <document_type>S.</document_type>
+    <document_number>5</document_number>
+    <document_name>S. 5</document_name>
+    <document_title>A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</document_title>
+    <document_short_title/>
+  </document>
+  <amendment>
+    <amendment_number/>
+    <amendment_to_amendment_number/>
+    <amendment_to_amendment_to_amendment_number/>
+    <amendment_to_document_number/>
+    <amendment_to_document_short_title/>
+    <amendment_purpose>No Statement of Purpose on File.</amendment_purpose>
+  </amendment>
+  <count>
+    <yeas>84</yeas>
+    <nays>9</nays>
+    <present/>
+    <absent>6</absent>
+  </count>
+  <tie_breaker>
+    <by_whom/>
+    <tie_breaker_vote/>
+  </tie_breaker>
+  <members>
+    <member>
+      <member_full>Alsobrooks (D-MD)</member_full>
+      <last_name>Alsobrooks</last_name>
+      <first_name>Angela</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S428</lis_member_id>
+    </member>
+    <member>
+      <member_full>Baldwin (D-WI)</member_full>
+      <last_name>Baldwin</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>WI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S354</lis_member_id>
+    </member>
+    <member>
+      <member_full>Banks (R-IN)</member_full>
+      <last_name>Banks</last_name>
+      <first_name>Jim</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S429</lis_member_id>
+    </member>
+    <member>
+      <member_full>Barrasso (R-WY)</member_full>
+      <last_name>Barrasso</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S317</lis_member_id>
+    </member>
+    <member>
+      <member_full>Bennet (D-CO)</member_full>
+      <last_name>Bennet</last_name>
+      <first_name>Michael</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S330</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blackburn (R-TN)</member_full>
+      <last_name>Blackburn</last_name>
+      <first_name>Marsha</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S396</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blumenthal (D-CT)</member_full>
+      <last_name>Blumenthal</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S341</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blunt Rochester (D-DE)</member_full>
+      <last_name>Blunt Rochester</last_name>
+      <first_name>Lisa</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S430</lis_member_id>
+    </member>
+    <member>
+      <member_full>Booker (D-NJ)</member_full>
+      <last_name>Booker</last_name>
+      <first_name>Cory</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S370</lis_member_id>
+    </member>
+    <member>
+      <member_full>Boozman (R-AR)</member_full>
+      <last_name>Boozman</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S343</lis_member_id>
+    </member>
+    <member>
+      <member_full>Britt (R-AL)</member_full>
+      <last_name>Britt</last_name>
+      <first_name>Katie</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S416</lis_member_id>
+    </member>
+    <member>
+      <member_full>Budd (R-NC)</member_full>
+      <last_name>Budd</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S417</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cantwell (D-WA)</member_full>
+      <last_name>Cantwell</last_name>
+      <first_name>Maria</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S275</lis_member_id>
+    </member>
+    <member>
+      <member_full>Capito (R-WV)</member_full>
+      <last_name>Capito</last_name>
+      <first_name>Shelley</first_name>
+      <party>R</party>
+      <state>WV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S372</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cassidy (R-LA)</member_full>
+      <last_name>Cassidy</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S373</lis_member_id>
+    </member>
+    <member>
+      <member_full>Collins (R-ME)</member_full>
+      <last_name>Collins</last_name>
+      <first_name>Susan</first_name>
+      <party>R</party>
+      <state>ME</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S252</lis_member_id>
+    </member>
+    <member>
+      <member_full>Coons (D-DE)</member_full>
+      <last_name>Coons</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S337</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cornyn (R-TX)</member_full>
+      <last_name>Cornyn</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S287</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cortez Masto (D-NV)</member_full>
+      <last_name>Cortez Masto</last_name>
+      <first_name>Catherine</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S385</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cotton (R-AR)</member_full>
+      <last_name>Cotton</last_name>
+      <first_name>Tom</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S374</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cramer (R-ND)</member_full>
+      <last_name>Cramer</last_name>
+      <first_name>Kevin</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S398</lis_member_id>
+    </member>
+    <member>
+      <member_full>Crapo (R-ID)</member_full>
+      <last_name>Crapo</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S266</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cruz (R-TX)</member_full>
+      <last_name>Cruz</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S355</lis_member_id>
+    </member>
+    <member>
+      <member_full>Curtis (R-UT)</member_full>
+      <last_name>Curtis</last_name>
+      <first_name>John </first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S431</lis_member_id>
+    </member>
+    <member>
+      <member_full>Daines (R-MT)</member_full>
+      <last_name>Daines</last_name>
+      <first_name>Steve</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S375</lis_member_id>
+    </member>
+    <member>
+      <member_full>Duckworth (D-IL)</member_full>
+      <last_name>Duckworth</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S386</lis_member_id>
+    </member>
+    <member>
+      <member_full>Durbin (D-IL)</member_full>
+      <last_name>Durbin</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S253</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ernst (R-IA)</member_full>
+      <last_name>Ernst</last_name>
+      <first_name>Joni</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S376</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fetterman (D-PA)</member_full>
+      <last_name>Fetterman</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>PA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S418</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fischer (R-NE)</member_full>
+      <last_name>Fischer</last_name>
+      <first_name>Deb</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S357</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gallego (D-AZ)</member_full>
+      <last_name>Gallego</last_name>
+      <first_name>Ruben</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S432</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gillibrand (D-NY)</member_full>
+      <last_name>Gillibrand</last_name>
+      <first_name>Kirsten</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S331</lis_member_id>
+    </member>
+    <member>
+      <member_full>Graham (R-SC)</member_full>
+      <last_name>Graham</last_name>
+      <first_name>Lindsey</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S293</lis_member_id>
+    </member>
+    <member>
+      <member_full>Grassley (R-IA)</member_full>
+      <last_name>Grassley</last_name>
+      <first_name>Chuck</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S153</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hagerty (R-TN)</member_full>
+      <last_name>Hagerty</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S407</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hassan (D-NH)</member_full>
+      <last_name>Hassan</last_name>
+      <first_name>Maggie</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S388</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hawley (R-MO)</member_full>
+      <last_name>Hawley</last_name>
+      <first_name>Josh</first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S399</lis_member_id>
+    </member>
+    <member>
+      <member_full>Heinrich (D-NM)</member_full>
+      <last_name>Heinrich</last_name>
+      <first_name>Martin</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S359</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hickenlooper (D-CO)</member_full>
+      <last_name>Hickenlooper</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S408</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hirono (D-HI)</member_full>
+      <last_name>Hirono</last_name>
+      <first_name>Mazie</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S361</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hoeven (R-ND)</member_full>
+      <last_name>Hoeven</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S344</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hyde-Smith (R-MS)</member_full>
+      <last_name>Hyde-Smith</last_name>
+      <first_name>Cindy</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S395</lis_member_id>
+    </member>
+    <member>
+      <member_full>Johnson (R-WI)</member_full>
+      <last_name>Johnson</last_name>
+      <first_name>Ron</first_name>
+      <party>R</party>
+      <state>WI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S345</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kaine (D-VA)</member_full>
+      <last_name>Kaine</last_name>
+      <first_name>Timothy</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S362</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kelly (D-AZ)</member_full>
+      <last_name>Kelly</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S406</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kennedy (R-LA)</member_full>
+      <last_name>Kennedy</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S389</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kim (D-NJ)</member_full>
+      <last_name>Kim</last_name>
+      <first_name>Andy</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S426</lis_member_id>
+    </member>
+    <member>
+      <member_full>King (I-ME)</member_full>
+      <last_name>King</last_name>
+      <first_name>Angus</first_name>
+      <party>I</party>
+      <state>ME</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S363</lis_member_id>
+    </member>
+    <member>
+      <member_full>Klobuchar (D-MN)</member_full>
+      <last_name>Klobuchar</last_name>
+      <first_name>Amy</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S311</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lankford (R-OK)</member_full>
+      <last_name>Lankford</last_name>
+      <first_name>James</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S378</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lee (R-UT)</member_full>
+      <last_name>Lee</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S346</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lujan (D-NM)</member_full>
+      <last_name>Lujan</last_name>
+      <first_name>Ben</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S409</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lummis (R-WY)</member_full>
+      <last_name>Lummis</last_name>
+      <first_name>Cynthia</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S410</lis_member_id>
+    </member>
+    <member>
+      <member_full>Markey (D-MA)</member_full>
+      <last_name>Markey</last_name>
+      <first_name>Edward</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S369</lis_member_id>
+    </member>
+    <member>
+      <member_full>Marshall (R-KS)</member_full>
+      <last_name>Marshall</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S411</lis_member_id>
+    </member>
+    <member>
+      <member_full>McConnell (R-KY)</member_full>
+      <last_name>McConnell</last_name>
+      <first_name>Mitch</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S174</lis_member_id>
+    </member>
+    <member>
+      <member_full>McCormick (R-PA)</member_full>
+      <last_name>McCormick</last_name>
+      <first_name>David</first_name>
+      <party>R</party>
+      <state>PA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S433</lis_member_id>
+    </member>
+    <member>
+      <member_full>Merkley (D-OR)</member_full>
+      <last_name>Merkley</last_name>
+      <first_name>Jeff</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S322</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moran (R-KS)</member_full>
+      <last_name>Moran</last_name>
+      <first_name>Jerry</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S347</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moreno (R-OH)</member_full>
+      <last_name>Moreno</last_name>
+      <first_name>Bernie</first_name>
+      <party>R</party>
+      <state>OH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S434</lis_member_id>
+    </member>
+    <member>
+      <member_full>Mullin (R-OK)</member_full>
+      <last_name>Mullin</last_name>
+      <first_name>Markwayne</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S419</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murkowski (R-AK)</member_full>
+      <last_name>Murkowski</last_name>
+      <first_name>Lisa</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S288</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murphy (D-CT)</member_full>
+      <last_name>Murphy</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S364</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murray (D-WA)</member_full>
+      <last_name>Murray</last_name>
+      <first_name>Patty</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S229</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ossoff (D-GA)</member_full>
+      <last_name>Ossoff</last_name>
+      <first_name>Jon</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S414</lis_member_id>
+    </member>
+    <member>
+      <member_full>Padilla (D-CA)</member_full>
+      <last_name>Padilla</last_name>
+      <first_name>Alex</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S413</lis_member_id>
+    </member>
+    <member>
+      <member_full>Paul (R-KY)</member_full>
+      <last_name>Paul</last_name>
+      <first_name>Rand</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S348</lis_member_id>
+    </member>
+    <member>
+      <member_full>Peters (D-MI)</member_full>
+      <last_name>Peters</last_name>
+      <first_name>Gary</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S380</lis_member_id>
+    </member>
+    <member>
+      <member_full>Reed (D-RI)</member_full>
+      <last_name>Reed</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S259</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ricketts (R-NE)</member_full>
+      <last_name>Ricketts</last_name>
+      <first_name>Pete</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S423</lis_member_id>
+    </member>
+    <member>
+      <member_full>Risch (R-ID)</member_full>
+      <last_name>Risch</last_name>
+      <first_name>James </first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S323</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rosen (D-NV)</member_full>
+      <last_name>Rosen</last_name>
+      <first_name>Jacky</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S402</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rounds (R-SD)</member_full>
+      <last_name>Rounds</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S381</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rubio (R-FL)</member_full>
+      <last_name>Rubio</last_name>
+      <first_name>Marco</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S350</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sanders (I-VT)</member_full>
+      <last_name>Sanders</last_name>
+      <first_name>Bernie</first_name>
+      <party>I</party>
+      <state>VT</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S313</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schatz (D-HI)</member_full>
+      <last_name>Schatz</last_name>
+      <first_name>Brian</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S353</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schiff (D-CA)</member_full>
+      <last_name>Schiff</last_name>
+      <first_name>Adam</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S427</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schmitt (R-MO)</member_full>
+      <last_name>Schmitt</last_name>
+      <first_name>Eric </first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S420</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schumer (D-NY)</member_full>
+      <last_name>Schumer</last_name>
+      <first_name>Charles</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S270</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-FL)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Rick</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S404</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-SC)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S365</lis_member_id>
+    </member>
+    <member>
+      <member_full>Shaheen (D-NH)</member_full>
+      <last_name>Shaheen</last_name>
+      <first_name>Jeanne</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S324</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sheehy (R-MT)</member_full>
+      <last_name>Sheehy</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S435</lis_member_id>
+    </member>
+    <member>
+      <member_full>Slotkin (D-MI)</member_full>
+      <last_name>Slotkin</last_name>
+      <first_name>Elissa</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S436</lis_member_id>
+    </member>
+    <member>
+      <member_full>Smith (D-MN)</member_full>
+      <last_name>Smith</last_name>
+      <first_name>Tina</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S394</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sullivan (R-AK)</member_full>
+      <last_name>Sullivan</last_name>
+      <first_name>Dan</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S383</lis_member_id>
+    </member>
+    <member>
+      <member_full>Thune (R-SD)</member_full>
+      <last_name>Thune</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S303</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tillis (R-NC)</member_full>
+      <last_name>Tillis</last_name>
+      <first_name>Thomas</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S384</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tuberville (R-AL)</member_full>
+      <last_name>Tuberville</last_name>
+      <first_name>Tommy</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S412</lis_member_id>
+    </member>
+    <member>
+      <member_full>Van Hollen (D-MD)</member_full>
+      <last_name>Van Hollen</last_name>
+      <first_name>Chris</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S390</lis_member_id>
+    </member>
+    <member>
+      <member_full>Vance (R-OH)</member_full>
+      <last_name>Vance</last_name>
+      <first_name>J.</first_name>
+      <party>R</party>
+      <state>OH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S421</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warner (D-VA)</member_full>
+      <last_name>Warner</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S327</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warnock (D-GA)</member_full>
+      <last_name>Warnock</last_name>
+      <first_name>Raphael</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S415</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warren (D-MA)</member_full>
+      <last_name>Warren</last_name>
+      <first_name>Elizabeth</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S366</lis_member_id>
+    </member>
+    <member>
+      <member_full>Welch (D-VT)</member_full>
+      <last_name>Welch</last_name>
+      <first_name>Peter</first_name>
+      <party>D</party>
+      <state>VT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S422</lis_member_id>
+    </member>
+    <member>
+      <member_full>Whitehouse (D-RI)</member_full>
+      <last_name>Whitehouse</last_name>
+      <first_name>Sheldon</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S316</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wicker (R-MS)</member_full>
+      <last_name>Wicker</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S318</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wyden (D-OR)</member_full>
+      <last_name>Wyden</last_name>
+      <first_name>Ron</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S247</lis_member_id>
+    </member>
+    <member>
+      <member_full>Young (R-IN)</member_full>
+      <last_name>Young</last_name>
+      <first_name>Todd</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S391</lis_member_id>
+    </member>
+  </members>
+</roll_call_vote>

--- a/tests/fixtures/senate/detail_119_1_00002_motion.xml
+++ b/tests/fixtures/senate/detail_119_1_00002_motion.xml
@@ -1,0 +1,925 @@
+<?xml version="1.0" encoding="UTF-8"?><roll_call_vote>
+  <congress>119</congress>
+  <session>1</session>
+  <congress_year>2025</congress_year>
+  <vote_number>2</vote_number>
+  <vote_date>January 13, 2025,  05:26 PM</vote_date>
+  <modify_date>January 13, 2025,  06:43 PM</modify_date>
+  <vote_question_text>On the Motion to Proceed S. 5</vote_question_text>
+  <vote_document_text>A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</vote_document_text>
+  <vote_result_text>Motion to Proceed Agreed to (82-10)</vote_result_text>
+  <question>On the Motion to Proceed</question>
+  <vote_title>Motion to Proceed to S. 5</vote_title>
+  <majority_requirement>1/2</majority_requirement>
+  <vote_result>Motion to Proceed Agreed to</vote_result>
+  <document>
+    <document_congress>119</document_congress>
+    <document_type>S.</document_type>
+    <document_number>5</document_number>
+    <document_name>S. 5</document_name>
+    <document_title>A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</document_title>
+    <document_short_title/>
+  </document>
+  <amendment>
+    <amendment_number/>
+    <amendment_to_amendment_number/>
+    <amendment_to_amendment_to_amendment_number/>
+    <amendment_to_document_number/>
+    <amendment_to_document_short_title/>
+    <amendment_purpose>No Statement of Purpose on File.</amendment_purpose>
+  </amendment>
+  <count>
+    <yeas>82</yeas>
+    <nays>10</nays>
+    <present/>
+    <absent>6</absent>
+  </count>
+  <tie_breaker>
+    <by_whom/>
+    <tie_breaker_vote/>
+  </tie_breaker>
+  <members>
+    <member>
+      <member_full>Alsobrooks (D-MD)</member_full>
+      <last_name>Alsobrooks</last_name>
+      <first_name>Angela</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S428</lis_member_id>
+    </member>
+    <member>
+      <member_full>Baldwin (D-WI)</member_full>
+      <last_name>Baldwin</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>WI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S354</lis_member_id>
+    </member>
+    <member>
+      <member_full>Banks (R-IN)</member_full>
+      <last_name>Banks</last_name>
+      <first_name>Jim</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S429</lis_member_id>
+    </member>
+    <member>
+      <member_full>Barrasso (R-WY)</member_full>
+      <last_name>Barrasso</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S317</lis_member_id>
+    </member>
+    <member>
+      <member_full>Bennet (D-CO)</member_full>
+      <last_name>Bennet</last_name>
+      <first_name>Michael</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S330</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blackburn (R-TN)</member_full>
+      <last_name>Blackburn</last_name>
+      <first_name>Marsha</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S396</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blumenthal (D-CT)</member_full>
+      <last_name>Blumenthal</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S341</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blunt Rochester (D-DE)</member_full>
+      <last_name>Blunt Rochester</last_name>
+      <first_name>Lisa</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S430</lis_member_id>
+    </member>
+    <member>
+      <member_full>Booker (D-NJ)</member_full>
+      <last_name>Booker</last_name>
+      <first_name>Cory</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S370</lis_member_id>
+    </member>
+    <member>
+      <member_full>Boozman (R-AR)</member_full>
+      <last_name>Boozman</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S343</lis_member_id>
+    </member>
+    <member>
+      <member_full>Britt (R-AL)</member_full>
+      <last_name>Britt</last_name>
+      <first_name>Katie</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S416</lis_member_id>
+    </member>
+    <member>
+      <member_full>Budd (R-NC)</member_full>
+      <last_name>Budd</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S417</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cantwell (D-WA)</member_full>
+      <last_name>Cantwell</last_name>
+      <first_name>Maria</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S275</lis_member_id>
+    </member>
+    <member>
+      <member_full>Capito (R-WV)</member_full>
+      <last_name>Capito</last_name>
+      <first_name>Shelley</first_name>
+      <party>R</party>
+      <state>WV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S372</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cassidy (R-LA)</member_full>
+      <last_name>Cassidy</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S373</lis_member_id>
+    </member>
+    <member>
+      <member_full>Collins (R-ME)</member_full>
+      <last_name>Collins</last_name>
+      <first_name>Susan</first_name>
+      <party>R</party>
+      <state>ME</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S252</lis_member_id>
+    </member>
+    <member>
+      <member_full>Coons (D-DE)</member_full>
+      <last_name>Coons</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S337</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cornyn (R-TX)</member_full>
+      <last_name>Cornyn</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S287</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cortez Masto (D-NV)</member_full>
+      <last_name>Cortez Masto</last_name>
+      <first_name>Catherine</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S385</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cotton (R-AR)</member_full>
+      <last_name>Cotton</last_name>
+      <first_name>Tom</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S374</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cramer (R-ND)</member_full>
+      <last_name>Cramer</last_name>
+      <first_name>Kevin</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S398</lis_member_id>
+    </member>
+    <member>
+      <member_full>Crapo (R-ID)</member_full>
+      <last_name>Crapo</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S266</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cruz (R-TX)</member_full>
+      <last_name>Cruz</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S355</lis_member_id>
+    </member>
+    <member>
+      <member_full>Curtis (R-UT)</member_full>
+      <last_name>Curtis</last_name>
+      <first_name>John </first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S431</lis_member_id>
+    </member>
+    <member>
+      <member_full>Daines (R-MT)</member_full>
+      <last_name>Daines</last_name>
+      <first_name>Steve</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S375</lis_member_id>
+    </member>
+    <member>
+      <member_full>Duckworth (D-IL)</member_full>
+      <last_name>Duckworth</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S386</lis_member_id>
+    </member>
+    <member>
+      <member_full>Durbin (D-IL)</member_full>
+      <last_name>Durbin</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S253</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ernst (R-IA)</member_full>
+      <last_name>Ernst</last_name>
+      <first_name>Joni</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S376</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fetterman (D-PA)</member_full>
+      <last_name>Fetterman</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>PA</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S418</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fischer (R-NE)</member_full>
+      <last_name>Fischer</last_name>
+      <first_name>Deb</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S357</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gallego (D-AZ)</member_full>
+      <last_name>Gallego</last_name>
+      <first_name>Ruben</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S432</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gillibrand (D-NY)</member_full>
+      <last_name>Gillibrand</last_name>
+      <first_name>Kirsten</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S331</lis_member_id>
+    </member>
+    <member>
+      <member_full>Graham (R-SC)</member_full>
+      <last_name>Graham</last_name>
+      <first_name>Lindsey</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S293</lis_member_id>
+    </member>
+    <member>
+      <member_full>Grassley (R-IA)</member_full>
+      <last_name>Grassley</last_name>
+      <first_name>Chuck</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S153</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hagerty (R-TN)</member_full>
+      <last_name>Hagerty</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S407</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hassan (D-NH)</member_full>
+      <last_name>Hassan</last_name>
+      <first_name>Maggie</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S388</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hawley (R-MO)</member_full>
+      <last_name>Hawley</last_name>
+      <first_name>Josh</first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S399</lis_member_id>
+    </member>
+    <member>
+      <member_full>Heinrich (D-NM)</member_full>
+      <last_name>Heinrich</last_name>
+      <first_name>Martin</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S359</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hickenlooper (D-CO)</member_full>
+      <last_name>Hickenlooper</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S408</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hirono (D-HI)</member_full>
+      <last_name>Hirono</last_name>
+      <first_name>Mazie</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S361</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hoeven (R-ND)</member_full>
+      <last_name>Hoeven</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S344</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hyde-Smith (R-MS)</member_full>
+      <last_name>Hyde-Smith</last_name>
+      <first_name>Cindy</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S395</lis_member_id>
+    </member>
+    <member>
+      <member_full>Johnson (R-WI)</member_full>
+      <last_name>Johnson</last_name>
+      <first_name>Ron</first_name>
+      <party>R</party>
+      <state>WI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S345</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kaine (D-VA)</member_full>
+      <last_name>Kaine</last_name>
+      <first_name>Timothy</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S362</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kelly (D-AZ)</member_full>
+      <last_name>Kelly</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S406</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kennedy (R-LA)</member_full>
+      <last_name>Kennedy</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S389</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kim (D-NJ)</member_full>
+      <last_name>Kim</last_name>
+      <first_name>Andy</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S426</lis_member_id>
+    </member>
+    <member>
+      <member_full>King (I-ME)</member_full>
+      <last_name>King</last_name>
+      <first_name>Angus</first_name>
+      <party>I</party>
+      <state>ME</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S363</lis_member_id>
+    </member>
+    <member>
+      <member_full>Klobuchar (D-MN)</member_full>
+      <last_name>Klobuchar</last_name>
+      <first_name>Amy</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S311</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lankford (R-OK)</member_full>
+      <last_name>Lankford</last_name>
+      <first_name>James</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S378</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lee (R-UT)</member_full>
+      <last_name>Lee</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S346</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lujan (D-NM)</member_full>
+      <last_name>Lujan</last_name>
+      <first_name>Ben</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S409</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lummis (R-WY)</member_full>
+      <last_name>Lummis</last_name>
+      <first_name>Cynthia</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S410</lis_member_id>
+    </member>
+    <member>
+      <member_full>Markey (D-MA)</member_full>
+      <last_name>Markey</last_name>
+      <first_name>Edward</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S369</lis_member_id>
+    </member>
+    <member>
+      <member_full>Marshall (R-KS)</member_full>
+      <last_name>Marshall</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S411</lis_member_id>
+    </member>
+    <member>
+      <member_full>McConnell (R-KY)</member_full>
+      <last_name>McConnell</last_name>
+      <first_name>Mitch</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S174</lis_member_id>
+    </member>
+    <member>
+      <member_full>McCormick (R-PA)</member_full>
+      <last_name>McCormick</last_name>
+      <first_name>David</first_name>
+      <party>R</party>
+      <state>PA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S433</lis_member_id>
+    </member>
+    <member>
+      <member_full>Merkley (D-OR)</member_full>
+      <last_name>Merkley</last_name>
+      <first_name>Jeff</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S322</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moran (R-KS)</member_full>
+      <last_name>Moran</last_name>
+      <first_name>Jerry</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S347</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moreno (R-OH)</member_full>
+      <last_name>Moreno</last_name>
+      <first_name>Bernie</first_name>
+      <party>R</party>
+      <state>OH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S434</lis_member_id>
+    </member>
+    <member>
+      <member_full>Mullin (R-OK)</member_full>
+      <last_name>Mullin</last_name>
+      <first_name>Markwayne</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S419</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murkowski (R-AK)</member_full>
+      <last_name>Murkowski</last_name>
+      <first_name>Lisa</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S288</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murphy (D-CT)</member_full>
+      <last_name>Murphy</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S364</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murray (D-WA)</member_full>
+      <last_name>Murray</last_name>
+      <first_name>Patty</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S229</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ossoff (D-GA)</member_full>
+      <last_name>Ossoff</last_name>
+      <first_name>Jon</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S414</lis_member_id>
+    </member>
+    <member>
+      <member_full>Padilla (D-CA)</member_full>
+      <last_name>Padilla</last_name>
+      <first_name>Alex</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S413</lis_member_id>
+    </member>
+    <member>
+      <member_full>Paul (R-KY)</member_full>
+      <last_name>Paul</last_name>
+      <first_name>Rand</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S348</lis_member_id>
+    </member>
+    <member>
+      <member_full>Peters (D-MI)</member_full>
+      <last_name>Peters</last_name>
+      <first_name>Gary</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S380</lis_member_id>
+    </member>
+    <member>
+      <member_full>Reed (D-RI)</member_full>
+      <last_name>Reed</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S259</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ricketts (R-NE)</member_full>
+      <last_name>Ricketts</last_name>
+      <first_name>Pete</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S423</lis_member_id>
+    </member>
+    <member>
+      <member_full>Risch (R-ID)</member_full>
+      <last_name>Risch</last_name>
+      <first_name>James </first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S323</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rosen (D-NV)</member_full>
+      <last_name>Rosen</last_name>
+      <first_name>Jacky</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S402</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rounds (R-SD)</member_full>
+      <last_name>Rounds</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S381</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rubio (R-FL)</member_full>
+      <last_name>Rubio</last_name>
+      <first_name>Marco</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S350</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sanders (I-VT)</member_full>
+      <last_name>Sanders</last_name>
+      <first_name>Bernie</first_name>
+      <party>I</party>
+      <state>VT</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S313</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schatz (D-HI)</member_full>
+      <last_name>Schatz</last_name>
+      <first_name>Brian</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S353</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schiff (D-CA)</member_full>
+      <last_name>Schiff</last_name>
+      <first_name>Adam</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S427</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schmitt (R-MO)</member_full>
+      <last_name>Schmitt</last_name>
+      <first_name>Eric </first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S420</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schumer (D-NY)</member_full>
+      <last_name>Schumer</last_name>
+      <first_name>Charles</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S270</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-FL)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Rick</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S404</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-SC)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S365</lis_member_id>
+    </member>
+    <member>
+      <member_full>Shaheen (D-NH)</member_full>
+      <last_name>Shaheen</last_name>
+      <first_name>Jeanne</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S324</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sheehy (R-MT)</member_full>
+      <last_name>Sheehy</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S435</lis_member_id>
+    </member>
+    <member>
+      <member_full>Slotkin (D-MI)</member_full>
+      <last_name>Slotkin</last_name>
+      <first_name>Elissa</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S436</lis_member_id>
+    </member>
+    <member>
+      <member_full>Smith (D-MN)</member_full>
+      <last_name>Smith</last_name>
+      <first_name>Tina</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S394</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sullivan (R-AK)</member_full>
+      <last_name>Sullivan</last_name>
+      <first_name>Dan</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S383</lis_member_id>
+    </member>
+    <member>
+      <member_full>Thune (R-SD)</member_full>
+      <last_name>Thune</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S303</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tillis (R-NC)</member_full>
+      <last_name>Tillis</last_name>
+      <first_name>Thomas</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S384</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tuberville (R-AL)</member_full>
+      <last_name>Tuberville</last_name>
+      <first_name>Tommy</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S412</lis_member_id>
+    </member>
+    <member>
+      <member_full>Van Hollen (D-MD)</member_full>
+      <last_name>Van Hollen</last_name>
+      <first_name>Chris</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S390</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warner (D-VA)</member_full>
+      <last_name>Warner</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S327</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warnock (D-GA)</member_full>
+      <last_name>Warnock</last_name>
+      <first_name>Raphael</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S415</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warren (D-MA)</member_full>
+      <last_name>Warren</last_name>
+      <first_name>Elizabeth</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S366</lis_member_id>
+    </member>
+    <member>
+      <member_full>Welch (D-VT)</member_full>
+      <last_name>Welch</last_name>
+      <first_name>Peter</first_name>
+      <party>D</party>
+      <state>VT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S422</lis_member_id>
+    </member>
+    <member>
+      <member_full>Whitehouse (D-RI)</member_full>
+      <last_name>Whitehouse</last_name>
+      <first_name>Sheldon</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S316</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wicker (R-MS)</member_full>
+      <last_name>Wicker</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S318</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wyden (D-OR)</member_full>
+      <last_name>Wyden</last_name>
+      <first_name>Ron</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S247</lis_member_id>
+    </member>
+    <member>
+      <member_full>Young (R-IN)</member_full>
+      <last_name>Young</last_name>
+      <first_name>Todd</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S391</lis_member_id>
+    </member>
+  </members>
+</roll_call_vote>

--- a/tests/fixtures/senate/detail_119_1_00003_amendment.xml
+++ b/tests/fixtures/senate/detail_119_1_00003_amendment.xml
@@ -1,0 +1,934 @@
+<?xml version="1.0" encoding="UTF-8"?><roll_call_vote>
+  <congress>119</congress>
+  <session>1</session>
+  <congress_year>2025</congress_year>
+  <vote_number>3</vote_number>
+  <vote_date>January 15, 2025,  05:57 PM</vote_date>
+  <modify_date>January 15, 2025,  06:48 PM</modify_date>
+  <vote_question_text>On the Amendment S.Amdt. 14 to S.Amdt. 8 to S. 5 (No short title on file)</vote_question_text>
+  <vote_document_text>To expand the list of criminal offenses that subject inadmissible aliens to mandatory detention.</vote_document_text>
+  <vote_result_text>Amendment Agreed to (70-25)</vote_result_text>
+  <question>On the Amendment</question>
+  <vote_title>Cornyn Amdt. No. 14</vote_title>
+  <majority_requirement>1/2</majority_requirement>
+  <vote_result>Amendment Agreed to</vote_result>
+  <document>
+    <document_congress>119</document_congress>
+    <document_type>S.Amdt.</document_type>
+    <document_number/>
+    <document_name/>
+    <document_title/>
+    <document_short_title/>
+  </document>
+  <amendment>
+    <amendment_number>S.Amdt. 14</amendment_number>
+    <amendment_to_amendment_number>S.Amdt. 8</amendment_to_amendment_number>
+    <amendment_to_amendment_to_amendment_number/>
+    <amendment_to_document_number>S. 5</amendment_to_document_number>
+    <amendment_to_document_short_title>No short title on file</amendment_to_document_short_title>
+    <amendment_purpose>To expand the list of criminal offenses that subject inadmissible aliens to mandatory detention.</amendment_purpose>
+  </amendment>
+  <count>
+    <yeas>70</yeas>
+    <nays>25</nays>
+    <present/>
+    <absent>4</absent>
+  </count>
+  <tie_breaker>
+    <by_whom/>
+    <tie_breaker_vote/>
+  </tie_breaker>
+  <members>
+    <member>
+      <member_full>Alsobrooks (D-MD)</member_full>
+      <last_name>Alsobrooks</last_name>
+      <first_name>Angela</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S428</lis_member_id>
+    </member>
+    <member>
+      <member_full>Baldwin (D-WI)</member_full>
+      <last_name>Baldwin</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>WI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S354</lis_member_id>
+    </member>
+    <member>
+      <member_full>Banks (R-IN)</member_full>
+      <last_name>Banks</last_name>
+      <first_name>Jim</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S429</lis_member_id>
+    </member>
+    <member>
+      <member_full>Barrasso (R-WY)</member_full>
+      <last_name>Barrasso</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S317</lis_member_id>
+    </member>
+    <member>
+      <member_full>Bennet (D-CO)</member_full>
+      <last_name>Bennet</last_name>
+      <first_name>Michael</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S330</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blackburn (R-TN)</member_full>
+      <last_name>Blackburn</last_name>
+      <first_name>Marsha</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S396</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blumenthal (D-CT)</member_full>
+      <last_name>Blumenthal</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S341</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blunt Rochester (D-DE)</member_full>
+      <last_name>Blunt Rochester</last_name>
+      <first_name>Lisa</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S430</lis_member_id>
+    </member>
+    <member>
+      <member_full>Booker (D-NJ)</member_full>
+      <last_name>Booker</last_name>
+      <first_name>Cory</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S370</lis_member_id>
+    </member>
+    <member>
+      <member_full>Boozman (R-AR)</member_full>
+      <last_name>Boozman</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S343</lis_member_id>
+    </member>
+    <member>
+      <member_full>Britt (R-AL)</member_full>
+      <last_name>Britt</last_name>
+      <first_name>Katie</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S416</lis_member_id>
+    </member>
+    <member>
+      <member_full>Budd (R-NC)</member_full>
+      <last_name>Budd</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S417</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cantwell (D-WA)</member_full>
+      <last_name>Cantwell</last_name>
+      <first_name>Maria</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S275</lis_member_id>
+    </member>
+    <member>
+      <member_full>Capito (R-WV)</member_full>
+      <last_name>Capito</last_name>
+      <first_name>Shelley</first_name>
+      <party>R</party>
+      <state>WV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S372</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cassidy (R-LA)</member_full>
+      <last_name>Cassidy</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S373</lis_member_id>
+    </member>
+    <member>
+      <member_full>Collins (R-ME)</member_full>
+      <last_name>Collins</last_name>
+      <first_name>Susan</first_name>
+      <party>R</party>
+      <state>ME</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S252</lis_member_id>
+    </member>
+    <member>
+      <member_full>Coons (D-DE)</member_full>
+      <last_name>Coons</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S337</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cornyn (R-TX)</member_full>
+      <last_name>Cornyn</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S287</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cortez Masto (D-NV)</member_full>
+      <last_name>Cortez Masto</last_name>
+      <first_name>Catherine</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S385</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cotton (R-AR)</member_full>
+      <last_name>Cotton</last_name>
+      <first_name>Tom</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S374</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cramer (R-ND)</member_full>
+      <last_name>Cramer</last_name>
+      <first_name>Kevin</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S398</lis_member_id>
+    </member>
+    <member>
+      <member_full>Crapo (R-ID)</member_full>
+      <last_name>Crapo</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S266</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cruz (R-TX)</member_full>
+      <last_name>Cruz</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S355</lis_member_id>
+    </member>
+    <member>
+      <member_full>Curtis (R-UT)</member_full>
+      <last_name>Curtis</last_name>
+      <first_name>John </first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S431</lis_member_id>
+    </member>
+    <member>
+      <member_full>Daines (R-MT)</member_full>
+      <last_name>Daines</last_name>
+      <first_name>Steve</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S375</lis_member_id>
+    </member>
+    <member>
+      <member_full>Duckworth (D-IL)</member_full>
+      <last_name>Duckworth</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S386</lis_member_id>
+    </member>
+    <member>
+      <member_full>Durbin (D-IL)</member_full>
+      <last_name>Durbin</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S253</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ernst (R-IA)</member_full>
+      <last_name>Ernst</last_name>
+      <first_name>Joni</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S376</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fetterman (D-PA)</member_full>
+      <last_name>Fetterman</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>PA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S418</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fischer (R-NE)</member_full>
+      <last_name>Fischer</last_name>
+      <first_name>Deb</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S357</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gallego (D-AZ)</member_full>
+      <last_name>Gallego</last_name>
+      <first_name>Ruben</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S432</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gillibrand (D-NY)</member_full>
+      <last_name>Gillibrand</last_name>
+      <first_name>Kirsten</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S331</lis_member_id>
+    </member>
+    <member>
+      <member_full>Graham (R-SC)</member_full>
+      <last_name>Graham</last_name>
+      <first_name>Lindsey</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S293</lis_member_id>
+    </member>
+    <member>
+      <member_full>Grassley (R-IA)</member_full>
+      <last_name>Grassley</last_name>
+      <first_name>Chuck</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S153</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hagerty (R-TN)</member_full>
+      <last_name>Hagerty</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S407</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hassan (D-NH)</member_full>
+      <last_name>Hassan</last_name>
+      <first_name>Maggie</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S388</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hawley (R-MO)</member_full>
+      <last_name>Hawley</last_name>
+      <first_name>Josh</first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S399</lis_member_id>
+    </member>
+    <member>
+      <member_full>Heinrich (D-NM)</member_full>
+      <last_name>Heinrich</last_name>
+      <first_name>Martin</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S359</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hickenlooper (D-CO)</member_full>
+      <last_name>Hickenlooper</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S408</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hirono (D-HI)</member_full>
+      <last_name>Hirono</last_name>
+      <first_name>Mazie</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S361</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hoeven (R-ND)</member_full>
+      <last_name>Hoeven</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S344</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hyde-Smith (R-MS)</member_full>
+      <last_name>Hyde-Smith</last_name>
+      <first_name>Cindy</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S395</lis_member_id>
+    </member>
+    <member>
+      <member_full>Johnson (R-WI)</member_full>
+      <last_name>Johnson</last_name>
+      <first_name>Ron</first_name>
+      <party>R</party>
+      <state>WI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S345</lis_member_id>
+    </member>
+    <member>
+      <member_full>Justice (R-WV)</member_full>
+      <last_name>Justice</last_name>
+      <first_name>James</first_name>
+      <party>R</party>
+      <state>WV</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S437</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kaine (D-VA)</member_full>
+      <last_name>Kaine</last_name>
+      <first_name>Timothy</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S362</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kelly (D-AZ)</member_full>
+      <last_name>Kelly</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S406</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kennedy (R-LA)</member_full>
+      <last_name>Kennedy</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S389</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kim (D-NJ)</member_full>
+      <last_name>Kim</last_name>
+      <first_name>Andy</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S426</lis_member_id>
+    </member>
+    <member>
+      <member_full>King (I-ME)</member_full>
+      <last_name>King</last_name>
+      <first_name>Angus</first_name>
+      <party>I</party>
+      <state>ME</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S363</lis_member_id>
+    </member>
+    <member>
+      <member_full>Klobuchar (D-MN)</member_full>
+      <last_name>Klobuchar</last_name>
+      <first_name>Amy</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S311</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lankford (R-OK)</member_full>
+      <last_name>Lankford</last_name>
+      <first_name>James</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S378</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lee (R-UT)</member_full>
+      <last_name>Lee</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S346</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lujan (D-NM)</member_full>
+      <last_name>Lujan</last_name>
+      <first_name>Ben</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S409</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lummis (R-WY)</member_full>
+      <last_name>Lummis</last_name>
+      <first_name>Cynthia</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S410</lis_member_id>
+    </member>
+    <member>
+      <member_full>Markey (D-MA)</member_full>
+      <last_name>Markey</last_name>
+      <first_name>Edward</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S369</lis_member_id>
+    </member>
+    <member>
+      <member_full>Marshall (R-KS)</member_full>
+      <last_name>Marshall</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S411</lis_member_id>
+    </member>
+    <member>
+      <member_full>McConnell (R-KY)</member_full>
+      <last_name>McConnell</last_name>
+      <first_name>Mitch</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S174</lis_member_id>
+    </member>
+    <member>
+      <member_full>McCormick (R-PA)</member_full>
+      <last_name>McCormick</last_name>
+      <first_name>David</first_name>
+      <party>R</party>
+      <state>PA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S433</lis_member_id>
+    </member>
+    <member>
+      <member_full>Merkley (D-OR)</member_full>
+      <last_name>Merkley</last_name>
+      <first_name>Jeff</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S322</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moran (R-KS)</member_full>
+      <last_name>Moran</last_name>
+      <first_name>Jerry</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S347</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moreno (R-OH)</member_full>
+      <last_name>Moreno</last_name>
+      <first_name>Bernie</first_name>
+      <party>R</party>
+      <state>OH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S434</lis_member_id>
+    </member>
+    <member>
+      <member_full>Mullin (R-OK)</member_full>
+      <last_name>Mullin</last_name>
+      <first_name>Markwayne</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S419</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murkowski (R-AK)</member_full>
+      <last_name>Murkowski</last_name>
+      <first_name>Lisa</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S288</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murphy (D-CT)</member_full>
+      <last_name>Murphy</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S364</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murray (D-WA)</member_full>
+      <last_name>Murray</last_name>
+      <first_name>Patty</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S229</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ossoff (D-GA)</member_full>
+      <last_name>Ossoff</last_name>
+      <first_name>Jon</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S414</lis_member_id>
+    </member>
+    <member>
+      <member_full>Padilla (D-CA)</member_full>
+      <last_name>Padilla</last_name>
+      <first_name>Alex</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S413</lis_member_id>
+    </member>
+    <member>
+      <member_full>Paul (R-KY)</member_full>
+      <last_name>Paul</last_name>
+      <first_name>Rand</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S348</lis_member_id>
+    </member>
+    <member>
+      <member_full>Peters (D-MI)</member_full>
+      <last_name>Peters</last_name>
+      <first_name>Gary</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S380</lis_member_id>
+    </member>
+    <member>
+      <member_full>Reed (D-RI)</member_full>
+      <last_name>Reed</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S259</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ricketts (R-NE)</member_full>
+      <last_name>Ricketts</last_name>
+      <first_name>Pete</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S423</lis_member_id>
+    </member>
+    <member>
+      <member_full>Risch (R-ID)</member_full>
+      <last_name>Risch</last_name>
+      <first_name>James </first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S323</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rosen (D-NV)</member_full>
+      <last_name>Rosen</last_name>
+      <first_name>Jacky</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S402</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rounds (R-SD)</member_full>
+      <last_name>Rounds</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S381</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rubio (R-FL)</member_full>
+      <last_name>Rubio</last_name>
+      <first_name>Marco</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S350</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sanders (I-VT)</member_full>
+      <last_name>Sanders</last_name>
+      <first_name>Bernie</first_name>
+      <party>I</party>
+      <state>VT</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S313</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schatz (D-HI)</member_full>
+      <last_name>Schatz</last_name>
+      <first_name>Brian</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S353</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schiff (D-CA)</member_full>
+      <last_name>Schiff</last_name>
+      <first_name>Adam</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S427</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schmitt (R-MO)</member_full>
+      <last_name>Schmitt</last_name>
+      <first_name>Eric </first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S420</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schumer (D-NY)</member_full>
+      <last_name>Schumer</last_name>
+      <first_name>Charles</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S270</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-FL)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Rick</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S404</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-SC)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S365</lis_member_id>
+    </member>
+    <member>
+      <member_full>Shaheen (D-NH)</member_full>
+      <last_name>Shaheen</last_name>
+      <first_name>Jeanne</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S324</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sheehy (R-MT)</member_full>
+      <last_name>Sheehy</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S435</lis_member_id>
+    </member>
+    <member>
+      <member_full>Slotkin (D-MI)</member_full>
+      <last_name>Slotkin</last_name>
+      <first_name>Elissa</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S436</lis_member_id>
+    </member>
+    <member>
+      <member_full>Smith (D-MN)</member_full>
+      <last_name>Smith</last_name>
+      <first_name>Tina</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S394</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sullivan (R-AK)</member_full>
+      <last_name>Sullivan</last_name>
+      <first_name>Dan</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S383</lis_member_id>
+    </member>
+    <member>
+      <member_full>Thune (R-SD)</member_full>
+      <last_name>Thune</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S303</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tillis (R-NC)</member_full>
+      <last_name>Tillis</last_name>
+      <first_name>Thomas</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S384</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tuberville (R-AL)</member_full>
+      <last_name>Tuberville</last_name>
+      <first_name>Tommy</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S412</lis_member_id>
+    </member>
+    <member>
+      <member_full>Van Hollen (D-MD)</member_full>
+      <last_name>Van Hollen</last_name>
+      <first_name>Chris</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S390</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warner (D-VA)</member_full>
+      <last_name>Warner</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S327</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warnock (D-GA)</member_full>
+      <last_name>Warnock</last_name>
+      <first_name>Raphael</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S415</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warren (D-MA)</member_full>
+      <last_name>Warren</last_name>
+      <first_name>Elizabeth</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S366</lis_member_id>
+    </member>
+    <member>
+      <member_full>Welch (D-VT)</member_full>
+      <last_name>Welch</last_name>
+      <first_name>Peter</first_name>
+      <party>D</party>
+      <state>VT</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S422</lis_member_id>
+    </member>
+    <member>
+      <member_full>Whitehouse (D-RI)</member_full>
+      <last_name>Whitehouse</last_name>
+      <first_name>Sheldon</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S316</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wicker (R-MS)</member_full>
+      <last_name>Wicker</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S318</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wyden (D-OR)</member_full>
+      <last_name>Wyden</last_name>
+      <first_name>Ron</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Not Voting</vote_cast>
+      <lis_member_id>S247</lis_member_id>
+    </member>
+    <member>
+      <member_full>Young (R-IN)</member_full>
+      <last_name>Young</last_name>
+      <first_name>Todd</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S391</lis_member_id>
+    </member>
+  </members>
+</roll_call_vote>

--- a/tests/fixtures/senate/detail_119_1_00007_bill.xml
+++ b/tests/fixtures/senate/detail_119_1_00007_bill.xml
@@ -1,0 +1,934 @@
+<?xml version="1.0" encoding="UTF-8"?><roll_call_vote>
+  <congress>119</congress>
+  <session>1</session>
+  <congress_year>2025</congress_year>
+  <vote_number>7</vote_number>
+  <vote_date>January 20, 2025,  06:12 PM</vote_date>
+  <modify_date>January 20, 2025,  06:44 PM</modify_date>
+  <vote_question_text>On Passage of the Bill S. 5</vote_question_text>
+  <vote_document_text>A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</vote_document_text>
+  <vote_result_text>Bill Passed (64-35)</vote_result_text>
+  <question>On Passage of the Bill</question>
+  <vote_title>S. 5, As Amended</vote_title>
+  <majority_requirement>1/2</majority_requirement>
+  <vote_result>Bill Passed</vote_result>
+  <document>
+    <document_congress>119</document_congress>
+    <document_type>S.</document_type>
+    <document_number>5</document_number>
+    <document_name>S. 5</document_name>
+    <document_title>A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</document_title>
+    <document_short_title/>
+  </document>
+  <amendment>
+    <amendment_number/>
+    <amendment_to_amendment_number/>
+    <amendment_to_amendment_to_amendment_number/>
+    <amendment_to_document_number/>
+    <amendment_to_document_short_title/>
+    <amendment_purpose>No Statement of Purpose on File.</amendment_purpose>
+  </amendment>
+  <count>
+    <yeas>64</yeas>
+    <nays>35</nays>
+    <present/>
+    <absent/>
+  </count>
+  <tie_breaker>
+    <by_whom/>
+    <tie_breaker_vote/>
+  </tie_breaker>
+  <members>
+    <member>
+      <member_full>Alsobrooks (D-MD)</member_full>
+      <last_name>Alsobrooks</last_name>
+      <first_name>Angela</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S428</lis_member_id>
+    </member>
+    <member>
+      <member_full>Baldwin (D-WI)</member_full>
+      <last_name>Baldwin</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>WI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S354</lis_member_id>
+    </member>
+    <member>
+      <member_full>Banks (R-IN)</member_full>
+      <last_name>Banks</last_name>
+      <first_name>Jim</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S429</lis_member_id>
+    </member>
+    <member>
+      <member_full>Barrasso (R-WY)</member_full>
+      <last_name>Barrasso</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S317</lis_member_id>
+    </member>
+    <member>
+      <member_full>Bennet (D-CO)</member_full>
+      <last_name>Bennet</last_name>
+      <first_name>Michael</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S330</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blackburn (R-TN)</member_full>
+      <last_name>Blackburn</last_name>
+      <first_name>Marsha</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S396</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blumenthal (D-CT)</member_full>
+      <last_name>Blumenthal</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S341</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blunt Rochester (D-DE)</member_full>
+      <last_name>Blunt Rochester</last_name>
+      <first_name>Lisa</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S430</lis_member_id>
+    </member>
+    <member>
+      <member_full>Booker (D-NJ)</member_full>
+      <last_name>Booker</last_name>
+      <first_name>Cory</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S370</lis_member_id>
+    </member>
+    <member>
+      <member_full>Boozman (R-AR)</member_full>
+      <last_name>Boozman</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S343</lis_member_id>
+    </member>
+    <member>
+      <member_full>Britt (R-AL)</member_full>
+      <last_name>Britt</last_name>
+      <first_name>Katie</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S416</lis_member_id>
+    </member>
+    <member>
+      <member_full>Budd (R-NC)</member_full>
+      <last_name>Budd</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S417</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cantwell (D-WA)</member_full>
+      <last_name>Cantwell</last_name>
+      <first_name>Maria</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S275</lis_member_id>
+    </member>
+    <member>
+      <member_full>Capito (R-WV)</member_full>
+      <last_name>Capito</last_name>
+      <first_name>Shelley</first_name>
+      <party>R</party>
+      <state>WV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S372</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cassidy (R-LA)</member_full>
+      <last_name>Cassidy</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S373</lis_member_id>
+    </member>
+    <member>
+      <member_full>Collins (R-ME)</member_full>
+      <last_name>Collins</last_name>
+      <first_name>Susan</first_name>
+      <party>R</party>
+      <state>ME</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S252</lis_member_id>
+    </member>
+    <member>
+      <member_full>Coons (D-DE)</member_full>
+      <last_name>Coons</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S337</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cornyn (R-TX)</member_full>
+      <last_name>Cornyn</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S287</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cortez Masto (D-NV)</member_full>
+      <last_name>Cortez Masto</last_name>
+      <first_name>Catherine</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S385</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cotton (R-AR)</member_full>
+      <last_name>Cotton</last_name>
+      <first_name>Tom</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S374</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cramer (R-ND)</member_full>
+      <last_name>Cramer</last_name>
+      <first_name>Kevin</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S398</lis_member_id>
+    </member>
+    <member>
+      <member_full>Crapo (R-ID)</member_full>
+      <last_name>Crapo</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S266</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cruz (R-TX)</member_full>
+      <last_name>Cruz</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S355</lis_member_id>
+    </member>
+    <member>
+      <member_full>Curtis (R-UT)</member_full>
+      <last_name>Curtis</last_name>
+      <first_name>John </first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S431</lis_member_id>
+    </member>
+    <member>
+      <member_full>Daines (R-MT)</member_full>
+      <last_name>Daines</last_name>
+      <first_name>Steve</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S375</lis_member_id>
+    </member>
+    <member>
+      <member_full>Duckworth (D-IL)</member_full>
+      <last_name>Duckworth</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S386</lis_member_id>
+    </member>
+    <member>
+      <member_full>Durbin (D-IL)</member_full>
+      <last_name>Durbin</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S253</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ernst (R-IA)</member_full>
+      <last_name>Ernst</last_name>
+      <first_name>Joni</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S376</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fetterman (D-PA)</member_full>
+      <last_name>Fetterman</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>PA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S418</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fischer (R-NE)</member_full>
+      <last_name>Fischer</last_name>
+      <first_name>Deb</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S357</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gallego (D-AZ)</member_full>
+      <last_name>Gallego</last_name>
+      <first_name>Ruben</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S432</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gillibrand (D-NY)</member_full>
+      <last_name>Gillibrand</last_name>
+      <first_name>Kirsten</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S331</lis_member_id>
+    </member>
+    <member>
+      <member_full>Graham (R-SC)</member_full>
+      <last_name>Graham</last_name>
+      <first_name>Lindsey</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S293</lis_member_id>
+    </member>
+    <member>
+      <member_full>Grassley (R-IA)</member_full>
+      <last_name>Grassley</last_name>
+      <first_name>Chuck</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S153</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hagerty (R-TN)</member_full>
+      <last_name>Hagerty</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S407</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hassan (D-NH)</member_full>
+      <last_name>Hassan</last_name>
+      <first_name>Maggie</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S388</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hawley (R-MO)</member_full>
+      <last_name>Hawley</last_name>
+      <first_name>Josh</first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S399</lis_member_id>
+    </member>
+    <member>
+      <member_full>Heinrich (D-NM)</member_full>
+      <last_name>Heinrich</last_name>
+      <first_name>Martin</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S359</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hickenlooper (D-CO)</member_full>
+      <last_name>Hickenlooper</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S408</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hirono (D-HI)</member_full>
+      <last_name>Hirono</last_name>
+      <first_name>Mazie</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S361</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hoeven (R-ND)</member_full>
+      <last_name>Hoeven</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S344</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hyde-Smith (R-MS)</member_full>
+      <last_name>Hyde-Smith</last_name>
+      <first_name>Cindy</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S395</lis_member_id>
+    </member>
+    <member>
+      <member_full>Johnson (R-WI)</member_full>
+      <last_name>Johnson</last_name>
+      <first_name>Ron</first_name>
+      <party>R</party>
+      <state>WI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S345</lis_member_id>
+    </member>
+    <member>
+      <member_full>Justice (R-WV)</member_full>
+      <last_name>Justice</last_name>
+      <first_name>James</first_name>
+      <party>R</party>
+      <state>WV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S437</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kaine (D-VA)</member_full>
+      <last_name>Kaine</last_name>
+      <first_name>Timothy</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S362</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kelly (D-AZ)</member_full>
+      <last_name>Kelly</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S406</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kennedy (R-LA)</member_full>
+      <last_name>Kennedy</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S389</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kim (D-NJ)</member_full>
+      <last_name>Kim</last_name>
+      <first_name>Andy</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S426</lis_member_id>
+    </member>
+    <member>
+      <member_full>King (I-ME)</member_full>
+      <last_name>King</last_name>
+      <first_name>Angus</first_name>
+      <party>I</party>
+      <state>ME</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S363</lis_member_id>
+    </member>
+    <member>
+      <member_full>Klobuchar (D-MN)</member_full>
+      <last_name>Klobuchar</last_name>
+      <first_name>Amy</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S311</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lankford (R-OK)</member_full>
+      <last_name>Lankford</last_name>
+      <first_name>James</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S378</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lee (R-UT)</member_full>
+      <last_name>Lee</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S346</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lujan (D-NM)</member_full>
+      <last_name>Lujan</last_name>
+      <first_name>Ben</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S409</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lummis (R-WY)</member_full>
+      <last_name>Lummis</last_name>
+      <first_name>Cynthia</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S410</lis_member_id>
+    </member>
+    <member>
+      <member_full>Markey (D-MA)</member_full>
+      <last_name>Markey</last_name>
+      <first_name>Edward</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S369</lis_member_id>
+    </member>
+    <member>
+      <member_full>Marshall (R-KS)</member_full>
+      <last_name>Marshall</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S411</lis_member_id>
+    </member>
+    <member>
+      <member_full>McConnell (R-KY)</member_full>
+      <last_name>McConnell</last_name>
+      <first_name>Mitch</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S174</lis_member_id>
+    </member>
+    <member>
+      <member_full>McCormick (R-PA)</member_full>
+      <last_name>McCormick</last_name>
+      <first_name>David</first_name>
+      <party>R</party>
+      <state>PA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S433</lis_member_id>
+    </member>
+    <member>
+      <member_full>Merkley (D-OR)</member_full>
+      <last_name>Merkley</last_name>
+      <first_name>Jeff</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S322</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moran (R-KS)</member_full>
+      <last_name>Moran</last_name>
+      <first_name>Jerry</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S347</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moreno (R-OH)</member_full>
+      <last_name>Moreno</last_name>
+      <first_name>Bernie</first_name>
+      <party>R</party>
+      <state>OH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S434</lis_member_id>
+    </member>
+    <member>
+      <member_full>Mullin (R-OK)</member_full>
+      <last_name>Mullin</last_name>
+      <first_name>Markwayne</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S419</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murkowski (R-AK)</member_full>
+      <last_name>Murkowski</last_name>
+      <first_name>Lisa</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S288</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murphy (D-CT)</member_full>
+      <last_name>Murphy</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S364</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murray (D-WA)</member_full>
+      <last_name>Murray</last_name>
+      <first_name>Patty</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S229</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ossoff (D-GA)</member_full>
+      <last_name>Ossoff</last_name>
+      <first_name>Jon</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S414</lis_member_id>
+    </member>
+    <member>
+      <member_full>Padilla (D-CA)</member_full>
+      <last_name>Padilla</last_name>
+      <first_name>Alex</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S413</lis_member_id>
+    </member>
+    <member>
+      <member_full>Paul (R-KY)</member_full>
+      <last_name>Paul</last_name>
+      <first_name>Rand</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S348</lis_member_id>
+    </member>
+    <member>
+      <member_full>Peters (D-MI)</member_full>
+      <last_name>Peters</last_name>
+      <first_name>Gary</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S380</lis_member_id>
+    </member>
+    <member>
+      <member_full>Reed (D-RI)</member_full>
+      <last_name>Reed</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S259</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ricketts (R-NE)</member_full>
+      <last_name>Ricketts</last_name>
+      <first_name>Pete</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S423</lis_member_id>
+    </member>
+    <member>
+      <member_full>Risch (R-ID)</member_full>
+      <last_name>Risch</last_name>
+      <first_name>James </first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S323</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rosen (D-NV)</member_full>
+      <last_name>Rosen</last_name>
+      <first_name>Jacky</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S402</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rounds (R-SD)</member_full>
+      <last_name>Rounds</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S381</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rubio (R-FL)</member_full>
+      <last_name>Rubio</last_name>
+      <first_name>Marco</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S350</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sanders (I-VT)</member_full>
+      <last_name>Sanders</last_name>
+      <first_name>Bernie</first_name>
+      <party>I</party>
+      <state>VT</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S313</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schatz (D-HI)</member_full>
+      <last_name>Schatz</last_name>
+      <first_name>Brian</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S353</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schiff (D-CA)</member_full>
+      <last_name>Schiff</last_name>
+      <first_name>Adam</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S427</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schmitt (R-MO)</member_full>
+      <last_name>Schmitt</last_name>
+      <first_name>Eric </first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S420</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schumer (D-NY)</member_full>
+      <last_name>Schumer</last_name>
+      <first_name>Charles</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S270</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-FL)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Rick</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S404</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-SC)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S365</lis_member_id>
+    </member>
+    <member>
+      <member_full>Shaheen (D-NH)</member_full>
+      <last_name>Shaheen</last_name>
+      <first_name>Jeanne</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S324</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sheehy (R-MT)</member_full>
+      <last_name>Sheehy</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S435</lis_member_id>
+    </member>
+    <member>
+      <member_full>Slotkin (D-MI)</member_full>
+      <last_name>Slotkin</last_name>
+      <first_name>Elissa</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S436</lis_member_id>
+    </member>
+    <member>
+      <member_full>Smith (D-MN)</member_full>
+      <last_name>Smith</last_name>
+      <first_name>Tina</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S394</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sullivan (R-AK)</member_full>
+      <last_name>Sullivan</last_name>
+      <first_name>Dan</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S383</lis_member_id>
+    </member>
+    <member>
+      <member_full>Thune (R-SD)</member_full>
+      <last_name>Thune</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S303</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tillis (R-NC)</member_full>
+      <last_name>Tillis</last_name>
+      <first_name>Thomas</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S384</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tuberville (R-AL)</member_full>
+      <last_name>Tuberville</last_name>
+      <first_name>Tommy</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S412</lis_member_id>
+    </member>
+    <member>
+      <member_full>Van Hollen (D-MD)</member_full>
+      <last_name>Van Hollen</last_name>
+      <first_name>Chris</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S390</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warner (D-VA)</member_full>
+      <last_name>Warner</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S327</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warnock (D-GA)</member_full>
+      <last_name>Warnock</last_name>
+      <first_name>Raphael</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S415</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warren (D-MA)</member_full>
+      <last_name>Warren</last_name>
+      <first_name>Elizabeth</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S366</lis_member_id>
+    </member>
+    <member>
+      <member_full>Welch (D-VT)</member_full>
+      <last_name>Welch</last_name>
+      <first_name>Peter</first_name>
+      <party>D</party>
+      <state>VT</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S422</lis_member_id>
+    </member>
+    <member>
+      <member_full>Whitehouse (D-RI)</member_full>
+      <last_name>Whitehouse</last_name>
+      <first_name>Sheldon</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S316</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wicker (R-MS)</member_full>
+      <last_name>Wicker</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S318</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wyden (D-OR)</member_full>
+      <last_name>Wyden</last_name>
+      <first_name>Ron</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Nay</vote_cast>
+      <lis_member_id>S247</lis_member_id>
+    </member>
+    <member>
+      <member_full>Young (R-IN)</member_full>
+      <last_name>Young</last_name>
+      <first_name>Todd</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S391</lis_member_id>
+    </member>
+  </members>
+</roll_call_vote>

--- a/tests/fixtures/senate/detail_119_1_00008_nomination.xml
+++ b/tests/fixtures/senate/detail_119_1_00008_nomination.xml
@@ -1,0 +1,934 @@
+<?xml version="1.0" encoding="UTF-8"?><roll_call_vote>
+  <congress>119</congress>
+  <session>1</session>
+  <congress_year>2025</congress_year>
+  <vote_number>8</vote_number>
+  <vote_date>January 20, 2025,  06:35 PM</vote_date>
+  <modify_date>January 20, 2025,  07:17 PM</modify_date>
+  <vote_question_text>On the Nomination PN11-13</vote_question_text>
+  <vote_document_text>Marco Rubio, of Florida, to be Secretary of State</vote_document_text>
+  <vote_result_text>Nomination Confirmed (99-0)</vote_result_text>
+  <question>On the Nomination</question>
+  <vote_title>Confirmation: Marco Rubio, of Florida, to be Secretary of State</vote_title>
+  <majority_requirement>1/2</majority_requirement>
+  <vote_result>Nomination Confirmed</vote_result>
+  <document>
+    <document_congress>119</document_congress>
+    <document_type>PN</document_type>
+    <document_number>11-13</document_number>
+    <document_name>PN11-13</document_name>
+    <document_title>Marco Rubio, of Florida, to be Secretary of State</document_title>
+    <document_short_title/>
+  </document>
+  <amendment>
+    <amendment_number/>
+    <amendment_to_amendment_number/>
+    <amendment_to_amendment_to_amendment_number/>
+    <amendment_to_document_number/>
+    <amendment_to_document_short_title/>
+    <amendment_purpose>No Statement of Purpose on File.</amendment_purpose>
+  </amendment>
+  <count>
+    <yeas>99</yeas>
+    <nays>0</nays>
+    <present/>
+    <absent/>
+  </count>
+  <tie_breaker>
+    <by_whom/>
+    <tie_breaker_vote/>
+  </tie_breaker>
+  <members>
+    <member>
+      <member_full>Alsobrooks (D-MD)</member_full>
+      <last_name>Alsobrooks</last_name>
+      <first_name>Angela</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S428</lis_member_id>
+    </member>
+    <member>
+      <member_full>Baldwin (D-WI)</member_full>
+      <last_name>Baldwin</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>WI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S354</lis_member_id>
+    </member>
+    <member>
+      <member_full>Banks (R-IN)</member_full>
+      <last_name>Banks</last_name>
+      <first_name>Jim</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S429</lis_member_id>
+    </member>
+    <member>
+      <member_full>Barrasso (R-WY)</member_full>
+      <last_name>Barrasso</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S317</lis_member_id>
+    </member>
+    <member>
+      <member_full>Bennet (D-CO)</member_full>
+      <last_name>Bennet</last_name>
+      <first_name>Michael</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S330</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blackburn (R-TN)</member_full>
+      <last_name>Blackburn</last_name>
+      <first_name>Marsha</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S396</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blumenthal (D-CT)</member_full>
+      <last_name>Blumenthal</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S341</lis_member_id>
+    </member>
+    <member>
+      <member_full>Blunt Rochester (D-DE)</member_full>
+      <last_name>Blunt Rochester</last_name>
+      <first_name>Lisa</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S430</lis_member_id>
+    </member>
+    <member>
+      <member_full>Booker (D-NJ)</member_full>
+      <last_name>Booker</last_name>
+      <first_name>Cory</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S370</lis_member_id>
+    </member>
+    <member>
+      <member_full>Boozman (R-AR)</member_full>
+      <last_name>Boozman</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S343</lis_member_id>
+    </member>
+    <member>
+      <member_full>Britt (R-AL)</member_full>
+      <last_name>Britt</last_name>
+      <first_name>Katie</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S416</lis_member_id>
+    </member>
+    <member>
+      <member_full>Budd (R-NC)</member_full>
+      <last_name>Budd</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S417</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cantwell (D-WA)</member_full>
+      <last_name>Cantwell</last_name>
+      <first_name>Maria</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S275</lis_member_id>
+    </member>
+    <member>
+      <member_full>Capito (R-WV)</member_full>
+      <last_name>Capito</last_name>
+      <first_name>Shelley</first_name>
+      <party>R</party>
+      <state>WV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S372</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cassidy (R-LA)</member_full>
+      <last_name>Cassidy</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S373</lis_member_id>
+    </member>
+    <member>
+      <member_full>Collins (R-ME)</member_full>
+      <last_name>Collins</last_name>
+      <first_name>Susan</first_name>
+      <party>R</party>
+      <state>ME</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S252</lis_member_id>
+    </member>
+    <member>
+      <member_full>Coons (D-DE)</member_full>
+      <last_name>Coons</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>DE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S337</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cornyn (R-TX)</member_full>
+      <last_name>Cornyn</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S287</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cortez Masto (D-NV)</member_full>
+      <last_name>Cortez Masto</last_name>
+      <first_name>Catherine</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S385</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cotton (R-AR)</member_full>
+      <last_name>Cotton</last_name>
+      <first_name>Tom</first_name>
+      <party>R</party>
+      <state>AR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S374</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cramer (R-ND)</member_full>
+      <last_name>Cramer</last_name>
+      <first_name>Kevin</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S398</lis_member_id>
+    </member>
+    <member>
+      <member_full>Crapo (R-ID)</member_full>
+      <last_name>Crapo</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S266</lis_member_id>
+    </member>
+    <member>
+      <member_full>Cruz (R-TX)</member_full>
+      <last_name>Cruz</last_name>
+      <first_name>Ted</first_name>
+      <party>R</party>
+      <state>TX</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S355</lis_member_id>
+    </member>
+    <member>
+      <member_full>Curtis (R-UT)</member_full>
+      <last_name>Curtis</last_name>
+      <first_name>John </first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S431</lis_member_id>
+    </member>
+    <member>
+      <member_full>Daines (R-MT)</member_full>
+      <last_name>Daines</last_name>
+      <first_name>Steve</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S375</lis_member_id>
+    </member>
+    <member>
+      <member_full>Duckworth (D-IL)</member_full>
+      <last_name>Duckworth</last_name>
+      <first_name>Tammy</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S386</lis_member_id>
+    </member>
+    <member>
+      <member_full>Durbin (D-IL)</member_full>
+      <last_name>Durbin</last_name>
+      <first_name>Richard</first_name>
+      <party>D</party>
+      <state>IL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S253</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ernst (R-IA)</member_full>
+      <last_name>Ernst</last_name>
+      <first_name>Joni</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S376</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fetterman (D-PA)</member_full>
+      <last_name>Fetterman</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>PA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S418</lis_member_id>
+    </member>
+    <member>
+      <member_full>Fischer (R-NE)</member_full>
+      <last_name>Fischer</last_name>
+      <first_name>Deb</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S357</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gallego (D-AZ)</member_full>
+      <last_name>Gallego</last_name>
+      <first_name>Ruben</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S432</lis_member_id>
+    </member>
+    <member>
+      <member_full>Gillibrand (D-NY)</member_full>
+      <last_name>Gillibrand</last_name>
+      <first_name>Kirsten</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S331</lis_member_id>
+    </member>
+    <member>
+      <member_full>Graham (R-SC)</member_full>
+      <last_name>Graham</last_name>
+      <first_name>Lindsey</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S293</lis_member_id>
+    </member>
+    <member>
+      <member_full>Grassley (R-IA)</member_full>
+      <last_name>Grassley</last_name>
+      <first_name>Chuck</first_name>
+      <party>R</party>
+      <state>IA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S153</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hagerty (R-TN)</member_full>
+      <last_name>Hagerty</last_name>
+      <first_name>Bill</first_name>
+      <party>R</party>
+      <state>TN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S407</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hassan (D-NH)</member_full>
+      <last_name>Hassan</last_name>
+      <first_name>Maggie</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S388</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hawley (R-MO)</member_full>
+      <last_name>Hawley</last_name>
+      <first_name>Josh</first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S399</lis_member_id>
+    </member>
+    <member>
+      <member_full>Heinrich (D-NM)</member_full>
+      <last_name>Heinrich</last_name>
+      <first_name>Martin</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S359</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hickenlooper (D-CO)</member_full>
+      <last_name>Hickenlooper</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>CO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S408</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hirono (D-HI)</member_full>
+      <last_name>Hirono</last_name>
+      <first_name>Mazie</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S361</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hoeven (R-ND)</member_full>
+      <last_name>Hoeven</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>ND</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S344</lis_member_id>
+    </member>
+    <member>
+      <member_full>Hyde-Smith (R-MS)</member_full>
+      <last_name>Hyde-Smith</last_name>
+      <first_name>Cindy</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S395</lis_member_id>
+    </member>
+    <member>
+      <member_full>Johnson (R-WI)</member_full>
+      <last_name>Johnson</last_name>
+      <first_name>Ron</first_name>
+      <party>R</party>
+      <state>WI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S345</lis_member_id>
+    </member>
+    <member>
+      <member_full>Justice (R-WV)</member_full>
+      <last_name>Justice</last_name>
+      <first_name>James</first_name>
+      <party>R</party>
+      <state>WV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S437</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kaine (D-VA)</member_full>
+      <last_name>Kaine</last_name>
+      <first_name>Timothy</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S362</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kelly (D-AZ)</member_full>
+      <last_name>Kelly</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>AZ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S406</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kennedy (R-LA)</member_full>
+      <last_name>Kennedy</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>LA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S389</lis_member_id>
+    </member>
+    <member>
+      <member_full>Kim (D-NJ)</member_full>
+      <last_name>Kim</last_name>
+      <first_name>Andy</first_name>
+      <party>D</party>
+      <state>NJ</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S426</lis_member_id>
+    </member>
+    <member>
+      <member_full>King (I-ME)</member_full>
+      <last_name>King</last_name>
+      <first_name>Angus</first_name>
+      <party>I</party>
+      <state>ME</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S363</lis_member_id>
+    </member>
+    <member>
+      <member_full>Klobuchar (D-MN)</member_full>
+      <last_name>Klobuchar</last_name>
+      <first_name>Amy</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S311</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lankford (R-OK)</member_full>
+      <last_name>Lankford</last_name>
+      <first_name>James</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S378</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lee (R-UT)</member_full>
+      <last_name>Lee</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>UT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S346</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lujan (D-NM)</member_full>
+      <last_name>Lujan</last_name>
+      <first_name>Ben</first_name>
+      <party>D</party>
+      <state>NM</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S409</lis_member_id>
+    </member>
+    <member>
+      <member_full>Lummis (R-WY)</member_full>
+      <last_name>Lummis</last_name>
+      <first_name>Cynthia</first_name>
+      <party>R</party>
+      <state>WY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S410</lis_member_id>
+    </member>
+    <member>
+      <member_full>Markey (D-MA)</member_full>
+      <last_name>Markey</last_name>
+      <first_name>Edward</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S369</lis_member_id>
+    </member>
+    <member>
+      <member_full>Marshall (R-KS)</member_full>
+      <last_name>Marshall</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S411</lis_member_id>
+    </member>
+    <member>
+      <member_full>McConnell (R-KY)</member_full>
+      <last_name>McConnell</last_name>
+      <first_name>Mitch</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S174</lis_member_id>
+    </member>
+    <member>
+      <member_full>McCormick (R-PA)</member_full>
+      <last_name>McCormick</last_name>
+      <first_name>David</first_name>
+      <party>R</party>
+      <state>PA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S433</lis_member_id>
+    </member>
+    <member>
+      <member_full>Merkley (D-OR)</member_full>
+      <last_name>Merkley</last_name>
+      <first_name>Jeff</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S322</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moran (R-KS)</member_full>
+      <last_name>Moran</last_name>
+      <first_name>Jerry</first_name>
+      <party>R</party>
+      <state>KS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S347</lis_member_id>
+    </member>
+    <member>
+      <member_full>Moreno (R-OH)</member_full>
+      <last_name>Moreno</last_name>
+      <first_name>Bernie</first_name>
+      <party>R</party>
+      <state>OH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S434</lis_member_id>
+    </member>
+    <member>
+      <member_full>Mullin (R-OK)</member_full>
+      <last_name>Mullin</last_name>
+      <first_name>Markwayne</first_name>
+      <party>R</party>
+      <state>OK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S419</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murkowski (R-AK)</member_full>
+      <last_name>Murkowski</last_name>
+      <first_name>Lisa</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S288</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murphy (D-CT)</member_full>
+      <last_name>Murphy</last_name>
+      <first_name>Christopher</first_name>
+      <party>D</party>
+      <state>CT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S364</lis_member_id>
+    </member>
+    <member>
+      <member_full>Murray (D-WA)</member_full>
+      <last_name>Murray</last_name>
+      <first_name>Patty</first_name>
+      <party>D</party>
+      <state>WA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S229</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ossoff (D-GA)</member_full>
+      <last_name>Ossoff</last_name>
+      <first_name>Jon</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S414</lis_member_id>
+    </member>
+    <member>
+      <member_full>Padilla (D-CA)</member_full>
+      <last_name>Padilla</last_name>
+      <first_name>Alex</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S413</lis_member_id>
+    </member>
+    <member>
+      <member_full>Paul (R-KY)</member_full>
+      <last_name>Paul</last_name>
+      <first_name>Rand</first_name>
+      <party>R</party>
+      <state>KY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S348</lis_member_id>
+    </member>
+    <member>
+      <member_full>Peters (D-MI)</member_full>
+      <last_name>Peters</last_name>
+      <first_name>Gary</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S380</lis_member_id>
+    </member>
+    <member>
+      <member_full>Reed (D-RI)</member_full>
+      <last_name>Reed</last_name>
+      <first_name>John</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S259</lis_member_id>
+    </member>
+    <member>
+      <member_full>Ricketts (R-NE)</member_full>
+      <last_name>Ricketts</last_name>
+      <first_name>Pete</first_name>
+      <party>R</party>
+      <state>NE</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S423</lis_member_id>
+    </member>
+    <member>
+      <member_full>Risch (R-ID)</member_full>
+      <last_name>Risch</last_name>
+      <first_name>James </first_name>
+      <party>R</party>
+      <state>ID</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S323</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rosen (D-NV)</member_full>
+      <last_name>Rosen</last_name>
+      <first_name>Jacky</first_name>
+      <party>D</party>
+      <state>NV</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S402</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rounds (R-SD)</member_full>
+      <last_name>Rounds</last_name>
+      <first_name>Mike</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S381</lis_member_id>
+    </member>
+    <member>
+      <member_full>Rubio (R-FL)</member_full>
+      <last_name>Rubio</last_name>
+      <first_name>Marco</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S350</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sanders (I-VT)</member_full>
+      <last_name>Sanders</last_name>
+      <first_name>Bernie</first_name>
+      <party>I</party>
+      <state>VT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S313</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schatz (D-HI)</member_full>
+      <last_name>Schatz</last_name>
+      <first_name>Brian</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S353</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schiff (D-CA)</member_full>
+      <last_name>Schiff</last_name>
+      <first_name>Adam</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S427</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schmitt (R-MO)</member_full>
+      <last_name>Schmitt</last_name>
+      <first_name>Eric </first_name>
+      <party>R</party>
+      <state>MO</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S420</lis_member_id>
+    </member>
+    <member>
+      <member_full>Schumer (D-NY)</member_full>
+      <last_name>Schumer</last_name>
+      <first_name>Charles</first_name>
+      <party>D</party>
+      <state>NY</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S270</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-FL)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Rick</first_name>
+      <party>R</party>
+      <state>FL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S404</lis_member_id>
+    </member>
+    <member>
+      <member_full>Scott (R-SC)</member_full>
+      <last_name>Scott</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>SC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S365</lis_member_id>
+    </member>
+    <member>
+      <member_full>Shaheen (D-NH)</member_full>
+      <last_name>Shaheen</last_name>
+      <first_name>Jeanne</first_name>
+      <party>D</party>
+      <state>NH</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S324</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sheehy (R-MT)</member_full>
+      <last_name>Sheehy</last_name>
+      <first_name>Tim</first_name>
+      <party>R</party>
+      <state>MT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S435</lis_member_id>
+    </member>
+    <member>
+      <member_full>Slotkin (D-MI)</member_full>
+      <last_name>Slotkin</last_name>
+      <first_name>Elissa</first_name>
+      <party>D</party>
+      <state>MI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S436</lis_member_id>
+    </member>
+    <member>
+      <member_full>Smith (D-MN)</member_full>
+      <last_name>Smith</last_name>
+      <first_name>Tina</first_name>
+      <party>D</party>
+      <state>MN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S394</lis_member_id>
+    </member>
+    <member>
+      <member_full>Sullivan (R-AK)</member_full>
+      <last_name>Sullivan</last_name>
+      <first_name>Dan</first_name>
+      <party>R</party>
+      <state>AK</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S383</lis_member_id>
+    </member>
+    <member>
+      <member_full>Thune (R-SD)</member_full>
+      <last_name>Thune</last_name>
+      <first_name>John</first_name>
+      <party>R</party>
+      <state>SD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S303</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tillis (R-NC)</member_full>
+      <last_name>Tillis</last_name>
+      <first_name>Thomas</first_name>
+      <party>R</party>
+      <state>NC</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S384</lis_member_id>
+    </member>
+    <member>
+      <member_full>Tuberville (R-AL)</member_full>
+      <last_name>Tuberville</last_name>
+      <first_name>Tommy</first_name>
+      <party>R</party>
+      <state>AL</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S412</lis_member_id>
+    </member>
+    <member>
+      <member_full>Van Hollen (D-MD)</member_full>
+      <last_name>Van Hollen</last_name>
+      <first_name>Chris</first_name>
+      <party>D</party>
+      <state>MD</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S390</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warner (D-VA)</member_full>
+      <last_name>Warner</last_name>
+      <first_name>Mark</first_name>
+      <party>D</party>
+      <state>VA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S327</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warnock (D-GA)</member_full>
+      <last_name>Warnock</last_name>
+      <first_name>Raphael</first_name>
+      <party>D</party>
+      <state>GA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S415</lis_member_id>
+    </member>
+    <member>
+      <member_full>Warren (D-MA)</member_full>
+      <last_name>Warren</last_name>
+      <first_name>Elizabeth</first_name>
+      <party>D</party>
+      <state>MA</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S366</lis_member_id>
+    </member>
+    <member>
+      <member_full>Welch (D-VT)</member_full>
+      <last_name>Welch</last_name>
+      <first_name>Peter</first_name>
+      <party>D</party>
+      <state>VT</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S422</lis_member_id>
+    </member>
+    <member>
+      <member_full>Whitehouse (D-RI)</member_full>
+      <last_name>Whitehouse</last_name>
+      <first_name>Sheldon</first_name>
+      <party>D</party>
+      <state>RI</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S316</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wicker (R-MS)</member_full>
+      <last_name>Wicker</last_name>
+      <first_name>Roger</first_name>
+      <party>R</party>
+      <state>MS</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S318</lis_member_id>
+    </member>
+    <member>
+      <member_full>Wyden (D-OR)</member_full>
+      <last_name>Wyden</last_name>
+      <first_name>Ron</first_name>
+      <party>D</party>
+      <state>OR</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S247</lis_member_id>
+    </member>
+    <member>
+      <member_full>Young (R-IN)</member_full>
+      <last_name>Young</last_name>
+      <first_name>Todd</first_name>
+      <party>R</party>
+      <state>IN</state>
+      <vote_cast>Yea</vote_cast>
+      <lis_member_id>S391</lis_member_id>
+    </member>
+  </members>
+</roll_call_vote>

--- a/tests/fixtures/senate/senators_cfm.xml
+++ b/tests/fixtures/senate/senators_cfm.xml
@@ -1,0 +1,1210 @@
+<?xml version="1.0" encoding="UTF-8"?><contact_information><member>
+        <member_full>Alsobrooks (D-MD)</member_full>
+        <last_name>Alsobrooks</last_name> 
+        <first_name>Angela D.</first_name> 
+        <party>D</party>
+        <state>MD</state>
+        <address>374 Russell Senate Office Building Washington DC 20510</address> 
+        <phone>(202) 224-4524</phone>
+        <email>https://alsobrooks.senate.gov/</email>
+        <website>https://alsobrooks.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>A000382</bioguide_id>
+    </member><member>
+        <member_full>Armstrong (R-OK)</member_full>
+        <last_name>Armstrong</last_name>
+        <first_name>Alan</first_name>
+        <party>R</party>
+        <state>OK</state>
+        <address>330 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4721</phone>
+        <email>https://www.armstrong.senate.gov/</email>
+        <website>https://www.armstrong.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>A000383</bioguide_id>
+    </member><member>
+        <member_full>Baldwin (D-WI)</member_full>
+        <last_name>Baldwin</last_name> 
+        <first_name>Tammy</first_name> 
+        <party>D</party>
+        <state>WI</state>
+        <address>141 Hart Senate Office Building Washington DC 20510</address> 
+        <phone>(202) 224-5653</phone>
+        <email>https://www.baldwin.senate.gov/feedback</email>
+        <website>https://www.baldwin.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>B001230</bioguide_id>
+    </member><member>
+        <member_full>Banks (R-IN)</member_full>
+        <last_name>Banks</last_name>
+        <first_name>Jim</first_name>
+        <party>R</party>
+        <state>IN</state>
+        <address>303 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4814</phone>
+        <email>https://www.banks.senate.gov/</email>
+        <website>https://www.banks.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>B001299</bioguide_id>
+    </member><member>
+        <member_full>Barrasso (R-WY)</member_full>
+        <last_name>Barrasso</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>WY</state>
+        <address>307 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6441</phone>
+        <email>https://www.barrasso.senate.gov/public/index.cfm/contact-form</email>
+        <website>https://www.barrasso.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>B001261</bioguide_id>
+        <leadership_position>Majority Whip</leadership_position>
+    </member><member>
+        <member_full>Bennet (D-CO)</member_full>
+        <last_name>Bennet</last_name>
+        <first_name>Michael F.</first_name>
+        <party>D</party>
+        <state>CO</state>
+        <address>261 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5852</phone>
+        <email>https://www.bennet.senate.gov/public/index.cfm/contact</email>
+        <website>https://www.bennet.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>B001267</bioguide_id>
+    </member><member>
+        <member_full>Blackburn (R-TN)</member_full>
+        <last_name>Blackburn</last_name>
+        <first_name>Marsha</first_name>
+        <party>R</party>
+        <state>TN</state>
+        <address>357 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3344</phone>
+        <email>https://www.blackburn.senate.gov/email-me</email>
+        <website>https://www.blackburn.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>B001243</bioguide_id>
+    </member><member>
+        <member_full>Blumenthal (D-CT)</member_full>
+        <last_name>Blumenthal</last_name>
+        <first_name>Richard</first_name>
+        <party>D</party>
+        <state>CT</state>
+        <address>503 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2823</phone>
+        <email>https://www.blumenthal.senate.gov/contact/</email>
+        <website>https://www.blumenthal.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>B001277</bioguide_id>
+    </member><member>
+        <member_full>Blunt Rochester (D-DE)</member_full>
+        <last_name>Blunt Rochester</last_name>
+        <first_name>Lisa</first_name>
+        <party>D</party>
+        <state>DE</state>
+        <address>513 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2441</phone>
+        <email>https://www.bluntrochester.senate.gov/</email>
+        <website>https://www.bluntrochester.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>B001303</bioguide_id>
+    </member><member>
+        <member_full>Booker (D-NJ)</member_full>
+        <last_name>Booker</last_name>
+        <first_name>Cory A.</first_name>
+        <party>D</party>
+        <state>NJ</state>
+        <address>B40E Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3224</phone>
+        <email>https://www.booker.senate.gov/?p=contact</email>
+        <website>https://www.booker.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>B001288</bioguide_id>
+    </member><member>
+        <member_full>Boozman (R-AR)</member_full>
+        <last_name>Boozman</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>AR</state>
+        <address>555 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4843</phone>
+        <email>https://www.boozman.senate.gov/public/index.cfm/contact</email>
+        <website>https://www.boozman.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>B001236</bioguide_id>
+    </member><member>
+        <member_full>Britt (R-AL)</member_full>
+        <last_name>Britt</last_name>
+        <first_name>Katie Boyd</first_name>
+        <party>R</party>
+        <state>AL</state>
+        <address>416 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5744</phone>
+        <email>https://www.britt.senate.gov/contact/</email>
+        <website>https://www.britt.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>B001319</bioguide_id>
+    </member><member>
+        <member_full>Budd (R-NC)</member_full>
+        <last_name>Budd</last_name>
+        <first_name>Ted</first_name>
+        <party>R</party>
+        <state>NC</state>
+        <address>354 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3154</phone>
+        <email>https://www.budd.senate.gov/contact/</email>
+        <website>https://www.budd.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>B001305</bioguide_id>
+    </member><member>
+        <member_full>Cantwell (D-WA)</member_full>
+        <last_name>Cantwell</last_name>
+        <first_name>Maria</first_name>
+        <party>D</party>
+        <state>WA</state>
+        <address>511 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3441</phone>
+        <email>https://www.cantwell.senate.gov/public/index.cfm/email-maria</email>
+        <website>https://www.cantwell.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>C000127</bioguide_id>
+    </member><member>
+        <member_full>Capito (R-WV)</member_full>
+        <last_name>Capito</last_name>
+        <first_name>Shelley Moore</first_name>
+        <party>R</party>
+        <state>WV</state>
+        <address>170 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6472</phone>
+        <email>https://www.capito.senate.gov/contact/contact-shelley</email>
+        <website>https://www.capito.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>C001047</bioguide_id>
+    </member><member>
+        <member_full>Cassidy (R-LA)</member_full>
+        <last_name>Cassidy</last_name>
+        <first_name>Bill</first_name>
+        <party>R</party>
+        <state>LA</state>
+        <address>455 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5824</phone>
+        <email>https://www.cassidy.senate.gov/contact</email>
+        <website>https://www.cassidy.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>C001075</bioguide_id>
+    </member><member>
+        <member_full>Collins (R-ME)</member_full>
+        <last_name>Collins</last_name>
+        <first_name>Susan M.</first_name>
+        <party>R</party>
+        <state>ME</state>
+        <address>413 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2523</phone>
+        <email>https://www.collins.senate.gov/contact</email>
+        <website>https://www.collins.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>C001035</bioguide_id>
+    </member><member>
+        <member_full>Coons (D-DE)</member_full>
+        <last_name>Coons</last_name>
+        <first_name>Christopher A.</first_name>
+        <party>D</party>
+        <state>DE</state>
+        <address>218 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5042</phone>
+        <email>https://www.coons.senate.gov/contact</email>
+        <website>https://www.coons.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>C001088</bioguide_id>
+    </member><member>
+        <member_full>Cornyn (R-TX)</member_full>
+        <last_name>Cornyn</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>TX</state>
+        <address>517 Hart Senate Office Building Washington DC 20510
+        </address>
+        <phone>(202) 224-2934</phone>
+        <email>https://www.cornyn.senate.gov/contact</email>
+        <website>https://www.cornyn.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>C001056</bioguide_id>
+      </member><member>
+        <member_full>Cortez Masto (D-NV)</member_full>
+        <last_name>Cortez Masto</last_name>
+        <first_name>Catherine</first_name>
+        <party>D</party>
+        <state>NV</state>
+        <address>309 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3542</phone>
+        <email>https://www.cortezmasto.senate.gov/contact</email>
+        <website>https://www.cortezmasto.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>C001113</bioguide_id>
+    </member><member>
+        <member_full>Cotton (R-AR)</member_full>
+        <last_name>Cotton</last_name>
+        <first_name>Tom</first_name>
+        <party>R</party>
+        <state>AR</state>
+        <address>326 Russell Senate Office Building Washington DC 20510
+        </address>
+        <phone>(202) 224-2353</phone>
+        <email>https://www.cotton.senate.gov/contact/contact-tom</email>
+        <website>https://www.cotton.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>C001095</bioguide_id>
+    </member><member>
+        <member_full>Cramer (R-ND)</member_full>
+        <last_name>Cramer</last_name>
+        <first_name>Kevin</first_name>
+        <party>R</party>
+        <state>ND</state>
+        <address>313 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2043</phone>
+        <email>https://www.cramer.senate.gov/contact/contact-kevin</email>
+        <website>https://www.cramer.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>C001096</bioguide_id>
+    </member><member>
+        <member_full>Crapo (R-ID)</member_full>
+        <last_name>Crapo</last_name>
+        <first_name>Mike</first_name>
+        <party>R</party>
+        <state>ID</state>
+        <address>239 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6142</phone>
+        <email>https://www.crapo.senate.gov/contact</email>
+        <website>https://www.crapo.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>C000880</bioguide_id>
+    </member><member>
+        <member_full>Cruz (R-TX)</member_full>
+        <last_name>Cruz</last_name>
+        <first_name>Ted</first_name>
+        <party>R</party>
+        <state>TX</state>
+        <address>167 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5922</phone>
+        <email>https://www.cruz.senate.gov/?p=form&amp;id=16</email>
+        <website>https://www.cruz.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>C001098</bioguide_id>
+    </member><member>
+        <member_full>Curtis (R-UT)</member_full>
+        <last_name>Curtis</last_name>
+        <first_name>John R.</first_name>
+        <party>R</party>
+        <state>UT</state>
+        <address>502 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5251</phone>
+        <email>https://www.curtis.senate.gov/</email>
+        <website>https://www.curtis.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>C001114</bioguide_id>
+    </member><member>
+        <member_full>Daines (R-MT)</member_full>
+        <last_name>Daines</last_name>
+        <first_name>Steve</first_name>
+        <party>R</party>
+        <state>MT</state>
+        <address>320 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2651</phone>
+        <email>https://www.daines.senate.gov/connect/email-steve</email>
+        <website>https://www.daines.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>D000618</bioguide_id>
+    </member><member>
+        <member_full>Duckworth (D-IL)</member_full>
+        <last_name>Duckworth</last_name>
+        <first_name>Tammy</first_name>
+        <party>D</party>
+        <state>IL</state>
+        <address>524 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2854</phone>
+        <email>https://www.duckworth.senate.gov/content/contact-senator</email>
+        <website>https://www.duckworth.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>D000622</bioguide_id>
+    </member><member>
+        <member_full>Durbin (D-IL)</member_full>
+        <last_name>Durbin</last_name>
+        <first_name>Richard J.</first_name>
+        <party>D</party>
+        <state>IL</state>
+        <address>711 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2152</phone>
+        <email>https://www.durbin.senate.gov/contact/</email>
+        <website>https://www.durbin.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>D000563</bioguide_id>
+        <leadership_position>Democratic Whip</leadership_position>
+    </member><member>
+        <member_full>Ernst (R-IA)</member_full>
+        <last_name>Ernst</last_name>
+        <first_name>Joni</first_name>
+        <party>R</party>
+        <state>IA</state>
+        <address>260 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3254</phone>
+        <email>https://www.ernst.senate.gov/public/index.cfm/contact</email>
+        <website>https://www.ernst.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>E000295</bioguide_id>
+    </member><member>
+        <member_full>Fetterman (D-PA)</member_full>
+        <last_name>Fetterman</last_name>
+        <first_name>John</first_name>
+        <party>D</party>
+        <state>PA</state>
+        <address>142 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4254</phone>
+        <email>https://www.fetterman.senate.gov/contact/</email>
+        <website>https://www.fetterman.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>F000479</bioguide_id>
+    </member><member>
+        <member_full>Fischer (R-NE)</member_full>
+        <last_name>Fischer</last_name>
+        <first_name>Deb</first_name>
+        <party>R</party>
+        <state>NE</state>
+        <address>448 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6551</phone>
+        <email>https://www.fischer.senate.gov/public/index.cfm/contact</email>
+        <website>https://www.fischer.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>F000463</bioguide_id>
+    </member><member>
+        <member_full>Gallego (D-AZ)</member_full>
+        <last_name>Gallego</last_name>
+        <first_name>Ruben</first_name>
+        <party>D</party>
+        <state>AZ</state>
+        <address>302 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4521</phone>
+        <email>https://www.gallego.senate.gov/</email>
+        <website>https://www.gallego.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>G000574</bioguide_id>
+    </member><member>
+        <member_full>Gillibrand (D-NY)</member_full>
+        <last_name>Gillibrand</last_name>
+        <first_name>Kirsten E.</first_name>
+        <party>D</party>
+        <state>NY</state>
+        <address>478 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4451</phone>
+        <email>https://www.gillibrand.senate.gov/contact/email-me</email>
+        <website>https://www.gillibrand.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>G000555</bioguide_id>
+    </member><member>
+        <member_full>Graham (R-SC)</member_full>
+        <last_name>Graham</last_name>
+        <first_name>Lindsey</first_name>
+        <party>R</party>
+        <state>SC</state>
+        <address>211 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5972</phone>
+        <email>https://www.lgraham.senate.gov/public/index.cfm/e-mail-senator-graham</email>
+        <website>https://www.lgraham.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>G000359</bioguide_id>
+    </member><member>
+        <member_full>Grassley (R-IA)</member_full>
+        <last_name>Grassley</last_name>
+        <first_name>Chuck</first_name>
+        <party>R</party>
+        <state>IA</state>
+        <address>135 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3744</phone>
+        <email>https://www.grassley.senate.gov/contact</email>
+        <website>https://www.grassley.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>G000386</bioguide_id>
+        <leadership_position>President Pro Tempore</leadership_position>
+    </member><member>        
+        <member_full>Hagerty (R-TN)</member_full>
+        <last_name>Hagerty</last_name>
+        <first_name>Bill</first_name>
+        <party>R</party>
+        <state>TN</state>
+        <address>251 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4944</phone>
+        <email>https://www.hagerty.senate.gov/email-me/</email>
+        <website>https://www.hagerty.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>H000601</bioguide_id>
+    </member><member>
+        <member_full>Hassan (D-NH)</member_full>
+        <last_name>Hassan</last_name>
+        <first_name>Margaret Wood</first_name>
+        <party>D</party>
+        <state>NH</state>
+        <address>324 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3324</phone>
+        <email>https://www.hassan.senate.gov/content/contact-senator</email>
+        <website>https://www.hassan.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>H001076</bioguide_id>
+    </member><member>
+        <member_full>Hawley (R-MO)</member_full>
+        <last_name>Hawley</last_name>
+        <first_name>Josh</first_name>
+        <party>R</party>
+        <state>MO</state>
+        <address>381 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6154</phone>
+        <email>https://www.hawley.senate.gov/contact-senator-hawley</email>
+        <website>https://www.hawley.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>H001089</bioguide_id>
+    </member><member>
+        <member_full>Heinrich (D-NM)</member_full>
+        <last_name>Heinrich</last_name>
+        <first_name>Martin</first_name>
+        <party>D</party>
+        <state>NM</state>
+        <address>709 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5521</phone>
+        <email>https://www.heinrich.senate.gov/contact</email>
+        <website>https://www.heinrich.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>H001046</bioguide_id>
+    </member><member>
+        <member_full>Hickenlooper (D-CO)</member_full>
+        <last_name>Hickenlooper</last_name>
+        <first_name>John W.</first_name>
+        <party>D</party>
+        <state>CO</state>
+        <address>316 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5941</phone>
+        <email>https://www.hickenlooper.senate.gov/contact/</email>
+        <website>https://www.hickenlooper.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>H000273</bioguide_id>
+    </member><member>
+        <member_full>Hirono (D-HI)</member_full>
+        <last_name>Hirono</last_name>
+        <first_name>Mazie K.</first_name>
+        <party>D</party>
+        <state>HI</state>
+        <address>109 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6361</phone>
+        <email>https://www.hirono.senate.gov/contact</email>
+        <website>https://www.hirono.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>H001042</bioguide_id>
+    </member><member>
+        <member_full>Hoeven (R-ND)</member_full>
+        <last_name>Hoeven</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>ND</state>
+        <address>338 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2551</phone>
+        <email>https://www.hoeven.senate.gov/contact/contact-the-senator</email>
+        <website>https://www.hoeven.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>H001061</bioguide_id>
+    </member><member>
+        <member_full>Husted (R-OH)</member_full>
+        <last_name>Husted</last_name>
+        <first_name>Jon</first_name>
+        <party>R</party>
+        <state>OH</state>
+        <address>304 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3353</phone>
+        <email>https://www.husted.senate.gov</email>
+        <website>https://www.husted.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>H001104</bioguide_id>
+    </member><member>
+        <member_full>Hyde-Smith (R-MS)</member_full>
+        <last_name>Hyde-Smith</last_name>
+        <first_name>Cindy</first_name>
+        <party>R</party>
+        <state>MS</state>
+        <address>528 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5054</phone>
+        <email>https://www.hydesmith.senate.gov/contact-senator</email>
+        <website>https://www.hydesmith.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>H001079</bioguide_id>
+    </member><member>
+        <member_full>Johnson (R-WI)</member_full>
+        <last_name>Johnson</last_name>
+        <first_name>Ron</first_name>
+        <party>R</party>
+        <state>WI</state>
+        <address>328 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5323</phone>
+        <email>https://www.ronjohnson.senate.gov/public/index.cfm/email-the-senator</email>
+        <website>https://www.ronjohnson.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>J000293</bioguide_id>
+    </member><member>
+        <member_full>Justice (R-WV)</member_full>
+        <last_name>Justice</last_name>
+        <first_name>James C.</first_name>
+        <party>R</party>
+        <state>WV</state>
+        <address>509 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3954</phone>
+        <email>https://www.justice.senate.gov/</email>
+        <website>https://www.justice.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>J000312</bioguide_id>
+    </member><member>
+        <member_full>Kaine (D-VA)</member_full>
+        <last_name>Kaine</last_name>
+        <first_name>Tim</first_name>
+        <party>D</party>
+        <state>VA</state>
+        <address>231 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4024</phone>
+        <email>https://www.kaine.senate.gov/contact</email>
+        <website>https://www.kaine.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>K000384</bioguide_id>
+    </member><member>
+        <member_full>Kelly (D-AZ)</member_full>
+        <last_name>Kelly</last_name>
+        <first_name>Mark</first_name>
+        <party>D</party>
+        <state>AZ</state>
+        <address>516 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2235</phone>
+        <email>https://www.kelly.senate.gov/contact/contact-form/</email>
+        <website>https://www.kelly.senate.gov</website>         
+        <class>Class III</class>
+        <bioguide_id>K000377</bioguide_id>
+    </member><member>
+        <member_full>Kennedy (R-LA)</member_full>
+        <last_name>Kennedy</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>LA</state>
+        <address>437 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4623</phone>
+        <email>https://www.kennedy.senate.gov/public/email-me</email>
+        <website>https://www.kennedy.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>K000393</bioguide_id>
+    </member><member>
+        <member_full>Kim (D-NJ)</member_full>
+        <last_name>Kim</last_name>
+        <first_name>Andy</first_name>
+        <party>D</party>
+        <state>NJ</state>
+        <address>520 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4744</phone>
+        <email>https://www.kim.senate.gov/</email>
+        <website>https://www.kim.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>K000394</bioguide_id>
+    </member><member>
+        <member_full>King (I-ME)</member_full>
+        <last_name>King</last_name>
+        <first_name>Angus S., Jr.</first_name>
+        <party>I</party>
+        <state>ME</state>
+        <address>133 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5344</phone>
+        <email>https://www.king.senate.gov/contact</email>
+        <website>https://www.king.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>K000383</bioguide_id>
+    </member><member>
+        <member_full>Klobuchar (D-MN)</member_full>
+        <last_name>Klobuchar</last_name>
+        <first_name>Amy</first_name>
+        <party>D</party>
+        <state>MN</state>
+        <address>425 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3244</phone>
+        <email>https://www.klobuchar.senate.gov/public/index.cfm/contact</email>
+        <website>https://www.klobuchar.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>K000367</bioguide_id>
+    </member><member>
+        <member_full>Lankford (R-OK)</member_full>
+        <last_name>Lankford</last_name>
+        <first_name>James</first_name>
+        <party>R</party>
+        <state>OK</state>
+        <address>731 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5754</phone>
+        <email>https://www.lankford.senate.gov/contact/email</email>
+        <website>https://www.lankford.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>L000575</bioguide_id>
+    </member><member>
+        <member_full>Lee (R-UT)</member_full>
+        <last_name>Lee</last_name>
+        <first_name>Mike</first_name>
+        <party>R</party>
+        <state>UT</state>
+        <address>363 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5444</phone>
+        <email>https://www.lee.senate.gov/public/index.cfm/contact</email>
+        <website>https://www.lee.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>L000577</bioguide_id>
+    </member><member>
+        <member_full>Luján (D-NM)</member_full>
+        <last_name>Luján</last_name>
+        <first_name>Ben Ray</first_name>
+        <party>D</party>
+        <state>NM</state>
+        <address>498 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6621</phone>
+        <email>https://www.lujan.senate.gov/contact/</email>
+        <website>https://www.lujan.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>L000570</bioguide_id>
+    </member><member>
+        <member_full>Lummis (R-WY)</member_full>
+        <last_name>Lummis</last_name>
+        <first_name>Cynthia M.</first_name>
+        <party>R</party>
+        <state>WY</state>
+        <address>127A Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3424</phone>
+        <email>https://www.lummis.senate.gov/contact/contact-form/</email>
+        <website>https://www.lummis.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>L000571</bioguide_id>
+    </member><member>
+        <member_full>Markey (D-MA)</member_full>
+        <last_name>Markey</last_name>
+        <first_name>Edward J.</first_name>
+        <party>D</party>
+        <state>MA</state>
+        <address>255 Dirksen Senate Office Building Washington DC 20510
+        </address>
+        <phone>(202) 224-2742</phone>
+        <email>https://www.markey.senate.gov/contact</email>
+        <website>https://www.markey.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>M000133</bioguide_id>
+    </member><member>
+        <member_full>Marshall (R-KS)</member_full>
+        <last_name>Marshall</last_name>
+        <first_name>Roger</first_name>
+        <party>R</party>
+        <state>KS</state>
+        <address>479A Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4774</phone>
+        <email>https://www.marshall.senate.gov/contact/</email>
+        <website>https://www.marshall.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>M001198</bioguide_id>
+    </member><member>
+        <member_full>McConnell (R-KY)</member_full>
+        <last_name>McConnell</last_name>
+        <first_name>Mitch</first_name>
+        <party>R</party>
+        <state>KY</state>
+        <address>317 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2541</phone>
+        <email>https://www.mcconnell.senate.gov/public/index.cfm?p=contact</email>
+        <website>https://www.mcconnell.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>M000355</bioguide_id>
+    </member><member>
+        <member_full>McCormick (R-PA)</member_full>
+        <last_name>McCormick</last_name>
+        <first_name>David</first_name>
+        <party>R</party>
+        <state>PA</state>
+        <address>702 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6324</phone>
+        <email>https://mccormick.senate.gov/</email>
+        <website>https://mccormick.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>M001243</bioguide_id>
+    </member><member>
+        <member_full>Merkley (D-OR)</member_full>
+        <last_name>Merkley</last_name>
+        <first_name>Jeff</first_name>
+        <party>D</party>
+        <state>OR</state>
+        <address>531 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3753</phone>
+        <email>https://www.merkley.senate.gov/contact/</email>
+        <website>https://www.merkley.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>M001176</bioguide_id>
+    </member><member>
+        <member_full>Moody (R-FL)</member_full>
+        <last_name>Moody</last_name>
+        <first_name>Ashley</first_name>
+        <party>R</party>
+        <state>FL</state>
+        <address>387 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3041</phone>
+        <email>https://www.moody.senate.gov</email>
+        <website>https://www.moody.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>M001244</bioguide_id>
+    </member><member>
+        <member_full>Moran (R-KS)</member_full>
+        <last_name>Moran</last_name>
+        <first_name>Jerry</first_name>
+        <party>R</party>
+        <state>KS</state>
+        <address>521 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6521</phone>
+        <email>https://www.moran.senate.gov/public/index.cfm/e-mail-jerry</email>
+        <website>https://www.moran.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>M000934</bioguide_id>
+    </member><member>
+        <member_full>Moreno (R-OH)</member_full>
+        <last_name>Moreno</last_name>
+        <first_name>Bernie</first_name>
+        <party>R</party>
+        <state>OH</state>
+        <address>284 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2315</phone>
+        <email>https://www.moreno.senate.gov</email>
+        <website>https://www.moreno.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>M001242</bioguide_id>
+    </member><member>
+        <member_full>Murkowski (R-AK)</member_full>
+        <last_name>Murkowski</last_name>
+        <first_name>Lisa</first_name>
+        <party>R</party>
+        <state>AK</state>
+        <address>522 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6665</phone>
+        <email>https://www.murkowski.senate.gov/public/index.cfm/contact</email>
+        <website>https://www.murkowski.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>M001153</bioguide_id>
+    </member><member>
+        <member_full>Murphy (D-CT)</member_full>
+        <last_name>Murphy</last_name>
+        <first_name>Christopher</first_name>
+        <party>D</party>
+        <state>CT</state>
+        <address>136 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4041</phone>
+        <email>https://www.murphy.senate.gov/contact</email>
+        <website>https://www.murphy.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>M001169</bioguide_id>
+    </member><member>
+        <member_full>Murray (D-WA)</member_full>
+        <last_name>Murray</last_name>
+        <first_name>Patty</first_name>
+        <party>D</party>
+        <state>WA</state>
+        <address>154 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2621</phone>
+        <email>https://www.murray.senate.gov/write-to-patty/</email>
+        <website>https://www.murray.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>M001111</bioguide_id>
+    </member><member>
+        <member_full>Ossoff (D-GA)</member_full>
+        <last_name>Ossoff</last_name>
+        <first_name>Jon</first_name>
+        <party>D</party>
+        <state>GA</state>
+        <address>317 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3521</phone>
+        <email>https://www.ossoff.senate.gov/contact-us/</email>
+        <website>https://www.ossoff.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>O000174</bioguide_id>
+    </member><member>
+        <member_full>Padilla (D-CA)</member_full>
+        <last_name>Padilla</last_name>
+        <first_name>Alex</first_name>
+        <party>D</party>
+        <state>CA</state>
+        <address>331 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3553</phone>
+        <email>https://www.padilla.senate.gov/contact/</email>
+        <website>https://www.padilla.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>P000145</bioguide_id>
+    </member><member>
+        <member_full>Paul (R-KY)</member_full>
+        <last_name>Paul</last_name>
+        <first_name>Rand</first_name>
+        <party>R</party>
+        <state>KY</state>
+        <address>295 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4343</phone>
+        <email>https://www.paul.senate.gov/connect/email-rand</email>
+        <website>https://www.paul.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>P000603</bioguide_id>
+    </member><member>
+        <member_full>Peters (D-MI)</member_full>
+        <last_name>Peters</last_name>
+        <first_name>Gary C.</first_name>
+        <party>D</party>
+        <state>MI</state>
+        <address>724 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6221</phone>
+        <email>https://www.peters.senate.gov/contact/email-gary</email>
+        <website>https://www.peters.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>P000595</bioguide_id>
+    </member><member>
+        <member_full>Reed (D-RI)</member_full>
+        <last_name>Reed</last_name>
+        <first_name>Jack</first_name>
+        <party>D</party>
+        <state>RI</state>
+        <address>728 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4642</phone>
+        <email>https://www.reed.senate.gov/contact/</email>
+        <website>https://www.reed.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>R000122</bioguide_id>
+    </member><member>
+        <member_full>Ricketts (R-NE)</member_full>
+        <last_name>Ricketts</last_name>
+        <first_name>Pete</first_name>
+        <party>R</party>
+        <state>NE</state>
+        <address>139 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4224</phone>
+        <email>https://www.ricketts.senate.gov/contact/</email>
+        <website>https://www.ricketts.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>R000618</bioguide_id>
+    </member><member>
+        <member_full>Risch (R-ID)</member_full>
+        <last_name>Risch</last_name>
+        <first_name>James E.</first_name>
+        <party>R</party>
+        <state>ID</state>
+        <address>483 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2752</phone>
+        <email>https://www.risch.senate.gov/public/index.cfm?p=Email</email>
+        <website>https://www.risch.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>R000584</bioguide_id>
+    </member><member>
+        <member_full>Rosen (D-NV)</member_full>
+        <last_name>Rosen</last_name>
+        <first_name>Jacky</first_name>
+        <party>D</party>
+        <state>NV</state>
+        <address>713 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6244</phone>
+        <email>https://www.rosen.senate.gov/contact_jacky</email>
+        <website>https://www.rosen.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>R000608</bioguide_id>
+    </member><member>
+        <member_full>Rounds (R-SD)</member_full>
+        <last_name>Rounds</last_name>
+        <first_name>Mike</first_name>
+        <party>R</party>
+        <state>SD</state>
+        <address>716 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5842</phone>
+        <email>https://www.rounds.senate.gov/contact/email-mike</email>
+        <website>https://www.rounds.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>R000605</bioguide_id>
+    </member><member>
+        <member_full>Sanders (I-VT)</member_full>
+        <last_name>Sanders</last_name>
+        <first_name>Bernard</first_name>
+        <party>I</party>
+        <state>VT</state>
+        <address>332 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5141</phone>
+        <email>https://www.sanders.senate.gov/contact/</email>
+        <website>https://www.sanders.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>S000033</bioguide_id>
+    </member><member>
+      <member_full>Schatz (D-HI)</member_full>
+      <last_name>Schatz</last_name>
+      <first_name>Brian</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <address>722 Hart Senate Office Building Washington DC 20510</address>
+      <phone>(202) 224-3934</phone>
+      <email>https://www.schatz.senate.gov/contact</email>
+      <website>https://www.schatz.senate.gov</website>
+      <class>Class III</class>
+      <bioguide_id>S001194</bioguide_id>
+    </member><member>
+      <member_full>Schiff (D-CA)</member_full>
+      <last_name>Schiff</last_name>
+      <first_name>Adam B.</first_name>
+      <party>D</party>
+      <state>CA</state>
+      <address>B40C Dirksen Senate Office Building Washington DC 20510</address>
+      <phone>(202) 224-3841</phone>
+      <email>https://www.schiff.senate.gov</email>
+      <website>https://www.schiff.senate.gov</website>
+      <class>Class I</class>
+      <bioguide_id>S001150</bioguide_id>
+    </member><member>
+        <member_full>Schmitt (R-MO)</member_full>
+        <last_name>Schmitt</last_name>
+        <first_name>Eric</first_name>
+        <party>R</party>
+        <state>MO</state>
+        <address>404 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5721</phone>
+        <email>https://www.schmitt.senate.gov/contact/</email>
+        <website>https://www.schmitt.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>S001227</bioguide_id>
+    </member><member>
+        <member_full>Schumer (D-NY)</member_full>
+        <last_name>Schumer</last_name>
+        <first_name>Charles E.</first_name>
+        <party>D</party>
+        <state>NY</state>
+        <address>322 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6542</phone>
+        <email>https://www.schumer.senate.gov/contact/email-chuck</email>
+        <website>https://www.schumer.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>S000148</bioguide_id>
+        <leadership_position>Democratic Leader Chair of the Conference</leadership_position>
+    </member><member>
+        <member_full>Scott (R-FL)</member_full>
+        <last_name>Scott</last_name>
+        <first_name>Rick</first_name>
+        <party>R</party>
+        <state>FL</state>
+        <address>110 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5274</phone>
+        <email>https://www.rickscott.senate.gov/contact/contact</email>
+        <website>https://www.rickscott.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>S001217</bioguide_id>
+    </member><member>
+        <member_full>Scott (R-SC)</member_full>
+        <last_name>Scott</last_name>
+        <first_name>Tim</first_name>
+        <party>R</party>
+        <state>SC</state>
+        <address>104 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6121</phone>
+        <email>https://www.scott.senate.gov/contact/email-me</email>
+        <website>https://www.scott.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>S001184</bioguide_id>
+    </member><member>
+        <member_full>Shaheen (D-NH)</member_full>
+        <last_name>Shaheen</last_name>
+        <first_name>Jeanne</first_name>
+        <party>D</party>
+        <state>NH</state>
+        <address>506 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2841</phone>
+        <email>https://www.shaheen.senate.gov/contact/contact-jeanne</email>
+        <website>https://www.shaheen.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>S001181</bioguide_id>
+    </member><member>
+        <member_full>Sheehy (R-MT)</member_full>
+        <last_name>Sheehy</last_name>
+        <first_name>Tim</first_name>
+        <party>R</party>
+        <state>MT</state>
+        <address>124 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2644</phone>
+        <email>https://www.sheehy.senate.gov/</email>
+        <website>https://www.sheehy.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>S001232</bioguide_id>
+    </member><member>
+        <member_full>Slotkin (D-MI)</member_full>
+        <last_name>Slotkin</last_name>
+        <first_name>Elissa</first_name>
+        <party>D</party>
+        <state>MI</state>
+        <address>291 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4822</phone>
+        <email>https://www.slotkin.senate.gov/</email>
+        <website>https://www.slotkin.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>S001208</bioguide_id>
+    </member><member>
+        <member_full>Smith (D-MN)</member_full>
+        <last_name>Smith</last_name>
+        <first_name>Tina</first_name>
+        <party>D</party>
+        <state>MN</state>
+        <address>720 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5641</phone>
+        <email>https://www.smith.senate.gov/share-your-opinion/</email>
+        <website>https://www.smith.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>S001203</bioguide_id>
+    </member><member>
+        <member_full>Sullivan (R-AK)</member_full>
+        <last_name>Sullivan</last_name>
+        <first_name>Dan</first_name>
+        <party>R</party>
+        <state>AK</state>
+        <address>706 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3004</phone>
+        <email>https://www.sullivan.senate.gov/contact/email</email>
+        <website>https://www.sullivan.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>S001198</bioguide_id>
+    </member><member>
+        <member_full>Thune (R-SD)</member_full>
+        <last_name>Thune</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>SD</state>
+        <address>511 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2321</phone>
+        <email>https://www.thune.senate.gov/public/index.cfm/contact</email>
+        <website>https://www.thune.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>T000250</bioguide_id>
+         <leadership_position>Majority Leader</leadership_position>
+    </member><member>
+        <member_full>Tillis (R-NC)</member_full>
+        <last_name>Tillis</last_name>
+        <first_name>Thom</first_name>
+        <party>R</party>
+        <state>NC</state>
+        <address>113 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6342</phone>
+        <email>https://www.tillis.senate.gov/public/index.cfm/email-me</email>
+        <website>https://www.tillis.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>T000476</bioguide_id>
+    </member><member>
+        <member_full>Tuberville (R-AL)</member_full>
+        <last_name>Tuberville</last_name>
+        <first_name>Tommy</first_name>
+        <party>R</party>
+        <state>AL</state>
+        <address>455 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4124</phone>
+        <email>https://www.tuberville.senate.gov/contact/contact-form/</email>
+        <website>https://www.tuberville.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>T000278</bioguide_id>
+    </member><member>
+        <member_full>Van Hollen (D-MD)</member_full>
+        <last_name>Van Hollen</last_name>
+        <first_name>Chris</first_name>
+        <party>D</party>
+        <state>MD</state>
+        <address>730 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4654</phone>
+        <email>https://www.vanhollen.senate.gov/contact/email</email>
+        <website>https://www.vanhollen.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>V000128</bioguide_id>
+    </member><member>
+        <member_full>Warner (D-VA)</member_full>
+        <last_name>Warner</last_name>
+        <first_name>Mark R.</first_name>
+        <party>D</party>
+        <state>VA</state>
+        <address>703 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2023</phone>
+        <email>https://www.warner.senate.gov/public/index.cfm?p=Contact</email>
+        <website>https://www.warner.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>W000805</bioguide_id>
+    </member><member>
+        <member_full>Warnock (D-GA)</member_full>
+        <last_name>Warnock</last_name>
+        <first_name>Raphael G.</first_name>
+        <party>D</party>
+        <state>GA</state>
+        <address>717 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3643</phone>
+        <email>https://www.warnock.senate.gov/contact/</email>
+        <website>https://www.warnock.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>W000790</bioguide_id>
+    </member><member>
+        <member_full>Warren (D-MA)</member_full>
+        <last_name>Warren</last_name>
+        <first_name>Elizabeth</first_name>
+        <party>D</party>
+        <state>MA</state>
+        <address>311 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4543</phone>
+        <email>https://www.warren.senate.gov/?p=email_senator</email>
+        <website>https://www.warren.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>W000817</bioguide_id>
+    </member><member>
+        <member_full>Welch (D-VT)</member_full>
+        <last_name>Welch</last_name>
+        <first_name>Peter</first_name>
+        <party>D</party>
+        <state>VT</state>
+        <address>115 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4242</phone>
+        <email>https://www.welch.senate.gov/email-peter/</email>
+        <website>https://www.welch.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>W000800</bioguide_id>
+    </member><member>
+        <member_full>Whitehouse (D-RI)</member_full>
+        <last_name>Whitehouse</last_name>
+        <first_name>Sheldon</first_name>
+        <party>D</party>
+        <state>RI</state>
+        <address>530 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2921</phone>
+        <email>https://www.whitehouse.senate.gov/contact/email-sheldon</email>
+        <website>https://www.whitehouse.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>W000802</bioguide_id>
+    </member><member>
+        <member_full>Wicker (R-MS)</member_full>
+        <last_name>Wicker</last_name>
+        <first_name>Roger F.</first_name>
+        <party>R</party>
+        <state>MS</state>
+        <address>425 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6253</phone>
+        <email>https://www.wicker.senate.gov/public/index.cfm/contact</email>
+        <website>https://www.wicker.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>W000437</bioguide_id>
+    </member><member>
+        <member_full>Wyden (D-OR)</member_full>
+        <last_name>Wyden</last_name>
+        <first_name>Ron</first_name>
+        <party>D</party>
+        <state>OR</state>
+        <address>221 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5244</phone>
+        <email>https://www.wyden.senate.gov/contact/</email>
+        <website>https://www.wyden.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>W000779</bioguide_id>
+    </member><member>
+        <member_full>Young (R-IN)</member_full>
+        <last_name>Young</last_name>
+        <first_name>Todd</first_name>
+        <party>R</party>
+        <state>IN</state>
+        <address>185 Dirksen Senate Office Building Washington DC
+      20510</address>
+        <phone>(202) 224-5623</phone>
+        <email>https://www.young.senate.gov/contact</email>
+        <website>https://www.young.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>Y000064</bioguide_id>
+    </member><last_updated>2026-05-04T11:17-05:00</last_updated></contact_information>

--- a/tests/fixtures/senate/vote_menu_119_1.xml
+++ b/tests/fixtures/senate/vote_menu_119_1.xml
@@ -1,0 +1,11797 @@
+<?xml version="1.0" encoding="UTF-8"?><vote_summary>
+  <congress>119</congress>
+  <session>1</session>
+  <congress_year>2025</congress_year>
+  <votes>
+    <vote>
+      <vote_number>00659</vote_number>
+      <vote_date>18-Dec</vote_date>
+      <issue>PN373</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Sara Bailey to be Director of National Drug Control Policy</title>
+    </vote>
+    <vote>
+      <vote_number>00658</vote_number>
+      <vote_date>18-Dec</vote_date>
+      <issue>PN615-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>35</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Alexander C. Van Hook to be U.S. District Judge for the Western District of Louisiana</title>
+    </vote>
+    <vote>
+      <vote_number>00657</vote_number>
+      <vote_date>18-Dec</vote_date>
+      <issue>PN12-1</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>58</yeas>
+        <nays>36</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Keith Bass to be Assistant Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00656</vote_number>
+      <vote_date>18-Dec</vote_date>
+      <issue>PN499-11</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Joshua Simmons to be General Counsel of the Central Intelligence Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00655</vote_number>
+      <vote_date>18-Dec</vote_date>
+      <en_bloc>
+        <matter>
+          <issue>PN416-9</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-12</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN499-12</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN465-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN345-14</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN345-13</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN345-10</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN624-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN624-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-17</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-16</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN416-6</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN519-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN445-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN416-12</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN345-12</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN465-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-26</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-10</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN416-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-20</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-6</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN560-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN462-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN462-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN416-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN518-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN499-10</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN499-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN462-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-10</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-24</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN445-10</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN445-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN445-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-12</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-27</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-17</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-17</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-11</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-11</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN445-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN466-9</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN466-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN466-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN447</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN499-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN345-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-11</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN445-11</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN416-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-15</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-13</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-11</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-20</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-25</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-47</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-13</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-26</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-19</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN445-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-26</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-22</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN416-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-9</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-18</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-14</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN416-10</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-21</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-13</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-6</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-44</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-39</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-13</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-26</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-22</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-16</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-12</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-34</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-37</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-29</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+      </en_bloc>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: En Bloc Nominations as Provided for Under the Provisions of S. Res. 532</title>
+    </vote>
+    <vote>
+      <vote_number>00654</vote_number>
+      <vote_date>18-Dec</vote_date>
+      <issue>S.J.Res. 82</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>S. J. Res. 82; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Office of the Secretary of the Department of Health and Human Services relating to "Policy on Adhering to the Text of the Administrative Procedure Act".</title>
+    </vote>
+    <vote>
+      <vote_number>00653</vote_number>
+      <vote_date>17-Dec</vote_date>
+      <en_bloc>
+        <matter>
+          <issue>PN25-29</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-37</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-34</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-12</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-16</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-22</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-26</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-13</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-39</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-44</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-6</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-13</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-21</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-10</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-14</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-18</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-9</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-22</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-26</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN445-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-26</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-13</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-47</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-25</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-20</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-11</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-13</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-15</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN445-11</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-11</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN345-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN499-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN447</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN466-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN466-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN466-9</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN445-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-11</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-11</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-17</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-17</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-27</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-12</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN445-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN445-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN445-10</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-24</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-10</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN462-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN499-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN499-10</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN518-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN462-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN462-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN560-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-6</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-20</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-10</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-26</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN465-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN345-12</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-12</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN445-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN519-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-6</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-16</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-17</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN624-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN624-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN345-10</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN345-13</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN345-14</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN465-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN499-12</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-12</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-9</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+      </en_bloc>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: En Bloc Nominations Provided for Under the Provisions of S. Res. 412</title>
+    </vote>
+    <vote>
+      <vote_number>00652</vote_number>
+      <vote_date>17-Dec</vote_date>
+      <issue>PN645-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>71</yeas>
+        <nays>29</nays>
+      </vote_tally>
+      <title>Confirmation: Douglas Weaver, of Maryland, to be a Member of the Nuclear Regulatory Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00651</vote_number>
+      <vote_date>17-Dec</vote_date>
+      <issue>PN645-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>69</yeas>
+        <nays>27</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Douglas Weaver to be a Member of the Nuclear Regulatory Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00650</vote_number>
+      <vote_date>17-Dec</vote_date>
+      <issue>PN650</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>67</yeas>
+        <nays>30</nays>
+      </vote_tally>
+      <title>Confirmation: Jared Isaacman, of Pennsylvania, to be Administrator of the National Aeronautics and Space Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00649</vote_number>
+      <vote_date>17-Dec</vote_date>
+      <issue>PN650</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>67</yeas>
+        <nays>30</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jared Isaacman to be Administrator of the National Aeronautics and Space Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00648</vote_number>
+      <vote_date>17-Dec</vote_date>
+      <issue>S. 1071</issue>
+      <question>On the Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>77</yeas>
+        <nays>20</nays>
+      </vote_tally>
+      <title>Motion to Concur in the House Amendment to S. 1071; A bill to require the Secretary of Veterans Affairs to disinter the remains of Fernando V. Cota from Fort Sam Houston National Cemetery, Texas, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00647</vote_number>
+      <vote_date>15-Dec</vote_date>
+      <issue>S. 1071</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>76</yeas>
+        <nays>20</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Concur in the House Amendment to S. 1071; A bill to require the Secretary of Veterans Affairs to disinter the remains of Fernando V. Cota from Fort Sam Houston National Cemetery, Texas, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00646</vote_number>
+      <vote_date>11-Dec</vote_date>
+      <issue>S. 1071</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>75</yeas>
+        <nays>22</nays>
+      </vote_tally>
+      <title>Motion to Proceed to the House Message to Accompany S. 1071; A bill to require the Secretary of Veterans Affairs to disinter the remains of Fernando V. Cota from Fort Sam Houston National Cemetery, Texas, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00645</vote_number>
+      <vote_date>11-Dec</vote_date>
+      <issue>S.Res. 532</issue>
+      <question>On the Resolution
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>S.Res. 532; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00644</vote_number>
+      <vote_date>11-Dec</vote_date>
+      <issue>S. 3385</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 3385; A bill to amend the Internal Revenue Code of 1986 to extend the enhancement of the health care premium tax credit.</title>
+    </vote>
+    <vote>
+      <vote_number>00643</vote_number>
+      <vote_date>11-Dec</vote_date>
+      <issue>S. 3386</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 3386; A bill to provide a health savings account contribution to certain enrollees, to reduce health care costs, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00642</vote_number>
+      <vote_date>10-Dec</vote_date>
+      <issue>S.Res. 532</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: S.Res. 532; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00641</vote_number>
+      <vote_date>10-Dec</vote_date>
+      <issue>S.J.Res. 82</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J.Res. 82; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Office of the Secretary of the Department of Health and Human Services relating to "Policy on Adhering to the Text of the Administrative Procedure Act".</title>
+    </vote>
+    <vote>
+      <vote_number>00640</vote_number>
+      <vote_date>09-Dec</vote_date>
+      <issue>PN466-5</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: James D. Maxwell II, of Mississippi, to be U.S. District Judge for the Northern District of Mississippi</title>
+    </vote>
+    <vote>
+      <vote_number>00639</vote_number>
+      <vote_date>09-Dec</vote_date>
+      <issue>PN466-5</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: James D. Maxwell II to be U.S. District Judge for the Northern District of Mississippi</title>
+    </vote>
+    <vote>
+      <vote_number>00638</vote_number>
+      <vote_date>09-Dec</vote_date>
+      <issue>PN615-1</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: William J. Crain, of Louisiana, to be U.S. District Judge for the Eastern District of Louisiana</title>
+    </vote>
+    <vote>
+      <vote_number>00637</vote_number>
+      <vote_date>09-Dec</vote_date>
+      <issue>PN615-1</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: William J. Crain to be U.S. District Judge for the Eastern District of Louisiana</title>
+    </vote>
+    <vote>
+      <vote_number>00636</vote_number>
+      <vote_date>09-Dec</vote_date>
+      <issue>PN466-1</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Robert P. Chamberlin, of Mississippi, to be U.S. District Judge for the Northern District of Mississippi</title>
+    </vote>
+    <vote>
+      <vote_number>00635</vote_number>
+      <vote_date>08-Dec</vote_date>
+      <issue>PN466-1</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Robert P. Chamberlain to be U.S. District Judge for the Northern District of Mississippi</title>
+    </vote>
+    <vote>
+      <vote_number>00634</vote_number>
+      <vote_date>04-Dec</vote_date>
+      <issue>PN520-4</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>57</yeas>
+        <nays>32</nays>
+      </vote_tally>
+      <title>Confirmation: Susan Courtwright Rodriguez, of North Carolina, to be U.S. District Judge for the Western District of North Carolina</title>
+    </vote>
+    <vote>
+      <vote_number>00633</vote_number>
+      <vote_date>04-Dec</vote_date>
+      <issue>S.Res. 520</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>43</yeas>
+        <nays>37</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: S. Res. 520; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00632</vote_number>
+      <vote_date>04-Dec</vote_date>
+      <issue>H.J.Res. 131</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>H.J. Res. 131; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "Coastal Plain Oil and Gas Leasing Program Record of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00631</vote_number>
+      <vote_date>03-Dec</vote_date>
+      <issue>PN520-4</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>63</yeas>
+        <nays>34</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Susan Courtwright Rodriguez to be U.S. District Judge for the Western District of North Carolina</title>
+    </vote>
+    <vote>
+      <vote_number>00630</vote_number>
+      <vote_date>03-Dec</vote_date>
+      <issue>S.J.Res. 91</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S. J. Res. 91; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "Coastal Plain Oil and Gas Leasing Program Record of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00629</vote_number>
+      <vote_date>03-Dec</vote_date>
+      <issue>PN520-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>57</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Confirmation: Matthew E. Orso, of North Carolina, to be U.S. District Judge for the Western District of North Carolina</title>
+    </vote>
+    <vote>
+      <vote_number>00628</vote_number>
+      <vote_date>03-Dec</vote_date>
+      <issue>PN520-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Matthew E. Orso to be U.S. District Judge for the Western District of North Carolina</title>
+    </vote>
+    <vote>
+      <vote_number>00627</vote_number>
+      <vote_date>02-Dec</vote_date>
+      <issue>PN520-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Confirmation: Lindsey Ann Freeman, of North Carolina, to be U.S. District Judge for the Middle District of North Carolina</title>
+    </vote>
+    <vote>
+      <vote_number>00626</vote_number>
+      <vote_date>02-Dec</vote_date>
+      <issue>PN520-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>61</yeas>
+        <nays>36</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Lindsey Ann Freeman to be U.S. District Judge for the Middle District of North Carolina</title>
+    </vote>
+    <vote>
+      <vote_number>00625</vote_number>
+      <vote_date>02-Dec</vote_date>
+      <issue>PN520-1</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: David A. Bragdon, of North Carolina, to be U.S. District Judge for the Middle District of North Carolina</title>
+    </vote>
+    <vote>
+      <vote_number>00624</vote_number>
+      <vote_date>01-Dec</vote_date>
+      <issue>PN520-1</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: David A. Bragdon to be U.S. District Judge for the Middle District of North Carolina</title>
+    </vote>
+    <vote>
+      <vote_number>00623</vote_number>
+      <vote_date>20-Nov</vote_date>
+      <issue>H.J.Res. 130</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>H.J.Res. 130; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "Buffalo Field Office Record of Decision and Approved Resource Management Plan Amendment".</title>
+    </vote>
+    <vote>
+      <vote_number>00622</vote_number>
+      <vote_date>19-Nov</vote_date>
+      <issue>S.J.Res. 76</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J.Res. 76; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "Extension of Deadlines in Standards of Performance for New, Reconstructed, and Modified Sources and Emissions Guidelines for Existing Sources: Oil and Natural Gas Sector Climate Review Final Rule".</title>
+    </vote>
+    <vote>
+      <vote_number>00621</vote_number>
+      <vote_date>19-Nov</vote_date>
+      <issue>S.J.Res. 89</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J.Res. 89; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "Buffalo Field Office Record of Decision and Approved Resource Management Plan Amendment".</title>
+    </vote>
+    <vote>
+      <vote_number>00620</vote_number>
+      <vote_date>19-Nov</vote_date>
+      <issue>PN445-6</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>66</yeas>
+        <nays>32</nays>
+      </vote_tally>
+      <title>Confirmation: Ho Nieh, of Alabama, to be a Member of the Nuclear Regulatory Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00619</vote_number>
+      <vote_date>18-Nov</vote_date>
+      <issue>PN445-6</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>65</yeas>
+        <nays>32</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Ho Nieh to be a Member of the Nuclear Regulatory Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00618</vote_number>
+      <vote_date>10-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>H.R. 5371, As Amended; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00617</vote_number>
+      <vote_date>10-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: H.R. 5371, As Amended; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00616</vote_number>
+      <vote_date>10-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3937</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Collins Amdt. No. 3937; In the nature of a substitute.</title>
+    </vote>
+    <vote>
+      <vote_number>00615</vote_number>
+      <vote_date>10-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On the Cloture Motion
+        <measure>S.Amdt. 3937</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Collins Amdt. No. 3937; In the nature of a substitute.</title>
+    </vote>
+    <vote>
+      <vote_number>00614</vote_number>
+      <vote_date>10-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On the Motion to Table
+        <measure>S.Amdt. 3941</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>76</yeas>
+        <nays>24</nays>
+      </vote_tally>
+      <title>Motion to Table Paul Amdt. No. 3941; To strike a provision modifying the definition of hemp for purposes of the Agricultural Marketing Act of 1946.</title>
+    </vote>
+    <vote>
+      <vote_number>00613</vote_number>
+      <vote_date>10-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On the Motion to Table
+        <measure>S.Amdt. 3946</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Merkley Motion to Table Amdt. No. 3946; To improve the bill.</title>
+    </vote>
+    <vote>
+      <vote_number>00612</vote_number>
+      <vote_date>10-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On the Motion to Table
+        <measure>S.Amdt. 3947</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Baldwin Motion to Table Amdt. No. 3947; To improve the bill.</title>
+    </vote>
+    <vote>
+      <vote_number>00611</vote_number>
+      <vote_date>10-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00610</vote_number>
+      <vote_date>09-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Upon Reconsideration, Motion to Invoke Cloture on the Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00609</vote_number>
+      <vote_date>07-Nov</vote_date>
+      <issue>S. 3012</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 3012, Upon Reconsideration; A bill to appropriate funds for pay and allowances of excepted Federal employees for periods of work performed during a lapse in appropriations, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00608</vote_number>
+      <vote_date>06-Nov</vote_date>
+      <issue>S.J.Res. 90</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Discharge S.J.Res. 90; A joint resolution to direct the removal of United States Armed Forces from hostilities within or against Venezuela that have not been authorized by Congress.</title>
+    </vote>
+    <vote>
+      <vote_number>00607</vote_number>
+      <vote_date>05-Nov</vote_date>
+      <issue>PN25-37</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>57</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Caleb Orr, of Texas, to be an Assistant Secretary of State (Economic and Business Affairs)</title>
+    </vote>
+    <vote>
+      <vote_number>00606</vote_number>
+      <vote_date>05-Nov</vote_date>
+      <issue>PN25-37</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>57</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Caleb Orr to be an Assistant Secretary of State (Economic and Business Affairs)</title>
+    </vote>
+    <vote>
+      <vote_number>00605</vote_number>
+      <vote_date>05-Nov</vote_date>
+      <issue>PN400-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Eric Chunyee Tung, of California, to be U.S. Circuit Judge for the Ninth Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00604</vote_number>
+      <vote_date>04-Nov</vote_date>
+      <issue>PN400-1</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Joshua D. Dunlap, of Maine, to be U.S. Circuit Judge for the First Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00603</vote_number>
+      <vote_date>04-Nov</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00602</vote_number>
+      <vote_date>03-Nov</vote_date>
+      <issue>PN400-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Eric Chunyee Tung to be U.S. Circuit Judge for the Ninth Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00601</vote_number>
+      <vote_date>30-Oct</vote_date>
+      <issue>PN400-1</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Joshua D. Dunlap to be U.S. Circuit Judge for the First Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00600</vote_number>
+      <vote_date>30-Oct</vote_date>
+      <issue>S.J.Res. 88</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>S.J.Res. 88; A joint resolution terminating the national emergency declared to impose global tariffs.</title>
+    </vote>
+    <vote>
+      <vote_number>00599</vote_number>
+      <vote_date>30-Oct</vote_date>
+      <issue>S.J.Res. 80</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>S.J. Res. 80; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "National Petroleum Reserve in Alaska Integrated Activity Plan Record of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00598</vote_number>
+      <vote_date>29-Oct</vote_date>
+      <issue>S.J.Res. 77</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>S.J.Res. 77; A joint resolution terminating the national emergency declared to impose duties on articles imported from Canada.</title>
+    </vote>
+    <vote>
+      <vote_number>00597</vote_number>
+      <vote_date>29-Oct</vote_date>
+      <issue>S.J.Res. 69</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>25</yeas>
+        <nays>72</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J.Res. 69; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the United States Fish and Wildlife Service relating to "Record of Decision for the Barred Owl Management Strategy; Washington, Oregon, and California".</title>
+    </vote>
+    <vote>
+      <vote_number>00596</vote_number>
+      <vote_date>29-Oct</vote_date>
+      <issue>PN466-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Edmund G. LaCour, Jr., of Alabama, to be U.S. District Judge for the Northern District of Alabama</title>
+    </vote>
+    <vote>
+      <vote_number>00595</vote_number>
+      <vote_date>29-Oct</vote_date>
+      <issue>S.J.Res. 80</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J.Res. 80; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "National Petroleum Reserve in Alaska Integrated Activity Plan Record of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00594</vote_number>
+      <vote_date>28-Oct</vote_date>
+      <issue>S.J.Res. 81</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>S.J.Res. 81; A joint resolution terminating the national emergency declared to impose duties on articles imported from Brazil.</title>
+    </vote>
+    <vote>
+      <vote_number>00593</vote_number>
+      <vote_date>28-Oct</vote_date>
+      <issue>PN466-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Edmund G. LaCour, Jr. to be U.S. District Judge for the Northern District of Alabama</title>
+    </vote>
+    <vote>
+      <vote_number>00592</vote_number>
+      <vote_date>28-Oct</vote_date>
+      <issue>PN346-6</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Jordan Emery Pratt, of Florida, to be U.S. District Judge for the Middle District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00591</vote_number>
+      <vote_date>28-Oct</vote_date>
+      <issue>PN346-6</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jordan Emery Pratt to be U.S. District Judge for the Middle District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00590</vote_number>
+      <vote_date>28-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Upon Reconsideration: Motion to Invoke Cloture on the Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00589</vote_number>
+      <vote_date>27-Oct</vote_date>
+      <issue>PN466-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>58</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Confirmation: Bill Lewis, of Alabama, to be U.S. District Judge for the Middle District of Alabama</title>
+    </vote>
+    <vote>
+      <vote_number>00588</vote_number>
+      <vote_date>27-Oct</vote_date>
+      <issue>PN520-5</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Rebecca L. Taibleson, of Wisconsin, to be U.S. Circuit Judge for the Seventh Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00587</vote_number>
+      <vote_date>23-Oct</vote_date>
+      <issue>PN520-5</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Rebecca L. Taibleson to be U.S. Circuit Judge for the Seventh Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00586</vote_number>
+      <vote_date>23-Oct</vote_date>
+      <issue>PN368</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Stephen Chad Meredith, of Kentucky, to be U.S. District Judge for the Eastern District of Kentucky</title>
+    </vote>
+    <vote>
+      <vote_number>00585</vote_number>
+      <vote_date>23-Oct</vote_date>
+      <issue>S. 3012</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 3012; A bill to appropriate funds for pay and allowances of excepted Federal employees for periods of work performed during a lapse in appropriations, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00584</vote_number>
+      <vote_date>22-Oct</vote_date>
+      <issue>PN400-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: William W. Mercer, of Montana, to be U.S. District Judge for the District of Montana</title>
+    </vote>
+    <vote>
+      <vote_number>00583</vote_number>
+      <vote_date>22-Oct</vote_date>
+      <issue>PN368</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Stephen Chad Meredith to be U.S. District Judge for the Eastern District of Kentucky</title>
+    </vote>
+    <vote>
+      <vote_number>00582</vote_number>
+      <vote_date>22-Oct</vote_date>
+      <issue>PN466-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Bill Lewis to be U.S. District Judge for the Middle District of Alabama</title>
+    </vote>
+    <vote>
+      <vote_number>00581</vote_number>
+      <vote_date>22-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00580</vote_number>
+      <vote_date>21-Oct</vote_date>
+      <issue>PN346-5</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Anne-Leigh Gaylord Moe, of Florida, to be U.S. District Judge for the Middle District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00579</vote_number>
+      <vote_date>21-Oct</vote_date>
+      <issue>PN400-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: William W. Mercer to be U.S. District Judge for the District of Montana</title>
+    </vote>
+    <vote>
+      <vote_number>00578</vote_number>
+      <vote_date>21-Oct</vote_date>
+      <issue>PN346-5</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Anne-Leigh Gaylord Moe to be U.S. District Judge for the Middle District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00577</vote_number>
+      <vote_date>21-Oct</vote_date>
+      <issue>PN466-6</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>66</yeas>
+        <nays>32</nays>
+      </vote_tally>
+      <title>Confirmation: Harold D. Mooty III, of Alabama, to be U.S. District Judge for the Northern District of Alabama</title>
+    </vote>
+    <vote>
+      <vote_number>00576</vote_number>
+      <vote_date>20-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00575</vote_number>
+      <vote_date>16-Oct</vote_date>
+      <issue>H.R. 4016</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture on the Motion to Proceed to H.R. 4016; A bill making appropriations for the Department of Defense for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00574</vote_number>
+      <vote_date>16-Oct</vote_date>
+      <issue>PN466-6</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>62</yeas>
+        <nays>34</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Harold D. Mooty III to be U.S. District Judge for the Northern District of Alabama</title>
+    </vote>
+    <vote>
+      <vote_number>00573</vote_number>
+      <vote_date>16-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture on the Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00572</vote_number>
+      <vote_date>15-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Upon Reconsideration, Motion to Invoke Cloture on the Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00571</vote_number>
+      <vote_date>14-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00570</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2296</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>77</yeas>
+        <nays>20</nays>
+      </vote_tally>
+      <title>S. 2296, as amended; An original bill to authorize appropriations for fiscal year 2026 for military activities of the Department of Defense, for military construction, and for defense activities of the Department of Energy, to prescribe military personnel strengths for such fiscal year, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00569</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3927</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Merkley Amdt. No. 3927; To limit the use of Federal law enforcement officers for crowd control, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00568</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3853</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>10</yeas>
+        <nays>88</nays>
+      </vote_tally>
+      <title>Sanders Amdt. No. 3853; To reduce the bloated Pentagon budget by 10 percent and instead expand veteran dental care at the Department of Veterans Affairs.</title>
+    </vote>
+    <vote>
+      <vote_number>00567</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3210</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Duckworth Amdt. No. 3210; To limit the provision of support by the Armed Forces to civilian law enforcement activities.</title>
+    </vote>
+    <vote>
+      <vote_number>00566</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3872</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Van Hollen Amdt. No. 3872; To amend title 32, United States Code, to clarify certain limitations on full-time National Guard duty performed in a State, Territory, or the District of Columbia.</title>
+    </vote>
+    <vote>
+      <vote_number>00565</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3109</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Schumer Amdt. No. 3109; To prohibit the use of funds to procure or modify foreign aircraft for presidential airlift.</title>
+    </vote>
+    <vote>
+      <vote_number>00564</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3697</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Curtis Amdt. No. 3697; To require a review of the methodologies used to determine the amounts of locality-based comparability payments and to require the President's Pay Agent to conduct a pilot program establishing alternative models for determining the amounts of those payments.</title>
+    </vote>
+    <vote>
+      <vote_number>00563</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3535</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Scott (FL) Amdt. No. 3535; To require Presidential appointment and Senate confirmation of the Inspector General of the Board of Governors of the Federal Reserve System and the Bureau of Consumer Financial Protection.</title>
+    </vote>
+    <vote>
+      <vote_number>00562</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3761</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>14</yeas>
+        <nays>83</nays>
+      </vote_tally>
+      <title>Paul Amdt. No. 3761; To prohibit earnings on balances maintained at a Federal Reserve bank by or on behalf of a depository institution.</title>
+    </vote>
+    <vote>
+      <vote_number>00561</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>PN466-4</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Jennifer Lee Mascott, of Delaware, to be U.S. Circuit Judge for the Third Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00560</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>H.J.Res. 106</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>H. J. Res. 106; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "Central Yukon Record of Decision and Approved Resource Management Plan".</title>
+    </vote>
+    <vote>
+      <vote_number>00559</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>H.J.Res. 106</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H. J. Res. 106; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "Central Yukon Record of Decision and Approved Resource Management Plan".</title>
+    </vote>
+    <vote>
+      <vote_number>00558</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00557</vote_number>
+      <vote_date>09-Oct</vote_date>
+      <issue>S. 2882</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 2882; A bill making continuing appropriations for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00556</vote_number>
+      <vote_date>08-Oct</vote_date>
+      <issue>H.J.Res. 105</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>H. J. Res. 105; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "North Dakota Field Office Record of Decision and Approved Resource Management Plan".</title>
+    </vote>
+    <vote>
+      <vote_number>00555</vote_number>
+      <vote_date>08-Oct</vote_date>
+      <issue>S.J.Res. 83</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Discharge S. J. Res. 83 from the Committee on Foreign Relations; A joint resolution to direct the removal of United States Armed Forces from hostilities that have not been authorized by Congress.</title>
+    </vote>
+    <vote>
+      <vote_number>00554</vote_number>
+      <vote_date>08-Oct</vote_date>
+      <issue>S.J.Res. 71</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>S. J. Res. 71; A joint resolution terminating the national emergency declared with respect to energy.</title>
+    </vote>
+    <vote>
+      <vote_number>00553</vote_number>
+      <vote_date>08-Oct</vote_date>
+      <issue>H.J.Res. 105</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H. J. Res. 105; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "North Dakota Field Office Record of Decision and Approved Resource Management Plan".</title>
+    </vote>
+    <vote>
+      <vote_number>00552</vote_number>
+      <vote_date>08-Oct</vote_date>
+      <issue>PN466-4</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jennifer Lee Mascott to be U.S. Circuit Judge for the Third Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00551</vote_number>
+      <vote_date>08-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Upon Reconsideration, Motion to Invoke Cloture on the Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00550</vote_number>
+      <vote_date>08-Oct</vote_date>
+      <issue>S. 2882</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Upon Reconsideration, Motion to Invoke Cloture on the Motion to Proceed to S. 2882; A bill making continuing appropriations for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00549</vote_number>
+      <vote_date>08-Oct</vote_date>
+      <issue>H.J.Res. 104</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>H. J. Res. 104; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "Miles City Field Office Record of Decision and Approved Resource Management Plan Amendment".</title>
+    </vote>
+    <vote>
+      <vote_number>00548</vote_number>
+      <vote_date>07-Oct</vote_date>
+      <issue>H.J.Res. 104</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H. J. Res. 104; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Land Management relating to "Miles City Field Office Record of Decision and Approved Resource Management Plan Amendment".</title>
+    </vote>
+    <vote>
+      <vote_number>00547</vote_number>
+      <vote_date>07-Oct</vote_date>
+      <en_bloc>
+        <matter>
+          <issue>PN22-9</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN345-19</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN345-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-15</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-49</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-24</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-10</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN12-21</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN465-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN465-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN465-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN416-11</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN380-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN380-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-14</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-48</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-37</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-32</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-29</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-23</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-21</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-19</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-11</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN54-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN54-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN54-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN54-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-41</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-30</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-17</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-34</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-18</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-38</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-15</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-31</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-32</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-13</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-24</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-36</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-32</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-21</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-14</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN379-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN416-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-15</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-14</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-52</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-48</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-15</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-23</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-9</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-19</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN246-17</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-38</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-23</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-17</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-48</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN13-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-33</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-6</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-6</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-40</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-14</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-47</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-11</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-55</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-34</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-17</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-46</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-12</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-49</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-16</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-46</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-25</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-14</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-16</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-12</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-35</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-22</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-38</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN24-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-28</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-13</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-6</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN12-17</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-30</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-21</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-33</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-23</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-9</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-13</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN18</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+      </en_bloc>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: En Bloc Nominations Provided for Under the Provisions of S. Res. 412</title>
+    </vote>
+    <vote>
+      <vote_number>00546</vote_number>
+      <vote_date>06-Oct</vote_date>
+      <en_bloc>
+        <matter>
+          <issue>PN22-9</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN345-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN345-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-15</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-49</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-24</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-10</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN12-21</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN465-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN465-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN465-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-11</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN380-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN380-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-14</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-48</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-37</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-32</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-29</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-23</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-21</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-11</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN54-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN54-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN54-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN54-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-41</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-30</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-17</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-34</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-18</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-38</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-15</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-31</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-32</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-13</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-24</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-36</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-32</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-21</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-14</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN379-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN416-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-15</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-14</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-52</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-48</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-15</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-23</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-9</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN246-17</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-38</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-23</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-17</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-48</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN13-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-33</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-6</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-6</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-40</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-14</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-47</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-11</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-55</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-34</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-17</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-46</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-12</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-49</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-16</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-46</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-25</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-14</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-16</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-12</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-35</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-22</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-38</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN24-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-28</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-13</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-6</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN12-17</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-30</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-21</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-33</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-23</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-9</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-13</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN18</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+      </en_bloc>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: En Bloc Nominations Provided for Under the Provisions of S.Res. 412</title>
+    </vote>
+    <vote>
+      <vote_number>00545</vote_number>
+      <vote_date>06-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00544</vote_number>
+      <vote_date>06-Oct</vote_date>
+      <issue>S. 2882</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>45</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 2882; A bill making continuing appropriations for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00543</vote_number>
+      <vote_date>03-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Upon Reconsideration, Motion to Invoke Cloture on the Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00542</vote_number>
+      <vote_date>03-Oct</vote_date>
+      <issue>S. 2882</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Upon Reconsideration, Motion to Invoke Cloture on the Motion to Proceed to S. 2882; A bill making continuing appropriations for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00541</vote_number>
+      <vote_date>03-Oct</vote_date>
+      <issue>S.Res. 412</issue>
+      <question>On the Resolution
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>S.Res. 412; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00540</vote_number>
+      <vote_date>01-Oct</vote_date>
+      <issue>S.Res. 412</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Executive Calendar No. 2, S.Res. 412; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00539</vote_number>
+      <vote_date>01-Oct</vote_date>
+      <issue>PN26-10</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Hung Cao, of Virginia, to be Under Secretary of the Navy</title>
+    </vote>
+    <vote>
+      <vote_number>00538</vote_number>
+      <vote_date>01-Oct</vote_date>
+      <issue>PN26-10</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Hung Cao to be Under Secretary of the Navy</title>
+    </vote>
+    <vote>
+      <vote_number>00537</vote_number>
+      <vote_date>01-Oct</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>55</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00536</vote_number>
+      <vote_date>01-Oct</vote_date>
+      <issue>S. 2882</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 2882; A bill making continuing appropriations for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00535</vote_number>
+      <vote_date>30-Sep</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>55</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Upon Reconsideration, H.R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00534</vote_number>
+      <vote_date>30-Sep</vote_date>
+      <issue>S. 2882</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Upon Reconsideration, S. 2882; A bill making continuing appropriations for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00533</vote_number>
+      <vote_date>29-Sep</vote_date>
+      <issue>S. 2806</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>37</yeas>
+        <nays>61</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 2806; A bill to provide for automatic continuing appropriations.</title>
+    </vote>
+    <vote>
+      <vote_number>00532</vote_number>
+      <vote_date>29-Sep</vote_date>
+      <issue>PN342</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Michael G. Waltz, of Florida, to be Representative of the United States of America to the General Assembly of the United Nations</title>
+    </vote>
+    <vote>
+      <vote_number>00531</vote_number>
+      <vote_date>29-Sep</vote_date>
+      <issue>PN342</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Michael G. Waltz to be Representative of the United States of America to the Sessions of the General Assembly of the United Nations</title>
+    </vote>
+    <vote>
+      <vote_number>00530</vote_number>
+      <vote_date>19-Sep</vote_date>
+      <issue>PN343</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Michael G. Waltz, of Florida, to be the Representative of the United States of America to the United Nations</title>
+    </vote>
+    <vote>
+      <vote_number>00529</vote_number>
+      <vote_date>19-Sep</vote_date>
+      <issue>PN343</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Michael G. Waltz to be Representative of the United States of America to the United Nations</title>
+    </vote>
+    <vote>
+      <vote_number>00528</vote_number>
+      <vote_date>19-Sep</vote_date>
+      <issue>H.R. 5371</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>44</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>H. R. 5371; A bill making continuing appropriations and extensions for fiscal year 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00527</vote_number>
+      <vote_date>19-Sep</vote_date>
+      <issue>S. 2882</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>S. 2882; A bill making continuing appropriations for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00526</vote_number>
+      <vote_date>18-Sep</vote_date>
+      <en_bloc>
+        <matter>
+          <issue>PN55-25</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-45</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN54-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN54-6</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-42</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN345-16</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN150-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-18</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-33</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-24</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN13-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-22</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-21</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN12-22</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-28</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN141-37</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-45</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN129-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-10</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-9</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-16</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-44</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN60-3</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-31</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-19</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-7</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-40</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-23</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-19</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-4</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN55-41</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-35</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-34</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN26-8</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-21</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-20</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-27</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-5</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-2</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN22-1</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN12-45</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN12-19</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+        <matter>
+          <issue>PN25-28</issue>
+          <question>On the Nomination</question>
+          <result>Confirmed</result>
+        </matter>
+      </en_bloc>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Executive Calendar Nos: 89, 105, 107, 121, 122, 123, 124, 132, 133, 135, 136, 137, 139, 141, 142, 152, 153, 154, 156, 157, 161, 177, 180, 185, 251, 276, 277, 278, 279, 283, 285, 289, 290, 297, 298, 303, 305, 324, 344, 346, 352, 356, 362, 365, 149, 286, 302, 350, en bloc</title>
+    </vote>
+    <vote>
+      <vote_number>00525</vote_number>
+      <vote_date>17-Sep</vote_date>
+      <en_bloc>
+        <matter>
+          <issue>PN25-28</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN12-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN12-45</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-27</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-20</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-21</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-34</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-35</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-41</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-23</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-40</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-31</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-44</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-16</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-9</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-10</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-45</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-37</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-28</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN12-22</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-21</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-22</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN13-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-24</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-33</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-18</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN150-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN345-16</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-42</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN54-6</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN54-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-45</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-25</issue>
+          <question>On the Cloture Motion</question>
+          <result>Agreed to</result>
+        </matter>
+      </en_bloc>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Executive Calendar Nos: 89, 105, 107, 121, 122, 123, 124, 132, 133, 135, 136, 137, 139, 141, 142, 152, 153, 154, 156, 157, 161, 177, 180, 185, 251, 276, 277, 278, 279, 283, 285, 289, 290, 297, 298, 303, 305, 324, 344, 346, 352, 356, 362, 365, 149, 286, 302, 350, en bloc, Upon Reconsideration</title>
+    </vote>
+    <vote>
+      <vote_number>00524</vote_number>
+      <vote_date>17-Sep</vote_date>
+      <en_bloc>
+        <matter>
+          <issue>PN12-19</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN25-28</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN12-45</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-1</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-2</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-5</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-27</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-20</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-21</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-8</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-34</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-35</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN55-41</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-4</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-8</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-19</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-1</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-23</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN25-40</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-7</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-19</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-31</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN60-3</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-44</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN25-2</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN55-16</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN60-9</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN60-10</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN129-8</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-45</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN141-37</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN141-7</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN141-28</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN12-22</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN25-21</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-3</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN26-22</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN13-5</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN22-24</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN25-33</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN141-18</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN150-5</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN345-16</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN55-42</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN54-6</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN54-7</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN55-45</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+        <matter>
+          <issue>PN55-25</issue>
+          <question>On the Decision of the Chair</question>
+          <result>Not Sustained</result>
+        </matter>
+      </en_bloc>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Shall the Decision of the Chair stand as the Judgment of the Senate?</title>
+    </vote>
+    <vote>
+      <vote_number>00523</vote_number>
+      <vote_date>17-Sep</vote_date>
+      <en_bloc>
+        <matter>
+          <issue>PN55-25</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-45</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN54-7</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN54-6</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-42</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN345-16</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN150-5</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-18</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-33</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-24</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN13-5</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-22</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-3</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-21</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN12-22</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-28</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-7</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN141-37</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-45</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN129-8</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-10</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-9</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-16</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-2</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-44</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN60-3</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-31</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-19</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-7</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-40</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-23</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-1</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-19</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-8</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-4</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN55-41</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-35</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-34</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN26-8</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-21</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-20</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-27</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-5</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-2</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN22-1</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN12-45</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN12-19</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+        <matter>
+          <issue>PN25-28</issue>
+          <question>On the Motion to Reconsider</question>
+          <result>Agreed to</result>
+        </matter>
+      </en_bloc>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Reconsider the Vote by which the Motion to Invoke Cloture on Executive Calendar Nos. en bloc (Roll Call Vote No. 522) was not agreed to</title>
+    </vote>
+    <vote>
+      <vote_number>00522</vote_number>
+      <vote_date>17-Sep</vote_date>
+      <en_bloc>
+        <matter>
+          <issue>PN25-28</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN12-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN12-45</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-27</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-20</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-21</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-34</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-35</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN55-41</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-4</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-1</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-23</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN25-40</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-19</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-31</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN60-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-44</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN25-2</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN55-16</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN60-9</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN60-10</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN129-8</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-45</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN141-37</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN141-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN141-28</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN12-22</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN25-21</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-3</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN26-22</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN13-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN22-24</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN25-33</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN141-18</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN150-5</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN345-16</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN55-42</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN54-6</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN54-7</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN55-45</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+        <matter>
+          <issue>PN55-25</issue>
+          <question>On the Cloture Motion</question>
+          <result>Rejected</result>
+        </matter>
+      </en_bloc>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Executive Calendar Nos: 89, 105, 107, 121, 122, 123, 124, 132, 133, 135, 136, 137, 139, 141, 142, 152, 153, 154, 156, 157, 161, 177, 180, 185, 251, 276, 277, 278, 279, 283, 285, 289, 290, 297, 298, 303, 305, 324, 344, 346, 352, 356, 362, 365, 149, 286, 302, 350, en bloc</title>
+    </vote>
+    <vote>
+      <vote_number>00521</vote_number>
+      <vote_date>16-Sep</vote_date>
+      <issue>S.Con.Res. 22</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>36</yeas>
+        <nays>62</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S. Con. Res. 22; A concurrent resolution setting forth the congressional budget for the United States Government for fiscal year 2026 and setting forth the appropriate budgetary levels for fiscal years 2027 through 2035.</title>
+    </vote>
+    <vote>
+      <vote_number>00520</vote_number>
+      <vote_date>16-Sep</vote_date>
+      <issue>S.J.Res. 60</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S. J. Res. 60; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "Emissions Budget and Allowance Allocations for Indiana Under the Revised Cross-State Air Pollution Rule Update".</title>
+    </vote>
+    <vote>
+      <vote_number>00519</vote_number>
+      <vote_date>15-Sep</vote_date>
+      <issue>PN464</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Stephen Miran, of New York, to be a Member of the Board of Governors of the Federal Reserve System</title>
+    </vote>
+    <vote>
+      <vote_number>00518</vote_number>
+      <vote_date>15-Sep</vote_date>
+      <issue>PN464</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Stephen Miran to be a Member of the Board of Governors of the Federal Reserve System</title>
+    </vote>
+    <vote>
+      <vote_number>00517</vote_number>
+      <vote_date>15-Sep</vote_date>
+      <issue>S.Res. 377</issue>
+      <question>On the Resolution
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>S. Res. 377; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00516</vote_number>
+      <vote_date>11-Sep</vote_date>
+      <issue>S.Res. 377</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture on Executive Calendar #1 S.Res. 377, Upon Reconsideration; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00515</vote_number>
+      <vote_date>11-Sep</vote_date>
+      <issue>S.Res. 377</issue>
+      <question>On the Decision of the Chair
+         </question>
+      <result>Not Sustained</result>
+      <vote_tally>
+        <yeas>45</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Shall the Decision of the Chair stand as the Judgement of the Senate?; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00514</vote_number>
+      <vote_date>11-Sep</vote_date>
+      <issue>S.Res. 377</issue>
+      <question>On the Motion to Reconsider
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Reconsider the Vote by which the Motion to Invoke Cloture on S. Res. 377 was Not Agreed to; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00513</vote_number>
+      <vote_date>11-Sep</vote_date>
+      <issue>S.Res. 377</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: S. Res. 377; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00512</vote_number>
+      <vote_date>10-Sep</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Motion to Table
+        <measure>S.Amdt. 3849</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Motion to Table Schumer Amdt. No. 3849; To direct the Attorney General to make publicly available documents related to Jeffrey Epstein.</title>
+    </vote>
+    <vote>
+      <vote_number>00511</vote_number>
+      <vote_date>09-Sep</vote_date>
+      <issue>S.Res. 377</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to consider S.Res. 377; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00510</vote_number>
+      <vote_date>09-Sep</vote_date>
+      <issue>S.Res. 377</issue>
+      <question>On the Motion to Table
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Table Schumer Point of Order Re: S. Res. 377; An executive resolution authorizing the en bloc consideration in Executive Session of certain nominations on the Executive Calendar.</title>
+    </vote>
+    <vote>
+      <vote_number>00509</vote_number>
+      <vote_date>09-Sep</vote_date>
+      <issue>PN346-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Kyle Christopher Dudek, of Florida, to be U.S. District Judge for the Middle District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00508</vote_number>
+      <vote_date>09-Sep</vote_date>
+      <issue>PN346-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Kyle Christopher Dudek to be U.S. District Judge for the Middle District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00507</vote_number>
+      <vote_date>09-Sep</vote_date>
+      <issue>PN129-10</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Robert Law, of the District of Columbia, to be Under Secretary for Strategy, Policy, and Plans, Department of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00506</vote_number>
+      <vote_date>09-Sep</vote_date>
+      <issue>PN129-10</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Robert Law to be Under Secretary for Strategy, Policy, and Plans, Department of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00505</vote_number>
+      <vote_date>09-Sep</vote_date>
+      <issue>PN150-4</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Maria A. Lanahan, of Missouri, to be U.S. District Judge for the Eastern District of Missouri</title>
+    </vote>
+    <vote>
+      <vote_number>00504</vote_number>
+      <vote_date>08-Sep</vote_date>
+      <issue>PN346-1</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Edward L. Artau of Florida, to be United States District Judge for the Southern District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00503</vote_number>
+      <vote_date>04-Sep</vote_date>
+      <issue>S. 2296</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>83</yeas>
+        <nays>13</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S. 2296; An original bill to authorize appropriations for fiscal year 2026 for military activities of the Department of Defense, for military construction, and for defense activities of the Department of Energy, to prescribe military personnel strengths for such fiscal year, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00502</vote_number>
+      <vote_date>04-Sep</vote_date>
+      <issue>PN346-1</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Edward L. Artau to be U.S. District Judge for the Southern District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00501</vote_number>
+      <vote_date>04-Sep</vote_date>
+      <issue>PN150-4</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Maria A. Lanahan to be U.S. District Judge for the Eastern District of Missouri</title>
+    </vote>
+    <vote>
+      <vote_number>00500</vote_number>
+      <vote_date>02-Sep</vote_date>
+      <issue>S. 2296</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>84</yeas>
+        <nays>14</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 2296; An original bill to authorize appropriations for fiscal year 2026 for military activities of the Department of Defense, for military construction, and for defense activities of the Department of Energy, to prescribe military personnel strengths for such fiscal year, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00499</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN22-18</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>71</yeas>
+        <nays>23</nays>
+      </vote_tally>
+      <title>Confirmation: Marcus Molinaro, of New York, to be Federal Transit Administrator</title>
+    </vote>
+    <vote>
+      <vote_number>00498</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN55-43</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>72</yeas>
+        <nays>22</nays>
+      </vote_tally>
+      <title>Confirmation: Adam Telle, of Mississippi, to be an Assistant Secretary of the Army</title>
+    </vote>
+    <vote>
+      <vote_number>00497</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN24-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>35</nays>
+      </vote_tally>
+      <title>Confirmation: Sean Cairncross, of Minnesota, to be National Cyber Director</title>
+    </vote>
+    <vote>
+      <vote_number>00496</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN26-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Confirmation: John Arrigo, of Florida, to be Ambassador of the United States of America to the Portuguese Republic</title>
+    </vote>
+    <vote>
+      <vote_number>00495</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN25-16</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Catherine Hanson, of South Carolina, to be Chief Financial Officer, Environmental Protection Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00494</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN12-26</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>78</yeas>
+        <nays>17</nays>
+      </vote_tally>
+      <title> Confirmation: Luke Lindberg, of South Dakota, to be Under Secretary of Agriculture for Trade and Foreign Agricultural Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00493</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN12-26</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>76</yeas>
+        <nays>19</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Luke Lindberg to be Under Secretary of Agriculture for Trade and Foreign Agricultural Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00492</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN345-15</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Jeanine Pirro, of New York, to be United States Attorney for the District of Columbia </title>
+    </vote>
+    <vote>
+      <vote_number>00491</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN345-15</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jeanine Pirro to be United States Attorney for the District of Columbia</title>
+    </vote>
+    <vote>
+      <vote_number>00490</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN26-40</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Jason Reding Quinones, of Florida, to be United States Attorney for the Southern District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00489</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN26-40</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jason Reding Quinones to be United States Attorney for the Southern District of Florida</title>
+    </vote>
+    <vote>
+      <vote_number>00488</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN26-5</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Brian Burch, of Illinois, to be Ambassador of the United States of America to the Holy See</title>
+    </vote>
+    <vote>
+      <vote_number>00487</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN26-5</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Brian Burch to be Ambassador of the United States of America to the Holy See</title>
+    </vote>
+    <vote>
+      <vote_number>00486</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN26-39</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Andrew Puzder, of Tennessee, to be Representative of the United States of America to the European Union with the rank of Ambassador</title>
+    </vote>
+    <vote>
+      <vote_number>00485</vote_number>
+      <vote_date>02-Aug</vote_date>
+      <issue>PN26-39</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Andrew Puzder to be Representative of the United States of America to the European Union with the rank of Ambassador</title>
+    </vote>
+    <vote>
+      <vote_number>00484</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>PN25-26</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Nicholas Kent, of Virginia, to be Under Secretary of Education</title>
+    </vote>
+    <vote>
+      <vote_number>00483</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>PN26-49</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: David Woll, of Virginia, to be General Counsel of the Department of Housing and Urban Development</title>
+    </vote>
+    <vote>
+      <vote_number>00482</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>PN55-36</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Luigi Rinaldi, of New York, to be Ambassador of the United States of America to the Oriental Republic of Uruguay</title>
+    </vote>
+    <vote>
+      <vote_number>00481</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3412</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>81</yeas>
+        <nays>15</nays>
+      </vote_tally>
+      <title>Mullin Amdt. No. 3412; To improve the bill.</title>
+    </vote>
+    <vote>
+      <vote_number>00480</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>87</yeas>
+        <nays>9</nays>
+      </vote_tally>
+      <title>H. R. 3944, as amended; A bill making appropriations for military construction, the Department of Veterans Affairs, and related agencies for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00479</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3411</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>87</yeas>
+        <nays>9</nays>
+      </vote_tally>
+      <title>Collins Amdt. No. 3411, as amended; In the nature of a substitute.</title>
+    </vote>
+    <vote>
+      <vote_number>00478</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3428</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>21</yeas>
+        <nays>75</nays>
+      </vote_tally>
+      <title>Johnson Amdt. No. 3428; To limit disclosures regarding earmarks.</title>
+    </vote>
+    <vote>
+      <vote_number>00477</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3113</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>15</yeas>
+        <nays>81</nays>
+      </vote_tally>
+      <title>Scott (FL) Amdt. No. 3113, as modified; To reduce funding for certain programs under the division making appropriations for Agriculture, Rural Development, Food and Drug Administration, and Related Agencies.</title>
+    </vote>
+    <vote>
+      <vote_number>00476</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3414</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>14</yeas>
+        <nays>81</nays>
+      </vote_tally>
+      <title>Kennedy Amdt. No. 3414; To reduce the Agriculture discretionary appropriations by 2 percent across the board.</title>
+    </vote>
+    <vote>
+      <vote_number>00475</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3466</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>45</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Duckworth Amdt. No. 3466; To require the Secretary of Veterans Affairs to submit to Congress a report on the plan of the Secretary for Department of Veterans Affairs workforce reduction in fiscal year 2026.</title>
+    </vote>
+    <vote>
+      <vote_number>00474</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3115</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>42</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Van Hollen Amdt. No. 3115; To prohibit funds from being used for reorganization of the Department of Agriculture and to require a benefit-cost analysis on that reorganization, a public comment period, and a report.</title>
+    </vote>
+    <vote>
+      <vote_number>00473</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 3447</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>44</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Murphy Amdt. No. 3447; To require a report on veterans who would have been reported to the national instant criminal background check system and who die by suicide with a firearm.</title>
+    </vote>
+    <vote>
+      <vote_number>00472</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 3114</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>44</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Points of Order Re: Merkley Amdt. No. 3114; To limit recissions of funding.</title>
+    </vote>
+    <vote>
+      <vote_number>00471</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>PN55-36</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Luigi Rinaldi to be Ambassador Extraordinary and Plenipotentiary of the United States of America to the Oriental Republic of Uruguay</title>
+    </vote>
+    <vote>
+      <vote_number>00470</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>PN25-35</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Brian Nesvik, of Wyoming, to be Director of the United States Fish and Wildlife Service</title>
+    </vote>
+    <vote>
+      <vote_number>00469</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>PN13-11</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Casey Mulligan, of Illinois, to be Chief Counsel for Advocacy, Small Business Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00468</vote_number>
+      <vote_date>01-Aug</vote_date>
+      <issue>PN13-11</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>55</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Brian Nesvik to be Director of the United States Fish and Wildlife Service</title>
+    </vote>
+    <vote>
+      <vote_number>00467</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN25-26</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Nicholas Kent to be Under Secretary of Education</title>
+    </vote>
+    <vote>
+      <vote_number>00466</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN26-49</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: David Woll to be General Counsel of the Department of Housing and Urban Development</title>
+    </vote>
+    <vote>
+      <vote_number>00465</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN13-11</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Casey Mulligan to be Chief Counsel for Advocacy, Small Business Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00464</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN55-28</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Andrea Lucas, of Virginia, to be a Member of the Equal Employment Opportunity Commission </title>
+    </vote>
+    <vote>
+      <vote_number>00463</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN26-25</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Matthew Kozma, of Virginia, to be Under Secretary for Intelligence and Analysis, Department of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00462</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN55-28</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Andrea Lucas to be a Member of the Equal Employment Opportunity Commission </title>
+    </vote>
+    <vote>
+      <vote_number>00461</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN141-30</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Cheryl Mason, of North Carolina, to be Inspector General, Department of Veterans Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00460</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN26-42</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Confirmation: Gadyaces Serralta, of Florida, to be Director of the United States Marshals Service</title>
+    </vote>
+    <vote>
+      <vote_number>00459</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN25-8</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Tyler Clarkson, of Virginia, to be General Counsel of the Department of Agriculture</title>
+    </vote>
+    <vote>
+      <vote_number>00458</vote_number>
+      <vote_date>31-Jul</vote_date>
+      <issue>PN141-30</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Cheryl Mason to be Inspector General, Department of Veterans Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00457</vote_number>
+      <vote_date>30-Jul</vote_date>
+      <issue>PN26-25</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Matthew Kozma to be Under Secretary for Intelligence and Analysis, Department of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00456</vote_number>
+      <vote_date>30-Jul</vote_date>
+      <issue>PN26-42</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>38</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Gadyaces Serralta to be Director of the United States Marshals Service</title>
+    </vote>
+    <vote>
+      <vote_number>00455</vote_number>
+      <vote_date>30-Jul</vote_date>
+      <issue>S.J.Res. 34</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>24</yeas>
+        <nays>73</nays>
+      </vote_tally>
+      <title>Motion to Discharge S. J. Res. 34; A joint resolution providing for congressional disapproval of the proposed foreign military sale to the Government of Israel of certain defense articles and services.</title>
+    </vote>
+    <vote>
+      <vote_number>00454</vote_number>
+      <vote_date>30-Jul</vote_date>
+      <issue>S.J.Res. 41</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>27</yeas>
+        <nays>70</nays>
+      </vote_tally>
+      <title>Motion to Discharge S. J. Res. 41; A joint resolution providing for congressional disapproval of the proposed export of certain defense articles to Israel.</title>
+    </vote>
+    <vote>
+      <vote_number>00453</vote_number>
+      <vote_date>30-Jul</vote_date>
+      <issue>PN25-8</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Tyler Clarkson to be General Counsel of the Department of Agriculture</title>
+    </vote>
+    <vote>
+      <vote_number>00452</vote_number>
+      <vote_date>30-Jul</vote_date>
+      <issue>PN25-27</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Joseph Kent, of Washington, to be Director of the National Counterterrorism Center, Office of the Director of National Intelligence</title>
+    </vote>
+    <vote>
+      <vote_number>00451</vote_number>
+      <vote_date>30-Jul</vote_date>
+      <issue>PN25-27</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jospeh Kent to be Director of the National Counterterrorism Center, Office of the Director of National Intelligence</title>
+    </vote>
+    <vote>
+      <vote_number>00450</vote_number>
+      <vote_date>30-Jul</vote_date>
+      <issue>PN129-4</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Thomas Gaiser, of Ohio, to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00449</vote_number>
+      <vote_date>30-Jul</vote_date>
+      <issue>PN129-4</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Thomas Gaiser to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00448</vote_number>
+      <vote_date>29-Jul</vote_date>
+      <issue>PN346-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Confirmation: Emil Bove III, of Pennsylvania, to be United States Circuit Judge for the Third Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00447</vote_number>
+      <vote_date>29-Jul</vote_date>
+      <issue>PN12-7</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Samuel Brown, of Nevada, to be Under Secretary of Veterans Affairs for Memorial Services</title>
+    </vote>
+    <vote>
+      <vote_number>00446</vote_number>
+      <vote_date>29-Jul</vote_date>
+      <issue>PN12-7</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Samuel Brown to be Under Secretary of Veterans Affairs for Memorial Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00445</vote_number>
+      <vote_date>29-Jul</vote_date>
+      <issue>PN60-14</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Susan Monarez, of Wisconsin, to be Director of the Centers for Disease Control and Prevention</title>
+    </vote>
+    <vote>
+      <vote_number>00444</vote_number>
+      <vote_date>29-Jul</vote_date>
+      <issue>PN60-14</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Susan Monarez to be Director of the Centers for Disease Control and Prevention</title>
+    </vote>
+    <vote>
+      <vote_number>00443</vote_number>
+      <vote_date>29-Jul</vote_date>
+      <issue>PN22-13</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: William Kimmitt, of Virginia, to be Under Secretary of Commerce for International Trade</title>
+    </vote>
+    <vote>
+      <vote_number>00442</vote_number>
+      <vote_date>29-Jul</vote_date>
+      <issue>PN22-13</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: William Kimmitt to be Under Secretary of Commerce for International Trade</title>
+    </vote>
+    <vote>
+      <vote_number>00441</vote_number>
+      <vote_date>29-Jul</vote_date>
+      <issue>PN22-17</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Earl Matthews, of Virginia, to be General Counsel of the Department of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00440</vote_number>
+      <vote_date>28-Jul</vote_date>
+      <issue>PN22-17</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Earl Matthews to be General Counsel of the Department of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00439</vote_number>
+      <vote_date>28-Jul</vote_date>
+      <issue>PN345-20</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Confirmation: David Wright, of South Carolina, to be a Member of the Nuclear Regulatory Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00438</vote_number>
+      <vote_date>28-Jul</vote_date>
+      <issue>PN345-20</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: David Wright to be a Member of the Nuclear Regulatory Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00437</vote_number>
+      <vote_date>24-Jul</vote_date>
+      <issue>PN346-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Emil J. Bove III to be U.S. Circuit Judge for the Third Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00436</vote_number>
+      <vote_date>24-Jul</vote_date>
+      <issue>PN25-54</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Richard Topping, of Ohio, to be Chief Financial Officer, Department of Veterans Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00435</vote_number>
+      <vote_date>24-Jul</vote_date>
+      <issue>PN25-54</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Richard Topping to be Chief Financial Officer, Department of Veterans Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00434</vote_number>
+      <vote_date>24-Jul</vote_date>
+      <issue>PN22-15</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Matthew Lohmeier, of Arizona, to be Under Secretary of the Air Force</title>
+    </vote>
+    <vote>
+      <vote_number>00433</vote_number>
+      <vote_date>23-Jul</vote_date>
+      <issue>PN22-15</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Matthew Lohmeier to be Under Secretary of the Air Force</title>
+    </vote>
+    <vote>
+      <vote_number>00432</vote_number>
+      <vote_date>23-Jul</vote_date>
+      <issue>PN25-53</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Aaron Szabo, of Virginia, to be an Assistant Administrator of the Environmental Protection Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00431</vote_number>
+      <vote_date>23-Jul</vote_date>
+      <issue>PN25-53</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Aaron Szabo to be an Assistant Administrator of the Environmental Protection Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00430</vote_number>
+      <vote_date>23-Jul</vote_date>
+      <issue>PN150-1</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Zachary M. Bluestone, of Missouri, to be U.S. District Judge for the Eastern District of Missouri</title>
+    </vote>
+    <vote>
+      <vote_number>00429</vote_number>
+      <vote_date>23-Jul</vote_date>
+      <issue>PN150-1</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Zachary M. Bluestone to be U.S. District Judge for the Eastern District of Missouri</title>
+    </vote>
+    <vote>
+      <vote_number>00428</vote_number>
+      <vote_date>23-Jul</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>90</yeas>
+        <nays>8</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.R. 3944; A bill making appropriations for military construction, the Department of Veterans Affairs, and related agencies for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00427</vote_number>
+      <vote_date>23-Jul</vote_date>
+      <issue>PN24-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: John Hurley, of California, to be Under Secretary for Terrorism and Financial Crimes</title>
+    </vote>
+    <vote>
+      <vote_number>00426</vote_number>
+      <vote_date>23-Jul</vote_date>
+      <issue>PN22-25</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Confirmation: Arielle Roth, of the District of Columbia, to be Assistant Secretary of Communications and Information</title>
+    </vote>
+    <vote>
+      <vote_number>00425</vote_number>
+      <vote_date>22-Jul</vote_date>
+      <issue>PN22-7</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>61</yeas>
+        <nays>35</nays>
+      </vote_tally>
+      <title>Confirmation: Bradley Hansell, of Virginia, to be Under Secretary of Defense for Intelligence and Security</title>
+    </vote>
+    <vote>
+      <vote_number>00424</vote_number>
+      <vote_date>22-Jul</vote_date>
+      <issue>PN26-27</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Aaron Lukas, of Arkansas, to be Principal Deputy Director of National Intelligence</title>
+    </vote>
+    <vote>
+      <vote_number>00423</vote_number>
+      <vote_date>22-Jul</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>91</yeas>
+        <nays>7</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to H.R. 3944; A bill making appropriations for military construction, the Department of Veterans Affairs, and related agencies for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00422</vote_number>
+      <vote_date>22-Jul</vote_date>
+      <issue>H.R. 3944</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to consider Emil J. Bove III; A bill making appropriations for military construction, the Department of Veterans Affairs, and related agencies for the fiscal year ending September 30, 2026, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00421</vote_number>
+      <vote_date>22-Jul</vote_date>
+      <issue>PN150-6</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Cristian M. Stevens, of Missouri, to be United States District Judge for the Eastern District of Missouri</title>
+    </vote>
+    <vote>
+      <vote_number>00420</vote_number>
+      <vote_date>22-Jul</vote_date>
+      <issue>PN150-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Joshua M. Divine, of Missouri, to be United States District Judge for the Eastern and Western Districts of Missouri</title>
+    </vote>
+    <vote>
+      <vote_number>00419</vote_number>
+      <vote_date>22-Jul</vote_date>
+      <issue>PN26-11</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Terrance Cole, of Virginia, to be Administrator of Drug Enforcement</title>
+    </vote>
+    <vote>
+      <vote_number>00418</vote_number>
+      <vote_date>21-Jul</vote_date>
+      <issue>PN26-11</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>44</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Terrance Cole to be Administrator of Drug Enforcement</title>
+    </vote>
+    <vote>
+      <vote_number>00417</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>PN24-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>36</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: John Hurley to be Under Secretary for Terrorism and Financial Crimes</title>
+    </vote>
+    <vote>
+      <vote_number>00416</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>PN22-25</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>34</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Arielle Roth to be Assistant Secretary of Commerce for Communications and Information</title>
+    </vote>
+    <vote>
+      <vote_number>00415</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>PN22-7</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>57</yeas>
+        <nays>31</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Bradley Hansell to be Under Secretary of Defense for Intelligence and Security</title>
+    </vote>
+    <vote>
+      <vote_number>00414</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>PN26-27</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Aaron Lukas to be Principal Deputy Director of National Intelligence</title>
+    </vote>
+    <vote>
+      <vote_number>00413</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>PN150-6</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Cristian M. Stevens to be U.S. District Judge for the Eastern District of Missouri</title>
+    </vote>
+    <vote>
+      <vote_number>00412</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>PN150-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Joshua M. Divine to be U.S. District Judge for the Eastern and Western Districts of Missouri</title>
+    </vote>
+    <vote>
+      <vote_number>00411</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>H.R. 4, As Amended; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00410</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2853</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Schmitt Admt. No. 2853; In the nature of a substitute.</title>
+    </vote>
+    <vote>
+      <vote_number>00409</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2863</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Merkley Amdt. No. 2863; To strike the paragraph of the bill that rescinds $15,000,000 that had been appropriated for the United States Institute of Peace.</title>
+    </vote>
+    <vote>
+      <vote_number>00408</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2896</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Ossoff Amdt. No. 2896; To reduce the amount rescinded from International Organizations and Programs and to ensure that UNICEF receives all of the funding previously appropriated to it by Congress.</title>
+    </vote>
+    <vote>
+      <vote_number>00407</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2898</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Shaheen Amdt. No. 2898; To reduce the amount rescinded from Assistance for Europe, Eurasia and Central Asia.</title>
+    </vote>
+    <vote>
+      <vote_number>00406</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2865</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Murkowski Amdt. No. 2865; To improve the bill.</title>
+    </vote>
+    <vote>
+      <vote_number>00405</vote_number>
+      <vote_date>17-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Table
+        <measure>S.Amdt. 2893</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Table Amdt. No. 2893; In the nature of a substitute.</title>
+    </vote>
+    <vote>
+      <vote_number>00404</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2887</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Booker Amdt. No. 2887; To strike the rescission of funds appropriated for the Feed the Future Program to improve global food security and agricultural resiliency and support agriculture research that benefits United States agribusinesses and universities.</title>
+    </vote>
+    <vote>
+      <vote_number>00403</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Recommit
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Kaine Motion to Recommit H.R. 4 to the Committee on Appropriations with Instructions; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00402</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2878</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Rosen Amdt. No. 2878; To strike the rescission of funds appropriated for Global Health programs, including family planning and reproductive health.</title>
+    </vote>
+    <vote>
+      <vote_number>00401</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Recommit
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Markey Motion to Recommit H.R. 4 to the Committee on Appropriations with Instructions; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00400</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2862</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Schiff Amdt. No. 2862; To reduce the amount rescinded from Global Health programs to preserve funding for programs addressing diseases.</title>
+    </vote>
+    <vote>
+      <vote_number>00399</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Recommit
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Schumer Motion to Recommit H.R. 4 to the Committee on Appropriations with Instructions; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00398</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Recommit
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Warner Motion to Recommit H.R. 4 to the Committee on Appropriations with Instructions; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00397</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2855</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Baldwin Amdt. No. 2855; To strike the rescissions of funding for the Corporation for Public Broadcasting.</title>
+    </vote>
+    <vote>
+      <vote_number>00396</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Recommit
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Hirono Motion to Recommit to the Committee on Appropriations with Instructions; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00395</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Recommit
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Gallego Motion to Recommit to the Committee on Appropriations with Instructions; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00394</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Recommit
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Cortez Masto Motion to Recommit H.R. 4 to the Committee on Appropriations with Instructions; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00393</vote_number>
+      <vote_date>16-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2856</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Coons Amdt. No. 2856; To strike the recession of amounts made available for international disaster assistance, to ensure the United States can compete with China and maintain our long tradition of providing lifesaving aid.</title>
+    </vote>
+    <vote>
+      <vote_number>00392</vote_number>
+      <vote_date>15-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.R. 4; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00391</vote_number>
+      <vote_date>15-Jul</vote_date>
+      <issue>H.R. 4</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Motion to Discharge H.R. 4 from the Committees on Appropriations and the Budget; A bill to rescind certain budget authority proposed to be rescinded in special messages transmitted to the Congress by the President on June 3, 2025, in accordance with section 1012(a) of the Congressional Budget and Impoundment Control Act of 1974.</title>
+    </vote>
+    <vote>
+      <vote_number>00390</vote_number>
+      <vote_date>15-Jul</vote_date>
+      <issue>PN26-15</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Joseph Edlow, of Maryland, to be Director of U.S. Citizenship and Immigration Services, Department of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00389</vote_number>
+      <vote_date>15-Jul</vote_date>
+      <issue>PN26-15</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Joseph Edlow to be Director of U.S. Citizenship and Immigration Services, Department of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00388</vote_number>
+      <vote_date>15-Jul</vote_date>
+      <issue>PN22-26</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Anthony Tata, of Florida, to be Under Secretary of Defense for Personnel and Readiness</title>
+    </vote>
+    <vote>
+      <vote_number>00387</vote_number>
+      <vote_date>15-Jul</vote_date>
+      <issue>PN22-26</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Anthony Tata to be Under Secretary of Defense for Personnel and Readiness</title>
+    </vote>
+    <vote>
+      <vote_number>00386</vote_number>
+      <vote_date>15-Jul</vote_date>
+      <issue>PN25-39</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>69</yeas>
+        <nays>30</nays>
+      </vote_tally>
+      <title>Confirmation: Luke Pettit, of the District of Columbia, to be an Assistant Secretary of the Treasury</title>
+    </vote>
+    <vote>
+      <vote_number>00385</vote_number>
+      <vote_date>14-Jul</vote_date>
+      <issue>PN25-39</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>28</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Luke Pettit to be an Assistant Secretary of the Treasury </title>
+    </vote>
+    <vote>
+      <vote_number>00384</vote_number>
+      <vote_date>14-Jul</vote_date>
+      <issue>PN150-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Confirmation: Whitney D. Hermandorfer, of Tennessee, to be United States Circuit Judge for the Sixth Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00383</vote_number>
+      <vote_date>10-Jul</vote_date>
+      <issue>PN25-15</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Jonathan Gould, of Virginia, to be Comptroller of the Currency</title>
+    </vote>
+    <vote>
+      <vote_number>00382</vote_number>
+      <vote_date>10-Jul</vote_date>
+      <issue>PN150-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Whitney D. Hermandorfer to be U.S. Circuit Judge for the Sixth Circuit</title>
+    </vote>
+    <vote>
+      <vote_number>00381</vote_number>
+      <vote_date>10-Jul</vote_date>
+      <issue>PN25-15</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jonathan Gould to be Comptroller of the Currency</title>
+    </vote>
+    <vote>
+      <vote_number>00380</vote_number>
+      <vote_date>09-Jul</vote_date>
+      <issue>PN13-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: William Briggs, of Texas, to be Deputy Administrator of the Small Business Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00379</vote_number>
+      <vote_date>09-Jul</vote_date>
+      <issue>PN12-24</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Scott Kupor, of California, to be Director of the Office of Personnel Management</title>
+    </vote>
+    <vote>
+      <vote_number>00378</vote_number>
+      <vote_date>09-Jul</vote_date>
+      <issue>PN13-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: William Briggs to be Deputy Administrator of the Small Business Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00377</vote_number>
+      <vote_date>09-Jul</vote_date>
+      <issue>PN55-6</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Bryan Bedford, of Indiana, to be Administrator of the Federal Aviation Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00376</vote_number>
+      <vote_date>09-Jul</vote_date>
+      <issue>PN12-24</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Scott Kupor to be Director of the Office of Personnel Management</title>
+    </vote>
+    <vote>
+      <vote_number>00375</vote_number>
+      <vote_date>09-Jul</vote_date>
+      <issue>PN12-20</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Preston Griffith, of Virginia, to be Under Secretary of Energy</title>
+    </vote>
+    <vote>
+      <vote_number>00374</vote_number>
+      <vote_date>08-Jul</vote_date>
+      <issue>PN55-6</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Bryan Bedford to be Administrator of the Federal Aviation Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00373</vote_number>
+      <vote_date>08-Jul</vote_date>
+      <issue>PN12-20</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Preston Griffith to be Under Secretary of Energy</title>
+    </vote>
+    <vote>
+      <vote_number>00372</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>H.R. 1, as Amended; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00371</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2360</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Amdt. No. 2360, as Amended; In the nature of a substitute.</title>
+    </vote>
+    <vote>
+      <vote_number>00370</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2848</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Graham Amdt. No. 2848; To improve the bill.</title>
+    </vote>
+    <vote>
+      <vote_number>00369</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2849</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>45</yeas>
+        <nays>55</nays>
+      </vote_tally>
+      <title>Klobuchar Amdt. No. 2849; To strike a provision relating to delayed implementation of the supplemental nutrition assistance program matching funds requirements.</title>
+    </vote>
+    <vote>
+      <vote_number>00368</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2585</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Van Hollen Amdt. No. 2585; To strike the appropriations for the Office of Management and Budget.</title>
+    </vote>
+    <vote>
+      <vote_number>00367</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2847</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Warner Amdt. No. 2847; Use of revenues from lease payments from Metropolitan Washington Airports for aviation safety improvements and other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00366</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2564</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Shaheen Amdt. No. 2564; To repeal amendments that terminate certain clean energy credits, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00365</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2719</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Hickenlooper Amdt. No. 2719; To modify the provision terminating the residential clean energy credit, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00364</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2717</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Rosen Amdt. No. 2717; To maintain parity for wind and solar facilities under the Internal Revenue Code of 1986.</title>
+    </vote>
+    <vote>
+      <vote_number>00363</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2814</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>99</yeas>
+        <nays>1</nays>
+      </vote_tally>
+      <title>Blackburn Amdt. No. 2814; To strike the section relating to support for artificial intelligence.</title>
+    </vote>
+    <vote>
+      <vote_number>00362</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2435</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Sanders Amdt. No. 2435; To cut the price of prescription drugs under Medicare in half and expand Medicare to cover dental, vision, and hearing.</title>
+    </vote>
+    <vote>
+      <vote_number>00361</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2817</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Kim Amdt. No. 2817; To strike a provision relating to limitations on certain Medicaid payments.</title>
+    </vote>
+    <vote>
+      <vote_number>00360</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2745</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>21</yeas>
+        <nays>79</nays>
+      </vote_tally>
+      <title>Lee Amdt. No. 2745; To terminate wind and solar credits.</title>
+    </vote>
+    <vote>
+      <vote_number>00359</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Warnock Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00358</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2382</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Hirono Amdt. No. 2382; To eliminate a program of qualified elementary and secondary education scholarships for public, private, or religious schools.</title>
+    </vote>
+    <vote>
+      <vote_number>00357</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Wyden Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00356</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2775</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Kennedy Amdt. No. 2775; To amend the Internal Revenue Code of 1986 to provide a deduction for expenses of home educators.</title>
+    </vote>
+    <vote>
+      <vote_number>00355</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2812</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>22</yeas>
+        <nays>78</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 302(f) of the CBA Re: Collins Amdt. No. 2812; To amend the Internal Revenue Code of 1986 to apply a 39.6 percent individual income tax rate, and to provide additional funding and specify eligible providers under the Rural Health Transformation Program.</title>
+    </vote>
+    <vote>
+      <vote_number>00354</vote_number>
+      <vote_date>01-Jul</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Bennet Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00353</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Padilla Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00352</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2772</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>42</yeas>
+        <nays>58</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 313(b)(1)(A) of the Congressional Budget Act Re: Kennedy Amdt. No. 2772 ; To prohibit the use of Defense Production Act of 1950 funds without the approval of Congress.</title>
+    </vote>
+    <vote>
+      <vote_number>00351</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Schiff Motion to Commit H.R. 1 to the Committee on Agriculture, Nutrition, and Forestry with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00350</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Duckworth Motion to Commit H.R. 1 to the Committee on Agriculture, Nutrition, and Forestry with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00349</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Hassan Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00348</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Gallego Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00347</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Blumenthal Motion to Commit H.R. 1 to the Committee on Armed Services with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00346</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Kaine Motion to Commit H.R. 1 to the Committee on Homeland Security and Governmental Affairs with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00345</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2401</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 313 (b)(1)(D) of the CBA Re: Amdt. No. 2401; To prohibit Federal financial participation under Medicaid and CHIP for individuals without verified citizenship, nationality, or satisfactory immigration status.</title>
+    </vote>
+    <vote>
+      <vote_number>00344</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2771</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 302(F) of the CBA Re: Murray Amdt. No. 2771; To strike the provision to defund Planned Parenthood.</title>
+    </vote>
+    <vote>
+      <vote_number>00343</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2446</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 313(b)(1)(D) of the Congressional Budget Act Re: Merkley Amdt. No. 2446; To prevent cryptocurrency corruption.</title>
+    </vote>
+    <vote>
+      <vote_number>00342</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2705</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 313(b)(1)(D) of the CBA Re: Cornyn Amdt. No. 2705; To reduce the FMAP for the Medicaid expansion to 80 percent in expansion States that provide State-funded coverage to aliens who are not qualified aliens and who are have been charged with or convicted of certain acts.</title>
+    </vote>
+    <vote>
+      <vote_number>00341</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2414</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 302(F) of the CBA Re: Amdt. No. 2414; To strike the reduction in the funding cap for the Bureau of Consumer Financial Protection.</title>
+    </vote>
+    <vote>
+      <vote_number>00340</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Blunt Rochester Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00339</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2696</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 302(F) of the CBA Re: Amdt. No. 2696; To amend the Internal Revenue Code of 1986 to extend the enhanced premium tax credits and increase the individual tax rate for taxpayers with income of $10,000,000.</title>
+    </vote>
+    <vote>
+      <vote_number>00338</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Reed Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00337</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Lujan Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00336</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00335</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Wyden Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00334</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 425(a)(2) of the CBA re: H.R. 1; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00333</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00332</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Schumer Motion to Commit H.R. 1 to the Committee on Finance with Instructions; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00331</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Decision of the Chair
+         </question>
+      <result>Sustained</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Does the Decision of the Chair Stand as the Judgment of the Senate that Amdt. No. 2360 does not Violate Section 313(b)(1)(b) of the Congressional Budget Act?; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00330</vote_number>
+      <vote_date>30-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Decision of the Chair
+        <measure>S.Amdt. 2360</measure></question>
+      <result>Sustained</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Does the Decision of the Chair Stand as the judgment of the Senate that amdt. no. 2360 does not violate section 313(b)(1)(E) of the CBA?; In the nature of a substitute.</title>
+    </vote>
+    <vote>
+      <vote_number>00329</vote_number>
+      <vote_date>28-Jun</vote_date>
+      <issue>H.R. 1</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.R. 1; A bill to provide for reconciliation pursuant to title II of H. Con. Res. 14.</title>
+    </vote>
+    <vote>
+      <vote_number>00328</vote_number>
+      <vote_date>27-Jun</vote_date>
+      <issue>S.J.Res. 59</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Motion to Discharge S.J. Res. 59 from the Committee on Foreign Relations; A joint resolution to direct the removal of United States Armed Forces from hostilities against the Islamic Republic of Iran that have not been authorized by Congress.</title>
+    </vote>
+    <vote>
+      <vote_number>00327</vote_number>
+      <vote_date>26-Jun</vote_date>
+      <issue>PN13-7</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Kenneth Kies, of Virginia, to be an Assistant Secretary of the Treasury</title>
+    </vote>
+    <vote>
+      <vote_number>00326</vote_number>
+      <vote_date>25-Jun</vote_date>
+      <issue>PN13-7</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Kenneth Kies to be an Assistant Secretary of the Treasury</title>
+    </vote>
+    <vote>
+      <vote_number>00325</vote_number>
+      <vote_date>25-Jun</vote_date>
+      <issue>PN26-12</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Confirmation: Paul Dabbar, of New York, to be Deputy Secretary of Commerce</title>
+    </vote>
+    <vote>
+      <vote_number>00324</vote_number>
+      <vote_date>24-Jun</vote_date>
+      <issue>PN26-12</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Paul Dabbar to be Deputy Secretary of Commerce</title>
+    </vote>
+    <vote>
+      <vote_number>00323</vote_number>
+      <vote_date>24-Jun</vote_date>
+      <issue>PN26-50</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>61</yeas>
+        <nays>35</nays>
+      </vote_tally>
+      <title>Confirmation: Daniel Zimmerman, of North Carolina, to be an Assistant Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00322</vote_number>
+      <vote_date>23-Jun</vote_date>
+      <issue>PN26-50</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>58</yeas>
+        <nays>33</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Daniel Zimmerman to be an Assistant Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00321</vote_number>
+      <vote_date>18-Jun</vote_date>
+      <issue>PN12-40</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Rodney Scott, of Oklahoma, to be Commissioner of U.S. Customs and Border Protection, Department of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00320</vote_number>
+      <vote_date>18-Jun</vote_date>
+      <issue>PN24-7</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Olivia Trusty, of Maryland, to be a Member of the Federal Communications Commission (Reappointment)</title>
+    </vote>
+    <vote>
+      <vote_number>00319</vote_number>
+      <vote_date>18-Jun</vote_date>
+      <issue>PN12-40</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Rodney Scott to be Commissioner of U.S. Customs and Border Protection, Department of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00318</vote_number>
+      <vote_date>17-Jun</vote_date>
+      <issue>S. 1582</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>68</yeas>
+        <nays>30</nays>
+      </vote_tally>
+      <title>S. 1582, As Amended; A bill to provide for the regulation of payment stablecoins, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00317</vote_number>
+      <vote_date>17-Jun</vote_date>
+      <issue>PN24-6</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Olivia Trusty, of Maryland, to be a Member of the Federal Communications Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00316</vote_number>
+      <vote_date>17-Jun</vote_date>
+      <issue>PN25-1</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>57</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Confirmation: Gary Andres, of Virginia, to be an Assistant Secretary of Health and Human Services</title>
+    </vote>
+    <vote>
+      <vote_number>00315</vote_number>
+      <vote_date>17-Jun</vote_date>
+      <issue>PN24-7</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Olivia Trusty to be a Member of the Federal Communications Commission (Reappointment)</title>
+    </vote>
+    <vote>
+      <vote_number>00314</vote_number>
+      <vote_date>17-Jun</vote_date>
+      <issue>PN24-6</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Olivia Trusty to be a Member of the Federal Communications Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00313</vote_number>
+      <vote_date>16-Jun</vote_date>
+      <issue>PN25-1</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>44</yeas>
+        <nays>33</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Gary Andres to be an Assistant Secretary of Health and Human Services</title>
+    </vote>
+    <vote>
+      <vote_number>00312</vote_number>
+      <vote_date>12-Jun</vote_date>
+      <issue>S. 1582</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>67</yeas>
+        <nays>27</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: S. 1582; A bill to provide for the regulation of payment stablecoins, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00311</vote_number>
+      <vote_date>12-Jun</vote_date>
+      <issue>S. 1582</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2307</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>67</yeas>
+        <nays>30</nays>
+      </vote_tally>
+      <title>Amdt. No. 2307; In the nature of a substitute.</title>
+    </vote>
+    <vote>
+      <vote_number>00310</vote_number>
+      <vote_date>12-Jun</vote_date>
+      <issue>S. 1582</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 2307</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>64</yeas>
+        <nays>33</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Amdt. No. 2307; In the nature of a substitute.</title>
+    </vote>
+    <vote>
+      <vote_number>00309</vote_number>
+      <vote_date>12-Jun</vote_date>
+      <issue>S. 1582</issue>
+      <question>On the Motion to Table
+        <measure>S.Amdt. 2310</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>45</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Motion to Table Amdt. No. 2310; To improve the bill.</title>
+    </vote>
+    <vote>
+      <vote_number>00308</vote_number>
+      <vote_date>12-Jun</vote_date>
+      <issue>PN12-27</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: William Long, of Missouri, to be Commissioner of Internal Revenue</title>
+    </vote>
+    <vote>
+      <vote_number>00307</vote_number>
+      <vote_date>11-Jun</vote_date>
+      <issue>S.J.Res. 54</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>39</yeas>
+        <nays>56</nays>
+      </vote_tally>
+      <title>Motion to Discharge: S.J. Res. 54; A joint resolution providing for congressional disapproval of the proposed foreign military sale to the Government of the United Arab Emirates of certain defense articles and services.</title>
+    </vote>
+    <vote>
+      <vote_number>00306</vote_number>
+      <vote_date>11-Jun</vote_date>
+      <issue>S.J.Res. 53</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>39</yeas>
+        <nays>56</nays>
+      </vote_tally>
+      <title>Motion to Discharge S. J. Res. 53; A joint resolution providing for congressional disapproval of the proposed foreign military sale to the Government of Qatar of certain defense articles and services.</title>
+    </vote>
+    <vote>
+      <vote_number>00305</vote_number>
+      <vote_date>11-Jun</vote_date>
+      <issue>S. 1582</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>68</yeas>
+        <nays>30</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Amdt. No. 2307 to S. 1582; A bill to provide for the regulation of payment stablecoins, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00304</vote_number>
+      <vote_date>11-Jun</vote_date>
+      <issue>PN12-27</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: William Long to be Commissioner of Internal Revenue</title>
+    </vote>
+    <vote>
+      <vote_number>00303</vote_number>
+      <vote_date>10-Jun</vote_date>
+      <issue>PN26-20</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Andrew Hughes, of Texas, to be Deputy Secretary of Housing and Urban Development</title>
+    </vote>
+    <vote>
+      <vote_number>00302</vote_number>
+      <vote_date>10-Jun</vote_date>
+      <issue>PN26-20</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Andrew Hughes to be Deputy Secretary of Housing and Urban Development</title>
+    </vote>
+    <vote>
+      <vote_number>00301</vote_number>
+      <vote_date>10-Jun</vote_date>
+      <issue>PN12-43</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Stephen Vaden, of Tennessee, to be Deputy Secretary of Agriculture</title>
+    </vote>
+    <vote>
+      <vote_number>00300</vote_number>
+      <vote_date>10-Jun</vote_date>
+      <issue>PN12-43</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Stephen Vaden to be Deputy Secretary of Agriculture</title>
+    </vote>
+    <vote>
+      <vote_number>00299</vote_number>
+      <vote_date>10-Jun</vote_date>
+      <issue>PN13-6</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Confirmation: David Fotouhi, of Virginia, to be Deputy Administrator of the Environmental Protection Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00298</vote_number>
+      <vote_date>09-Jun</vote_date>
+      <issue>PN13-6</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: David Fotouhi to be Deputy Administrator of the Environmental Protection Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00297</vote_number>
+      <vote_date>09-Jun</vote_date>
+      <issue>PN26-43</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Confirmation: Brett Shumate, of Virginia, to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00296</vote_number>
+      <vote_date>05-Jun</vote_date>
+      <issue>PN26-43</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Brett Shumate to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00295</vote_number>
+      <vote_date>05-Jun</vote_date>
+      <issue>PN26-16</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: John Andrew Eisenberg, of Virginia, to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00294</vote_number>
+      <vote_date>05-Jun</vote_date>
+      <issue>PN26-16</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: John Andrew Eisenberg to be an Assistant Attorney General (National Security Division)</title>
+    </vote>
+    <vote>
+      <vote_number>00293</vote_number>
+      <vote_date>05-Jun</vote_date>
+      <issue>PN12-33</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: James O'Neill, of California, to be Deputy Secretary of Health and Human Services</title>
+    </vote>
+    <vote>
+      <vote_number>00292</vote_number>
+      <vote_date>04-Jun</vote_date>
+      <issue>PN55-47</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>57</yeas>
+        <nays>38</nays>
+      </vote_tally>
+      <title>Confirmation: Edward Walsh, of New Jersey, to be Ambassador of the United States of America to Ireland</title>
+    </vote>
+    <vote>
+      <vote_number>00291</vote_number>
+      <vote_date>04-Jun</vote_date>
+      <issue>PN55-9</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Michelle Bowman, of Kansas, to be Vice Chairman for Supervision of the Board of Governors of the Federal Reserve System</title>
+    </vote>
+    <vote>
+      <vote_number>00290</vote_number>
+      <vote_date>04-Jun</vote_date>
+      <issue>PN12-33</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: James O'Neill to be Deputy Secretary of Health and Human Services </title>
+    </vote>
+    <vote>
+      <vote_number>00289</vote_number>
+      <vote_date>04-Jun</vote_date>
+      <issue>PN55-47</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>37</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Edward Walsh to be Ambassador of the United States of America to Ireland</title>
+    </vote>
+    <vote>
+      <vote_number>00288</vote_number>
+      <vote_date>04-Jun</vote_date>
+      <issue>PN55-9</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Michelle Bowman to be Vice Chairman for Supervision of the Board of Governors of the Federal Reserve System</title>
+    </vote>
+    <vote>
+      <vote_number>00287</vote_number>
+      <vote_date>03-Jun</vote_date>
+      <issue>PN22-16</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>72</yeas>
+        <nays>26</nays>
+      </vote_tally>
+      <title>Confirmation: Dale Marks, of Florida, to be an Assistant Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00286</vote_number>
+      <vote_date>03-Jun</vote_date>
+      <issue>PN22-16</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>66</yeas>
+        <nays>28</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Dale Marks to be an Assistant Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00285</vote_number>
+      <vote_date>03-Jun</vote_date>
+      <issue>PN25-19</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>36</nays>
+      </vote_tally>
+      <title>Confirmation: Allison Hooker, of Georgia, to be an Under Secretary of State (Political Affairs)</title>
+    </vote>
+    <vote>
+      <vote_number>00284</vote_number>
+      <vote_date>03-Jun</vote_date>
+      <issue>PN25-19</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>37</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Allison Hooker to be an Under Secretary of State (Political Affairs)</title>
+    </vote>
+    <vote>
+      <vote_number>00283</vote_number>
+      <vote_date>03-Jun</vote_date>
+      <issue>PN17</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Michael Duffey, of Virginia, to be Under Secretary of Defense for Acquisition and Sustainment</title>
+    </vote>
+    <vote>
+      <vote_number>00282</vote_number>
+      <vote_date>02-Jun</vote_date>
+      <issue>PN17</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Michael Duffey to be Under Secretary of Defense for Acquisition and Sustainment</title>
+    </vote>
+    <vote>
+      <vote_number>00281</vote_number>
+      <vote_date>22-May</vote_date>
+      <issue>H.J.Res. 89</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>H.J.Res. 89; A joint resolution providing congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "California State Motor Vehicle and Engine and Nonroad Engine Pollution Control Standards; The 'Omnibus' Low NOX Regulation; Waiver of Preemption; Notice of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00280</vote_number>
+      <vote_date>22-May</vote_date>
+      <issue>H.J.Res. 89</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.J.Res. 89; A joint resolution providing congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "California State Motor Vehicle and Engine and Nonroad Engine Pollution Control Standards; The 'Omnibus' Low NOX Regulation; Waiver of Preemption; Notice of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00279</vote_number>
+      <vote_date>22-May</vote_date>
+      <issue>H.J.Res. 87</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>H.J.Res. 87; A joint resolution providing congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "California State Motor Vehicle and Engine Pollution Control Standards; Heavy-Duty Vehicle and Engine Emission Warranty and Maintenance Provisions; Advanced Clean Trucks; Zero Emission Airport Shuttle; Zero-Emission Power Train Certification; Waiver of Preemption; Notice of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00278</vote_number>
+      <vote_date>22-May</vote_date>
+      <issue>H.J.Res. 87</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.J. Res. 87; A joint resolution providing congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "California State Motor Vehicle and Engine Pollution Control Standards; Heavy-Duty Vehicle and Engine Emission Warranty and Maintenance Provisions; Advanced Clean Trucks; Zero Emission Airport Shuttle; Zero-Emission Power Train Certification; Waiver of Preemption; Notice of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00277</vote_number>
+      <vote_date>22-May</vote_date>
+      <issue>H.J.Res. 88</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>H.J.Res. 88; A joint resolution providing congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "California State Motor Vehicle and Engine Pollution Control Standards; Advanced Clean Cars II; Waiver of Preemption; Notice of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00276</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>H.J.Res. 88</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.J.Res. 88; A joint resolution providing congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "California State Motor Vehicle and Engine Pollution Control Standards; Advanced Clean Cars II; Waiver of Preemption; Notice of Decision".</title>
+    </vote>
+    <vote>
+      <vote_number>00275</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>S.J.Res. 55; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00274</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Point of Order
+         </question>
+      <result>Sustained</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Shall Joint Resolutions that Meet All the Requirements of Section 802 of the Congressional Review Act or are Disapproving of Agency Actions which have been Determined to be Rules Subject to the Congressional Review Act by a Legal Decision from the Government Accountability Office, be Entitled to Expedited Procedures under the Congressional Review Act?; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00273</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Point of Order
+         </question>
+      <result>Sustained</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Shall Points of Order be in Order under the Congressional Review Act?; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00272</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Motion to Adjourn
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Adjourn; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00271</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>45</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Motion to Recess for Ten Minutes; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00270</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Recess for Fifteen Minutes; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00269</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Recess for Thirty Minutes; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00268</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>45</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Recess for 60 Minutes; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00267</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Motion
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Recess for Ninety Minutes; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00266</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Motion to Table
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Table the Appeal that Two Points of Order are Not in Order at the Same Time; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00265</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Motion to Table
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Motion to Table the Submitted Point of Order: Shall Points of Order Be in Order under the Congressional Review Act?; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00264</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S.J.Res. 55</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J.Res. 55; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Highway Traffic Safety Administration relating to "Federal Motor Vehicle Safety Standards; Fuel System Integrity of Hydrogen Vehicles; Compressed Hydrogen Storage System Integrity; Incorporation by Reference".</title>
+    </vote>
+    <vote>
+      <vote_number>00263</vote_number>
+      <vote_date>21-May</vote_date>
+      <issue>S. 1582</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>69</yeas>
+        <nays>31</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S. 1582; A bill to provide for the regulation of payment stablecoins, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00262</vote_number>
+      <vote_date>19-May</vote_date>
+      <issue>S. 1582</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>66</yeas>
+        <nays>32</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture on the Motion to Proceed to S. 1582; A bill to provide for the regulation of payment stablecoins, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00261</vote_number>
+      <vote_date>19-May</vote_date>
+      <issue>PN24-4</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Charles Kushner, of New York, to be Ambassador of the United States of America to the French Republic and the Principality of Monaco</title>
+    </vote>
+    <vote>
+      <vote_number>00260</vote_number>
+      <vote_date>19-May</vote_date>
+      <issue>PN24-4</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Charles Kushner to be Ambassador of the United States of America to the French Republic and the Principality of Monaco</title>
+    </vote>
+    <vote>
+      <vote_number>00259</vote_number>
+      <vote_date>15-May</vote_date>
+      <issue>S.Res. 195</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>45</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Motion to Discharge S. Res. 195; A resolution requesting information on El Salvador's human rights practices pursuant to section 502B(c) of the Foreign Assistance Act of 1961.</title>
+    </vote>
+    <vote>
+      <vote_number>00258</vote_number>
+      <vote_date>15-May</vote_date>
+      <issue>PN25-11</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Sean Donahue, of F.L., to be an Assistant Administrator of the Environmental Protection Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00257</vote_number>
+      <vote_date>14-May</vote_date>
+      <issue>PN25-11</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Sean Donahue to be an Assistant Administrator of the Environmental Protection Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00256</vote_number>
+      <vote_date>14-May</vote_date>
+      <issue>PN26-46</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Eric Matthew Ueland, of Virginia, to be Deputy Director for Management, Office of Management and Budget</title>
+    </vote>
+    <vote>
+      <vote_number>00255</vote_number>
+      <vote_date>14-May</vote_date>
+      <issue>PN26-46</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Eric Matthew Ueland to be Deputy Director for Management, Office of Management and Budget</title>
+    </vote>
+    <vote>
+      <vote_number>00254</vote_number>
+      <vote_date>14-May</vote_date>
+      <issue>PN12-31</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Emil Michael, of Florida, to be Under Secretary of Defense for Research and Engineering</title>
+    </vote>
+    <vote>
+      <vote_number>00253</vote_number>
+      <vote_date>14-May</vote_date>
+      <issue>PN12-31</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Emil Michael to be Under Secretary of Defense for Research and Engineering</title>
+    </vote>
+    <vote>
+      <vote_number>00252</vote_number>
+      <vote_date>14-May</vote_date>
+      <issue>PN12-38</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Michael Rigas, of Virginia, to be Deputy Secretary of State for Management and Resources</title>
+    </vote>
+    <vote>
+      <vote_number>00251</vote_number>
+      <vote_date>14-May</vote_date>
+      <issue>PN12-38</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Michael Rigas to be Deputy Secretary of State for Management and Resources</title>
+    </vote>
+    <vote>
+      <vote_number>00250</vote_number>
+      <vote_date>14-May</vote_date>
+      <issue>PN13-10</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Confirmation: Katharine MacGregor, of Florida, to be Deputy Secretary of the Interior</title>
+    </vote>
+    <vote>
+      <vote_number>00249</vote_number>
+      <vote_date>13-May</vote_date>
+      <issue>PN13-10</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>57</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Katharine MacGregor to be Deputy Secretary of the Interior</title>
+    </vote>
+    <vote>
+      <vote_number>00248</vote_number>
+      <vote_date>13-May</vote_date>
+      <issue>PN13-4</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: James Danly, of Tennessee, to be Deputy Secretary of Energy</title>
+    </vote>
+    <vote>
+      <vote_number>00247</vote_number>
+      <vote_date>13-May</vote_date>
+      <issue>PN13-4</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: James Danly to be Deputy Secretary of Energy</title>
+    </vote>
+    <vote>
+      <vote_number>00246</vote_number>
+      <vote_date>13-May</vote_date>
+      <issue>PN12-30</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>74</yeas>
+        <nays>25</nays>
+      </vote_tally>
+      <title>Confirmation: Troy Meink, of Virginia, to be Secretary of the Air Force</title>
+    </vote>
+    <vote>
+      <vote_number>00245</vote_number>
+      <vote_date>13-May</vote_date>
+      <issue>PN12-30</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>72</yeas>
+        <nays>26</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Troy Meink to be Secretary of the Air Force</title>
+    </vote>
+    <vote>
+      <vote_number>00244</vote_number>
+      <vote_date>13-May</vote_date>
+      <issue>PN25-50</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Reed Rubinstein, of Maryland, to be Legal Adviser of the Department of State</title>
+    </vote>
+    <vote>
+      <vote_number>00243</vote_number>
+      <vote_date>12-May</vote_date>
+      <issue>PN25-50</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Reed Rubinstein to be Legal Adviser of the Department of State</title>
+    </vote>
+    <vote>
+      <vote_number>00242</vote_number>
+      <vote_date>12-May</vote_date>
+      <issue>PN12-10</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Monica Crowley, of New York, to be Chief of Protocol and to have the rank of Ambassador</title>
+    </vote>
+    <vote>
+      <vote_number>00241</vote_number>
+      <vote_date>12-May</vote_date>
+      <issue>PN12-10</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Monica Crowley to be Chief of Protocol and to have the rank of Ambassador</title>
+    </vote>
+    <vote>
+      <vote_number>00240</vote_number>
+      <vote_date>08-May</vote_date>
+      <issue>S. 1582</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to proceed to S. 1582; A bill to provide for the regulation of payment stablecoins, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00239</vote_number>
+      <vote_date>08-May</vote_date>
+      <issue>H.J.Res. 60</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>H.J. Res. 60; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Park Service relating to "Glen Canyon National Recreation Area: Motor Vehicles".</title>
+    </vote>
+    <vote>
+      <vote_number>00238</vote_number>
+      <vote_date>08-May</vote_date>
+      <issue>S.J.Res. 7</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>38</nays>
+      </vote_tally>
+      <title>S.J. Res. 7; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Federal Communications Commission relating to "Addressing the Homework Gap Through the E-Rate Program".</title>
+    </vote>
+    <vote>
+      <vote_number>00237</vote_number>
+      <vote_date>07-May</vote_date>
+      <issue>S.J.Res. 13</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>S.J. Res. 13; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Office of the Comptroller of the Currency of the Department of the Treasury relating to the review of applications under the Bank Merger Act.</title>
+    </vote>
+    <vote>
+      <vote_number>00236</vote_number>
+      <vote_date>06-May</vote_date>
+      <issue>H.J.Res. 60</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to proceed to H.J. Res. 60; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the National Park Service relating to "Glen Canyon National Recreation Area: Motor Vehicles".</title>
+    </vote>
+    <vote>
+      <vote_number>00235</vote_number>
+      <vote_date>06-May</vote_date>
+      <issue>S.J.Res. 7</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to proceed to S.J. Res. 7; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Federal Communications Commission relating to "Addressing the Homework Gap Through the E-Rate Program".</title>
+    </vote>
+    <vote>
+      <vote_number>00234</vote_number>
+      <vote_date>06-May</vote_date>
+      <issue>PN20</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Frank Bisignano, of New Jersey, to be Commissioner of Social Security Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00233</vote_number>
+      <vote_date>06-May</vote_date>
+      <issue>S.J.Res. 13</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to proceed to S.J. Res. 13; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Office of the Comptroller of the Currency of the Department of the Treasury relating to the review of applications under the Bank Merger Act.</title>
+    </vote>
+    <vote>
+      <vote_number>00232</vote_number>
+      <vote_date>06-May</vote_date>
+      <issue>H.J.Res. 61</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>55</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>H.J.Res. 61; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "National Emission Standards for Hazardous Air Pollutants: Rubber Tire Manufacturing".</title>
+    </vote>
+    <vote>
+      <vote_number>00231</vote_number>
+      <vote_date>05-May</vote_date>
+      <issue>H.J.Res. 61</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to proceed to H.J. Res. 61; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "National Emission Standards for Hazardous Air Pollutants: Rubber Tire Manufacturing".</title>
+    </vote>
+    <vote>
+      <vote_number>00230</vote_number>
+      <vote_date>01-May</vote_date>
+      <issue>PN20</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Frank Bisignano to be Commissioner of the Social Security Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00229</vote_number>
+      <vote_date>01-May</vote_date>
+      <issue>S.J.Res. 31</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>S.J.Res. 31; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "Review of Final Rule Reclassification of Major Sources as Area Sources Under Section 112 of the Clean Air Act".</title>
+    </vote>
+    <vote>
+      <vote_number>00228</vote_number>
+      <vote_date>01-May</vote_date>
+      <issue>H.J.Res. 75</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>H.J.Res. 75; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Office of Energy Efficiency and Renewable Energy, Department of Energy relating to "Energy Conservation Program: Energy Conservation Standards for Commercial Refrigerators, Freezers, and Refrigerator-Freezers".</title>
+    </vote>
+    <vote>
+      <vote_number>00227</vote_number>
+      <vote_date>30-Apr</vote_date>
+      <issue>S.J.Res. 31</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J.Res. 31; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "Review of Final Rule Reclassification of Major Sources as Area Sources Under Section 112 of the Clean Air Act".</title>
+    </vote>
+    <vote>
+      <vote_number>00226</vote_number>
+      <vote_date>30-Apr</vote_date>
+      <issue>S.J.Res. 49</issue>
+      <question>On the Motion to Table
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Motion to Table the Motion to Reconsider the Vote by which S.J.Res. 49 Failed of Passage; A joint resolution terminating the national emergency declared to impose global tariffs.</title>
+    </vote>
+    <vote>
+      <vote_number>00225</vote_number>
+      <vote_date>30-Apr</vote_date>
+      <issue>S.J.Res. 49</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>S.J.Res. 49; A joint resolution terminating the national emergency declared to impose global tariffs.</title>
+    </vote>
+    <vote>
+      <vote_number>00224</vote_number>
+      <vote_date>30-Apr</vote_date>
+      <issue>H.J.Res. 75</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.J.Res. 75; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Office of Energy Efficiency and Renewable Energy, Department of Energy relating to "Energy Conservation Program: Energy Conservation Standards for Commercial Refrigerators, Freezers, and Refrigerator-Freezers".</title>
+    </vote>
+    <vote>
+      <vote_number>00223</vote_number>
+      <vote_date>30-Apr</vote_date>
+      <issue>H.J.Res. 42</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>H.J.Res. 42; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Department of Energy relating to "Energy Conservation Program for Appliance Standards: Certification Requirements, Labeling Requirements, and Enforcement Provisions for Certain Consumer Products and Commercial Equipment".</title>
+    </vote>
+    <vote>
+      <vote_number>00222</vote_number>
+      <vote_date>29-Apr</vote_date>
+      <issue>H.J.Res. 42</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.J.Res. 42; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Department of Energy relating to "Energy Conservation Program for Appliance Standards: Certification Requirements, Labeling Requirements, and Enforcement Provisions for Certain Consumer Products and Commercial Equipment".</title>
+    </vote>
+    <vote>
+      <vote_number>00221</vote_number>
+      <vote_date>29-Apr</vote_date>
+      <issue>PN26-18</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>83</yeas>
+        <nays>14</nays>
+      </vote_tally>
+      <title>Confirmation: Tilman Fertitta, of Texas, to be Ambassador of the United States of America to the Italian Republic and the Republic of San Marino</title>
+    </vote>
+    <vote>
+      <vote_number>00220</vote_number>
+      <vote_date>29-Apr</vote_date>
+      <issue>PN26-18</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>84</yeas>
+        <nays>13</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Tilman Fertitta to be Ambassador of the United States of America to the Italian Republic and the Republic of San Marino</title>
+    </vote>
+    <vote>
+      <vote_number>00219</vote_number>
+      <vote_date>29-Apr</vote_date>
+      <issue>PN26-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>36</nays>
+      </vote_tally>
+      <title>Confirmation: Thomas Barrack, of Colorado, to be Ambassador of the United States of America to the Republic of Turkey</title>
+    </vote>
+    <vote>
+      <vote_number>00218</vote_number>
+      <vote_date>29-Apr</vote_date>
+      <issue>PN26-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>62</yeas>
+        <nays>36</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Thomas Barrack to be Ambassador of the United States of America to the Republic of Turkey</title>
+    </vote>
+    <vote>
+      <vote_number>00217</vote_number>
+      <vote_date>29-Apr</vote_date>
+      <issue>PN24-5</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Confirmation: Warren Stephens, of Arkansas, to be Ambassador of the United States of America to the United Kingdom of Great Britain and Northern Ireland</title>
+    </vote>
+    <vote>
+      <vote_number>00216</vote_number>
+      <vote_date>29-Apr</vote_date>
+      <issue>PN24-5</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Warren Stephens to be Ambassador of the United States of America to the United Kingdom of Great Britain and Northern Ireland</title>
+    </vote>
+    <vote>
+      <vote_number>00215</vote_number>
+      <vote_date>29-Apr</vote_date>
+      <issue>PN54-5</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>67</yeas>
+        <nays>29</nays>
+      </vote_tally>
+      <title>Confirmation: David Perdue, of Georgia, to be Ambassador of the United States of America to the People's Republic of China</title>
+    </vote>
+    <vote>
+      <vote_number>00214</vote_number>
+      <vote_date>28-Apr</vote_date>
+      <issue>PN54-5</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>64</yeas>
+        <nays>27</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: David Perdue to be Ambassador Extraordinary and Plenipotentiary of the U.S. to the People's Republic of China</title>
+    </vote>
+    <vote>
+      <vote_number>00213</vote_number>
+      <vote_date>11-Apr</vote_date>
+      <issue>PN27</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>25</nays>
+      </vote_tally>
+      <title>Confirmation: Lt. Gen. John D. Caine (Retired) to be General and Chairman of the Joint Chiefs of Staff</title>
+    </vote>
+    <vote>
+      <vote_number>00212</vote_number>
+      <vote_date>11-Apr</vote_date>
+      <issue>PN27</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>25</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Lt. Gen. John D. Caine (Retired) to be General and Chairman of the Joint Chiefs of Staff</title>
+    </vote>
+    <vote>
+      <vote_number>00211</vote_number>
+      <vote_date>11-Apr</vote_date>
+      <issue>PN28</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>26</nays>
+      </vote_tally>
+      <title>Confirmation: Lt. Gen. John D. Caine (Retired) to be Major General in the Regular Air Force</title>
+    </vote>
+    <vote>
+      <vote_number>00210</vote_number>
+      <vote_date>11-Apr</vote_date>
+      <issue>PN28</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>25</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Lt. Gen. John D. Caine (Retired) to be Major General in the Regular Air Force</title>
+    </vote>
+    <vote>
+      <vote_number>00209</vote_number>
+      <vote_date>10-Apr</vote_date>
+      <issue>PN12-29</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Mark Meador, of Virginia, to be a Federal Trade Commissioner</title>
+    </vote>
+    <vote>
+      <vote_number>00208</vote_number>
+      <vote_date>10-Apr</vote_date>
+      <issue>PN12-29</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Mark Meador to be a Federal Trade Commissioner</title>
+    </vote>
+    <vote>
+      <vote_number>00207</vote_number>
+      <vote_date>10-Apr</vote_date>
+      <issue>H.J.Res. 20</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>H.J.Res. 20; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Department of Energy relating to "Energy Conservation Program: Energy Conservation Standards for Consumer Gas-fired Instantaneous Water Heaters".</title>
+    </vote>
+    <vote>
+      <vote_number>00206</vote_number>
+      <vote_date>09-Apr</vote_date>
+      <issue>H.J.Res. 20</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.J.Res. 20; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Department of Energy relating to "Energy Conservation Program: Energy Conservation Standards for Consumer Gas-fired Instantaneous Water Heaters".</title>
+    </vote>
+    <vote>
+      <vote_number>00205</vote_number>
+      <vote_date>09-Apr</vote_date>
+      <issue>PN12-18</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Paul Atkins, of Virginia, to be a Member of the Securities and Exchange Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00204</vote_number>
+      <vote_date>09-Apr</vote_date>
+      <issue>PN25-6</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Kevin Cabrera, of Florida, to be Ambassador Extrodinary and Plenipotentiary of the United States of America to the Republic of Panama</title>
+    </vote>
+    <vote>
+      <vote_number>00203</vote_number>
+      <vote_date>09-Apr</vote_date>
+      <issue>PN25-22</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Ronald Johnson, of Florida, to be Ambassador Extraordinary and Plenipotentiary of the United States of America to the United Mexican States</title>
+    </vote>
+    <vote>
+      <vote_number>00202</vote_number>
+      <vote_date>09-Apr</vote_date>
+      <issue>PN25-18</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>37</nays>
+      </vote_tally>
+      <title>Confirmation: Peter Hoekstra, of Michigan, to be Ambassador Extraordinary and Plenipotentiary of the United States of America to Canada</title>
+    </vote>
+    <vote>
+      <vote_number>00201</vote_number>
+      <vote_date>09-Apr</vote_date>
+      <issue>PN25-20</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Mike Huckabee, of Arkansas, to be Ambassador Extraordinary and Plenipotentiary of the United States of America to Israel</title>
+    </vote>
+    <vote>
+      <vote_number>00200</vote_number>
+      <vote_date>09-Apr</vote_date>
+      <issue>PN12-18</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Paul Atkins to be a Member of the Securities and Exchange Commission</title>
+    </vote>
+    <vote>
+      <vote_number>00199</vote_number>
+      <vote_date>08-Apr</vote_date>
+      <issue>PN25-6</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Kevin Cabrera to be Ambassador Extraordinary and Plenipotentiary of the United States of America to Panama</title>
+    </vote>
+    <vote>
+      <vote_number>00198</vote_number>
+      <vote_date>08-Apr</vote_date>
+      <issue>PN25-22</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Ronald Johnson  to be Ambassador Extraordinary and Plenipotentiary of the United States of America to the United Mexican States</title>
+    </vote>
+    <vote>
+      <vote_number>00197</vote_number>
+      <vote_date>08-Apr</vote_date>
+      <issue>PN25-18</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>37</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Peter Hoekstra to be Ambassador Extraordinary and Plenipotentiary of the United States of America to Canada</title>
+    </vote>
+    <vote>
+      <vote_number>00196</vote_number>
+      <vote_date>08-Apr</vote_date>
+      <issue>PN25-20</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Mike Huckabee to be Ambassador Extraordinary and Plenipotentiary of the United States of America to Israel</title>
+    </vote>
+    <vote>
+      <vote_number>00195</vote_number>
+      <vote_date>08-Apr</vote_date>
+      <issue>PN25-14</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>66</yeas>
+        <nays>32</nays>
+      </vote_tally>
+      <title>Confirmation: George Glass, of Oregon, to be Ambassador Extraordinary and Plenipotentiary of the United States of America to Japan</title>
+    </vote>
+    <vote>
+      <vote_number>00194</vote_number>
+      <vote_date>08-Apr</vote_date>
+      <issue>PN25-14</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>67</yeas>
+        <nays>32</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: George Glass to be Ambassador Extraordinary and Plenipotentiary of the United States of America to Japan</title>
+    </vote>
+    <vote>
+      <vote_number>00193</vote_number>
+      <vote_date>08-Apr</vote_date>
+      <issue>PN12-9</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Elbridge Colby, of the District of Columbia, to be Under Secretary of Defense for Policy</title>
+    </vote>
+    <vote>
+      <vote_number>00192</vote_number>
+      <vote_date>07-Apr</vote_date>
+      <issue>PN12-9</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Elbridge Colby to be Under Secretary of Defense for Policy</title>
+    </vote>
+    <vote>
+      <vote_number>00191</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Concurrent Resolution
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>H.Con.Res. 14, As Amended; A concurrent resolution establishing the congressional budget for the United States Government for fiscal year 2025 and setting forth the appropriate budgetary levels for fiscal years 2026 through 2034.</title>
+    </vote>
+    <vote>
+      <vote_number>00190</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2152</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Rosen Amdt. No. 2152; To provide tax relief for the middle class.</title>
+    </vote>
+    <vote>
+      <vote_number>00189</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1989</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Wyden Amdt. No. 1989; To strike section 2001(b)(4) relating to reconciliation instructions to the Committee on Energy and Commerce of the House of Representatives to cut $880,000,000,000 from Medicaid.</title>
+    </vote>
+    <vote>
+      <vote_number>00188</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2177</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Warnock Amdt. No. 2177; To establish a deficit-neutral reserve fund relating to access to health care, which may include legislation preventing reductions in funding for Medicaid that could lead to benefit cuts, coverage loss, or slashed provider payments.</title>
+    </vote>
+    <vote>
+      <vote_number>00187</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1529</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Markey Amdt. No. 1529; To preserve access to Social Security's phone service.</title>
+    </vote>
+    <vote>
+      <vote_number>00186</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1693</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Baldwin Amdt. No. 1693
+; To establish a deficit-neutral reserve fund relating to preventing a reduction in Medicaid funding that could lead to rural hospital closures, cost increases for individuals with other kinds of insurance, or higher rates of uncompensated care.</title>
+    </vote>
+    <vote>
+      <vote_number>00185</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 1690</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Motion to Waive Section 305(b)(2) of the CBA re: Cortez Masto Amdt. No. 1690; To create a point of order against legislation that would increase drug costs for seniors and people with disabilities on Medicare.</title>
+    </vote>
+    <vote>
+      <vote_number>00184</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2126</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Sanders Amdt. No. 2126; To make sure the Senate can increase the Federal minimum wage to $17 an hour by a simple majority vote.</title>
+    </vote>
+    <vote>
+      <vote_number>00183</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1644</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Kim Amdt. No. 1644; To establish a deficit-neutral reserve fund to prevent increased barriers to American caregivers, including individuals caring for seniors, children, home care workers, and individuals engaged in the care economy.</title>
+    </vote>
+    <vote>
+      <vote_number>00182</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2180</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Hirono Amdt. No. 2180; To prevent DOGE from closing Social Security offices, preserving access to benefits for seniors and people with disabilities.</title>
+    </vote>
+    <vote>
+      <vote_number>00181</vote_number>
+      <vote_date>05-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2107</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Hickenlooper Amdt. No. 2107; To establish a deficit-neutral reserve fund relating to preventing the use of proceeds from public land sales to reduce the Federal deficit.</title>
+    </vote>
+    <vote>
+      <vote_number>00180</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2186</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Ossoff Amdt. No. 2186; To establish a deficit-neutral reserve fund relating to reversing cuts to the Social Security Administration, which may include cuts ordered by the Department of Government Efficiency or any other cuts to seniors' services.</title>
+    </vote>
+    <vote>
+      <vote_number>00179</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1760</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>5</yeas>
+        <nays>94</nays>
+      </vote_tally>
+      <title>Paul Amdt. No. 1760; To modify the debt limit instruction for the House of Representatives and the Senate.</title>
+    </vote>
+    <vote>
+      <vote_number>00178</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1646</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Bennet Amdt. No. 1646; To prevent any disruption in security assistance to Ukraine.</title>
+    </vote>
+    <vote>
+      <vote_number>00177</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1774</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Padilla Amdt. No. 1774; Reiterating the importance of the Federal Emergency Management Agency and its continued role in providing nonpartisan and long-term disaster relief to disaster survivors.</title>
+    </vote>
+    <vote>
+      <vote_number>00176</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1884</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Schumer Amdt. No. 1884; To establish a deficit-neutral reserve fund relating to preventing Trump's tariffs from increasing the cost of groceries and everyday goods for families.</title>
+    </vote>
+    <vote>
+      <vote_number>00175</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1466</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Alsobrooks Amdt. No. 1466; To establish a deficit-neutral reserve fund relating to prohibiting attacks on Federal employees by protecting legally binding collective bargaining agreements and the right to organize.</title>
+    </vote>
+    <vote>
+      <vote_number>00174</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1310</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Warner Amdt. No. 1310; To establish a deficit-neutral reserve fund relating to strengthening protections for members of the Armed Forces by prohibiting the use of any commercial messaging application to transmit information revealing the timing, sequencing, or weapons to be used during impending United States military operations in foreign countries that may endanger the lives of members of the Armed Forces.</title>
+    </vote>
+    <vote>
+      <vote_number>00173</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1726</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Lujan Amdt. No. 1726; To strike the provision relating to instructions to the Committee on Agriculture.</title>
+    </vote>
+    <vote>
+      <vote_number>00172</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1645</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Reed Amdt. No. 1645; To establish a deficit-neutral reserve fund relating to preventing reduction in enrollment or benefits for individuals enrolled in Medicaid, including seniors, children, families, individuals with disabilities, veterans, and military families.</title>
+    </vote>
+    <vote>
+      <vote_number>00171</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1758</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Merkley Amdt. No. 1758; To create a point of order against legislation that would create more debt over a 30-year period than has accumulated over the past 249 years.</title>
+    </vote>
+    <vote>
+      <vote_number>00170</vote_number>
+      <vote_date>04-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 2035</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Sullivan Amdt. No. 2035; To establish a deficit-neutral reserve fund relating to protecting Medicare and Medicaid.</title>
+    </vote>
+    <vote>
+      <vote_number>00169</vote_number>
+      <vote_date>03-Apr</vote_date>
+      <issue>H.Con.Res. 14</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.Con.Res. 14; A concurrent resolution establishing the congressional budget for the United States Government for fiscal year 2025 and setting forth the appropriate budgetary levels for fiscal years 2026 through 2034.</title>
+    </vote>
+    <vote>
+      <vote_number>00168</vote_number>
+      <vote_date>03-Apr</vote_date>
+      <issue>PN12-11</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Harmeet Dhillon, of California, to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00167</vote_number>
+      <vote_date>03-Apr</vote_date>
+      <issue>PN12-34</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Mehmet Oz, of Pennsylvania, to be Administrator of the Centers for Medicare and Medicaid Services</title>
+    </vote>
+    <vote>
+      <vote_number>00166</vote_number>
+      <vote_date>03-Apr</vote_date>
+      <issue>S.J.Res. 26</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>15</yeas>
+        <nays>83</nays>
+      </vote_tally>
+      <title>Motion to Discharge S.J. Res. 26; A joint resolution providing for congressional disapproval of the proposed foreign military sale to Israel of certain defense articles and services.</title>
+    </vote>
+    <vote>
+      <vote_number>00165</vote_number>
+      <vote_date>03-Apr</vote_date>
+      <issue>S.J.Res. 33</issue>
+      <question>On the Motion to Discharge
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>15</yeas>
+        <nays>82</nays>
+      </vote_tally>
+      <title>Motion to Discharge: S.J. Res. 33; A joint resolution providing for congressional disapproval of the proposed foreign military sale to the Government of Israel of certain defense articles and services.</title>
+    </vote>
+    <vote>
+      <vote_number>00164</vote_number>
+      <vote_date>03-Apr</vote_date>
+      <issue>PN12-34</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Mehmet Oz to be Administrator of the Centers for Medicare and Medicaid Services</title>
+    </vote>
+    <vote>
+      <vote_number>00163</vote_number>
+      <vote_date>03-Apr</vote_date>
+      <issue>PN12-39</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Dean Sauer, of Missouri, to be Solicitor General of the United States</title>
+    </vote>
+    <vote>
+      <vote_number>00162</vote_number>
+      <vote_date>03-Apr</vote_date>
+      <issue>H.J.Res. 24</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>H.J. Res. 24; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Department of Energy relating to "Energy Conservation Program: Energy Conservation Standards for Walk-In Coolers and Walk-In Freezers".</title>
+    </vote>
+    <vote>
+      <vote_number>00161</vote_number>
+      <vote_date>02-Apr</vote_date>
+      <issue>H.J.Res. 24</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.J. Res. 24; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Department of Energy relating to "Energy Conservation Program: Energy Conservation Standards for Walk-In Coolers and Walk-In Freezers".</title>
+    </vote>
+    <vote>
+      <vote_number>00160</vote_number>
+      <vote_date>02-Apr</vote_date>
+      <issue>S.J.Res. 37</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>S.J. Res. 37; A joint resolution terminating the national emergency declared to impose duties on articles imported from Canada.</title>
+    </vote>
+    <vote>
+      <vote_number>00159</vote_number>
+      <vote_date>02-Apr</vote_date>
+      <issue>PN12-11</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Harmeet Dhillon to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00158</vote_number>
+      <vote_date>02-Apr</vote_date>
+      <issue>PN12-39</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Dean Sauer to be Solicitor General of the United States</title>
+    </vote>
+    <vote>
+      <vote_number>00157</vote_number>
+      <vote_date>01-Apr</vote_date>
+      <issue>PN25-56</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Matthew Whitaker, of Iowa, to be United States Permanent Representative on the Council of the North Atlantic Treaty Organization</title>
+    </vote>
+    <vote>
+      <vote_number>00156</vote_number>
+      <vote_date>31-Mar</vote_date>
+      <issue>PN25-56</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Matthew Whitaker, to be U.S. Permanent Representative on the Council of the North Atlantic Treaty Organization</title>
+    </vote>
+    <vote>
+      <vote_number>00155</vote_number>
+      <vote_date>27-Mar</vote_date>
+      <issue>PN13-9</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Paul Lawrence, of Virginia, to be Deputy Secretary of Veterans Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00154</vote_number>
+      <vote_date>27-Mar</vote_date>
+      <issue>PN13-9</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Paul Lawrence to be Deputy Secretary of Veterans Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00153</vote_number>
+      <vote_date>27-Mar</vote_date>
+      <issue>S.J.Res. 18</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>S.J.Res. 18; A joint resolution disapproving the rule submitted by the Bureau of Consumer Financial Protection relating to "Overdraft Lending: Very Large Financial Institutions".</title>
+    </vote>
+    <vote>
+      <vote_number>00152</vote_number>
+      <vote_date>26-Mar</vote_date>
+      <issue>S.J.Res. 18</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J.Res. 18; A joint resolution disapproving the rule submitted by the Bureau of Consumer Financial Protection relating to "Overdraft Lending: Very Large Financial Institutions".</title>
+    </vote>
+    <vote>
+      <vote_number>00151</vote_number>
+      <vote_date>26-Mar</vote_date>
+      <issue>H.J.Res. 25</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>70</yeas>
+        <nays>28</nays>
+      </vote_tally>
+      <title>H.J.Res. 25; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Internal Revenue Service relating to "Gross Proceeds Reporting by Brokers That Regularly Provide Services Effectuating Digital Asset Sales".</title>
+    </vote>
+    <vote>
+      <vote_number>00150</vote_number>
+      <vote_date>26-Mar</vote_date>
+      <issue>H.J.Res. 25</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>70</yeas>
+        <nays>28</nays>
+      </vote_tally>
+      <title>Motion to Proceed to H.J.Res. 25; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Internal Revenue Service relating to "Gross Proceeds Reporting by Brokers That Regularly Provide Services Effectuating Digital Asset Sales".</title>
+    </vote>
+    <vote>
+      <vote_number>00149</vote_number>
+      <vote_date>26-Mar</vote_date>
+      <issue>PN12-15</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Michael Faulkender, of Maryland, to be Deputy Secretary of the Treasury</title>
+    </vote>
+    <vote>
+      <vote_number>00148</vote_number>
+      <vote_date>26-Mar</vote_date>
+      <issue>PN12-15</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Michael Faulkender to be Deputy Secretary of the Treasury</title>
+    </vote>
+    <vote>
+      <vote_number>00147</vote_number>
+      <vote_date>26-Mar</vote_date>
+      <issue>PN12-37</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Aaron Reitz, of Texas, to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00146</vote_number>
+      <vote_date>26-Mar</vote_date>
+      <issue>PN12-37</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Aaron Reitz to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00145</vote_number>
+      <vote_date>26-Mar</vote_date>
+      <issue>PN12-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: James Bishop, of North Carolina, to be Deputy Director of the Office of Management and Budget</title>
+    </vote>
+    <vote>
+      <vote_number>00144</vote_number>
+      <vote_date>25-Mar</vote_date>
+      <issue>PN12-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: James Bishop to be Deputy Director of the Office of Management and Budget</title>
+    </vote>
+    <vote>
+      <vote_number>00143</vote_number>
+      <vote_date>25-Mar</vote_date>
+      <issue>PN12-28</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Martin Makary, of Virginia, to be Commissioner of Food and Drugs</title>
+    </vote>
+    <vote>
+      <vote_number>00142</vote_number>
+      <vote_date>25-Mar</vote_date>
+      <issue>PN12-28</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Martin Makary to be Commissioner of Food and Drugs</title>
+    </vote>
+    <vote>
+      <vote_number>00141</vote_number>
+      <vote_date>25-Mar</vote_date>
+      <issue>PN12-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Jayanta Bhattacharya, of California, to be Director of the National Institutes of Health</title>
+    </vote>
+    <vote>
+      <vote_number>00140</vote_number>
+      <vote_date>25-Mar</vote_date>
+      <issue>PN12-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jayanta Bhattacharya to be Director of the National Institutes of Health</title>
+    </vote>
+    <vote>
+      <vote_number>00139</vote_number>
+      <vote_date>25-Mar</vote_date>
+      <issue>PN13-8</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>74</yeas>
+        <nays>25</nays>
+      </vote_tally>
+      <title>Confirmation: Michael Kratsios, of South Carolina, to be Director of the Office of Science and Technology Policy</title>
+    </vote>
+    <vote>
+      <vote_number>00138</vote_number>
+      <vote_date>25-Mar</vote_date>
+      <issue>PN13-8</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>73</yeas>
+        <nays>25</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Michael Kratsios to be Director of the Office of Science and Technology Policy</title>
+    </vote>
+    <vote>
+      <vote_number>00137</vote_number>
+      <vote_date>24-Mar</vote_date>
+      <issue>PN12-25</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>60</yeas>
+        <nays>31</nays>
+      </vote_tally>
+      <title>Confirmation: Christopher Landau, of Maryland, to be Deputy Secretary of State</title>
+    </vote>
+    <vote>
+      <vote_number>00136</vote_number>
+      <vote_date>24-Mar</vote_date>
+      <issue>PN12-36</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>62</yeas>
+        <nays>30</nays>
+      </vote_tally>
+      <title>Confirmation: John Phelan, of Florida, to be Secretary of the Navy</title>
+    </vote>
+    <vote>
+      <vote_number>00135</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>PN12-25</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>63</yeas>
+        <nays>32</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Christopher Landau to be Deputy Secretary of State</title>
+    </vote>
+    <vote>
+      <vote_number>00134</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>PN12-36</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>64</yeas>
+        <nays>33</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: John Phelan to be Secretary of the Navy</title>
+    </vote>
+    <vote>
+      <vote_number>00133</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>H.R. 1968</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>H.R. 1968; A bill making further continuing appropriations and other extensions for the fiscal year ending September 30, 2025, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00132</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>H.R. 1968</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1266</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>27</yeas>
+        <nays>73</nays>
+      </vote_tally>
+      <title>Paul Amdt. No. 1266; To reduce the amount appropriated for the United States Agency for International Development.</title>
+    </vote>
+    <vote>
+      <vote_number>00131</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>H.R. 1968</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1272</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Van Hollen Amdt. No. 1272; To prohibit the use of appropriated amounts by DOGE.</title>
+    </vote>
+    <vote>
+      <vote_number>00130</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>H.R. 1968</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1274</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Duckworth Amdt. No. 1274; To make veteran Federal employees who were involuntarily dismissed without cause eligible for reinstatement and to require reports from Executive agencies on the number of veteran employees fired from such agencies.</title>
+    </vote>
+    <vote>
+      <vote_number>00129</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>H.R. 1968</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1273</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Merkley Amdt. No. 1273; To except the application of certain rescissions.</title>
+    </vote>
+    <vote>
+      <vote_number>00128</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>H.R. 1968</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>62</yeas>
+        <nays>38</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: H.R. 1968; A bill making further continuing appropriations and other extensions for the fiscal year ending September 30, 2025, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00127</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>S. 331</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>84</yeas>
+        <nays>16</nays>
+      </vote_tally>
+      <title>S. 331, as amended; A bill to amend the Controlled Substances Act with respect to the scheduling of fentanyl-related substances, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00126</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>PN12-16</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>40</nays>
+      </vote_tally>
+      <title>Confirmation: Stephen Feinberg, of New York, to be Deputy Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00125</vote_number>
+      <vote_date>14-Mar</vote_date>
+      <issue>PN12-16</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Stephen Feinberg to be Deputy Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00124</vote_number>
+      <vote_date>13-Mar</vote_date>
+      <issue>S. 331</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>84</yeas>
+        <nays>15</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: S. 331; A bill to amend the Controlled Substances Act with respect to the scheduling of fentanyl-related substances, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00123</vote_number>
+      <vote_date>13-Mar</vote_date>
+      <issue>PN22-12</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Jeffrey Kessler, of Virginia, to be Under Secretary of Commerce for Industry and Security</title>
+    </vote>
+    <vote>
+      <vote_number>00122</vote_number>
+      <vote_date>13-Mar</vote_date>
+      <issue>PN22-12</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jeffrey Kessler to be Under Secretary of Commerce for Industry and Security</title>
+    </vote>
+    <vote>
+      <vote_number>00121</vote_number>
+      <vote_date>13-Mar</vote_date>
+      <issue>PN13-12</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: William Pulte, of Florida, to be Director of the Federal Housing Finance Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00120</vote_number>
+      <vote_date>13-Mar</vote_date>
+      <issue>PN13-12</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>57</yeas>
+        <nays>41</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: William Pulte to be Director of the Federal Housing Finance Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00119</vote_number>
+      <vote_date>12-Mar</vote_date>
+      <issue>PN12-42</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Keith Sonderling, of Florida, to be Deputy Secretary of Labor</title>
+    </vote>
+    <vote>
+      <vote_number>00118</vote_number>
+      <vote_date>12-Mar</vote_date>
+      <issue>PN12-42</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Keith Sonderling to be Deputy Secretary of Labor</title>
+    </vote>
+    <vote>
+      <vote_number>00117</vote_number>
+      <vote_date>12-Mar</vote_date>
+      <issue>PN19</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Stephen Miran, of New York, to be Chairman of the Council of Economic Advisers</title>
+    </vote>
+    <vote>
+      <vote_number>00116</vote_number>
+      <vote_date>12-Mar</vote_date>
+      <issue>PN19</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Stephen Miran to be Chairman of the Council of Economic Advisers</title>
+    </vote>
+    <vote>
+      <vote_number>00115</vote_number>
+      <vote_date>11-Mar</vote_date>
+      <issue>PN12-41</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>78</yeas>
+        <nays>19</nays>
+      </vote_tally>
+      <title>Confirmation: Abigail Slater, of D.C., to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00114</vote_number>
+      <vote_date>11-Mar</vote_date>
+      <issue>PN12-41</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>76</yeas>
+        <nays>20</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Abigail Slater to be an Assistant Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00113</vote_number>
+      <vote_date>11-Mar</vote_date>
+      <issue>PN13-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Stephen Bradbury, of Virginia, to be Deputy Secretary of Transportation</title>
+    </vote>
+    <vote>
+      <vote_number>00112</vote_number>
+      <vote_date>11-Mar</vote_date>
+      <issue>PN13-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Steven Bradbury to be Deputy Secretary of Transportation</title>
+    </vote>
+    <vote>
+      <vote_number>00111</vote_number>
+      <vote_date>10-Mar</vote_date>
+      <issue>PN11-4</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>67</yeas>
+        <nays>32</nays>
+      </vote_tally>
+      <title>Confirmation: Lori Chavez-DeRemer, of Oregon, to be Secretary of Labor</title>
+    </vote>
+    <vote>
+      <vote_number>00110</vote_number>
+      <vote_date>06-Mar</vote_date>
+      <issue>S. 331</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>82</yeas>
+        <nays>12</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 331; A bill to amend the Controlled Substances Act with respect to the scheduling of fentanyl-related substances, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00109</vote_number>
+      <vote_date>06-Mar</vote_date>
+      <issue>PN11-4</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>66</yeas>
+        <nays>30</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Lori Chavez-DeRemer to be Secretary of Labor</title>
+    </vote>
+    <vote>
+      <vote_number>00108</vote_number>
+      <vote_date>06-Mar</vote_date>
+      <issue>PN12-14</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Troy Edgar, of California, to be Deputy Secretary of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00107</vote_number>
+      <vote_date>06-Mar</vote_date>
+      <issue>PN12-14</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Troy Edgar to be Deputy Secretary of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00106</vote_number>
+      <vote_date>05-Mar</vote_date>
+      <issue>S.J.Res. 28</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>S.J. Res. 28; A joint resolution disapproving the rule submitted by the Bureau of Consumer Financial Protection relating to "Defining Larger Participants of a Market for General-Use Digital Consumer Payment Applications".</title>
+    </vote>
+    <vote>
+      <vote_number>00105</vote_number>
+      <vote_date>05-Mar</vote_date>
+      <issue>PN12-5</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Todd Blanche, of Florida, to be Deputy Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00104</vote_number>
+      <vote_date>05-Mar</vote_date>
+      <issue>PN12-5</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Todd Blanche to be Deputy Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00103</vote_number>
+      <vote_date>04-Mar</vote_date>
+      <issue>S.J.Res. 28</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J. Res. 28; A joint resolution disapproving the rule submitted by the Bureau of Consumer Financial Protection relating to "Defining Larger Participants of a Market for General-Use Digital Consumer Payment Applications".</title>
+    </vote>
+    <vote>
+      <vote_number>00102</vote_number>
+      <vote_date>04-Mar</vote_date>
+      <issue>S.J.Res. 3</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>70</yeas>
+        <nays>27</nays>
+      </vote_tally>
+      <title>S.J. Res. 3; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Internal Revenue Service relating to "Gross Proceeds Reporting by Brokers That Regularly Provide Services Effectuating Digital Asset Sales".</title>
+    </vote>
+    <vote>
+      <vote_number>00101</vote_number>
+      <vote_date>04-Mar</vote_date>
+      <issue>S.J.Res. 3</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>70</yeas>
+        <nays>28</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.J. Res. 3; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Internal Revenue Service relating to "Gross Proceeds Reporting by Brokers That Regularly Provide Services Effectuating Digital Asset Sales".</title>
+    </vote>
+    <vote>
+      <vote_number>00100</vote_number>
+      <vote_date>03-Mar</vote_date>
+      <issue>S. 9</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 9; A bill to provide that for purposes of determining compliance with title IX of the Education Amendments of 1972 in athletics, sex shall be recognized based solely on a person's reproductive biology and genetics at birth.</title>
+    </vote>
+    <vote>
+      <vote_number>00099</vote_number>
+      <vote_date>03-Mar</vote_date>
+      <issue>PN11-10</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Linda McMahon, of Connecticut, to be Secretary of Education</title>
+    </vote>
+    <vote>
+      <vote_number>00098</vote_number>
+      <vote_date>27-Feb</vote_date>
+      <issue>PN11-10</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Linda McMahon to be Secretary of Education</title>
+    </vote>
+    <vote>
+      <vote_number>00097</vote_number>
+      <vote_date>27-Feb</vote_date>
+      <issue>H.J.Res. 35</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>H. J. Res. 35; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "Waste Emissions Charge for Petroleum and Natural Gas Systems: Procedures for Facilitating Compliance, Including Netting and Exemptions".</title>
+    </vote>
+    <vote>
+      <vote_number>00096</vote_number>
+      <vote_date>26-Feb</vote_date>
+      <issue>S.J.Res. 12</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S. J. Res. 12; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Environmental Protection Agency relating to "Waste Emissions Charge for Petroleum and Natural Gas Systems: Procedures for Facilitating Compliance, Including Netting and Exemptions".</title>
+    </vote>
+    <vote>
+      <vote_number>00095</vote_number>
+      <vote_date>26-Feb</vote_date>
+      <issue>S.J.Res. 10</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>S. J. Res. 10; A joint resolution terminating the national emergency declared with respect to energy.</title>
+    </vote>
+    <vote>
+      <vote_number>00094</vote_number>
+      <vote_date>26-Feb</vote_date>
+      <issue>PN11-17</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Confirmation: Jamieson Greer, of Maryland, to be U.S. Trade Representative</title>
+    </vote>
+    <vote>
+      <vote_number>00093</vote_number>
+      <vote_date>25-Feb</vote_date>
+      <issue>PN11-10</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to Consider the Nomination of Linda McMahon</title>
+    </vote>
+    <vote>
+      <vote_number>00092</vote_number>
+      <vote_date>25-Feb</vote_date>
+      <issue>S.J.Res. 11</issue>
+      <question>On the Joint Resolution
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>S. J. Res. 11; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Ocean Energy Management relating to "Protection of Marine Archaeological Resources".</title>
+    </vote>
+    <vote>
+      <vote_number>00091</vote_number>
+      <vote_date>25-Feb</vote_date>
+      <issue>S.J.Res. 11</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S. J. Res. 11; A joint resolution providing for congressional disapproval under chapter 8 of title 5, United States Code, of the rule submitted by the Bureau of Ocean Energy Management relating to "Protection of Marine Archaeological Resources".</title>
+    </vote>
+    <vote>
+      <vote_number>00090</vote_number>
+      <vote_date>25-Feb</vote_date>
+      <issue>PN12-12</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>66</yeas>
+        <nays>28</nays>
+      </vote_tally>
+      <title>Confirmation: Daniel Driscoll, of North Carolina, to be Secretary of the Army</title>
+    </vote>
+    <vote>
+      <vote_number>00089</vote_number>
+      <vote_date>24-Feb</vote_date>
+      <issue>PN11-17</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Jamieson Greer to be United States Trade Representative</title>
+    </vote>
+    <vote>
+      <vote_number>00088</vote_number>
+      <vote_date>24-Feb</vote_date>
+      <issue>PN12-12</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>66</yeas>
+        <nays>28</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Daniel Driscoll to be Secretary of the Army</title>
+    </vote>
+    <vote>
+      <vote_number>00087</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Concurrent Resolution
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>S.Con.Res. 7, As Amended; An original concurrent resolution setting forth the congressional budget for the United States Government for fiscal year 2025 and setting forth the appropriate budgetary levels for fiscal years 2026 through 2034.</title>
+    </vote>
+    <vote>
+      <vote_number>00086</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1207</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Merkley Amdt. No. 1207; To establish a deficit-neutral reserve fund relating to ending price gouging on prescription drugs.</title>
+    </vote>
+    <vote>
+      <vote_number>00085</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 922</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Lee Amdt. No. 922; To establish a deficit-neutral reserve fund relating to Congress continuing its work to rein in the administrative state by supporting legislation that prevents Federal agencies from finalizing major rules without congressional approval, strengthens the Article 1 law-making powers of Congress, cuts spending resulting from costly regulations, reduces inflation, and unleashes economic growth.</title>
+    </vote>
+    <vote>
+      <vote_number>00084</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 957</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Lujan Amdt. No. 957; To strike reconciliation instructions requiring damaging cuts to programs critical to rural Americans and food assistance for American families.</title>
+    </vote>
+    <vote>
+      <vote_number>00083</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 659</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Blumenthal Amdt. No. 659; To ensure full and uninterrupted funding for Department of Veterans Affairs health care and benefits provided by the Sergeant First Class Heath Robinson Honoring our Promise to Address Comprehensive Toxics Act of 2022 (Public Law 117-168), also known as the "PACT Act", preventing any cuts or delays.</title>
+    </vote>
+    <vote>
+      <vote_number>00082</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 971</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Duckworth Amdt. No. 971; To establish a deficit-neutral reserve fund relating to protecting access to fertility services, and eliminating barriers for families in need of high-quality, affordable fertility services by expanding nationwide coverage for in vitro fertilization.</title>
+    </vote>
+    <vote>
+      <vote_number>00081</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 699</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Lujan Amdt. No. 699; To establish a deficit-neutral reserve fund relating to supporting police, which may include initiatives that provide funding directly to law enforcement agencies to hire or rehire additional career law enforcement officers in an effort to increase their community policing capacity and crime prevention efforts.</title>
+    </vote>
+    <vote>
+      <vote_number>00080</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 436</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Shaheen Amdt. No. 436; To establish a deficit-neutral reserve fund relating to preserving and extending vital tax credits enacted under the Patient Protection and Affordable Care Act, which make heath care accessible and affordable and that have led to the lowest uninsured rate in our Nation's history.</title>
+    </vote>
+    <vote>
+      <vote_number>00079</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 233</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Van Hollen Amdt. No. 233; To create a point of order against legislation that would cut funding from the school lunch or school breakfast programs.</title>
+    </vote>
+    <vote>
+      <vote_number>00078</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 664</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Slotkin Amdt. No. 664; To establish a deficit-neutral reserve fund relating to preventing reductions in funding and staffing necessary to respond to, control, and prevent avian flu.</title>
+    </vote>
+    <vote>
+      <vote_number>00077</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 999</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>24</yeas>
+        <nays>76</nays>
+      </vote_tally>
+      <title>Paul Amdt No. 999; To require an adequate amount of deficit reduction as part of reconciliation.</title>
+    </vote>
+    <vote>
+      <vote_number>00076</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 299</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Reed Amdt. No. 299; To ensure continued United States support for the Government of Ukraine to stand firm against aggression by the Government of Russia in Europe.</title>
+    </vote>
+    <vote>
+      <vote_number>00075</vote_number>
+      <vote_date>21-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 172</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Reed Amdt. No. 172; To create a point of order against legislation that would reduce Medicare and Medicaid benefits for Americans.</title>
+    </vote>
+    <vote>
+      <vote_number>00074</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 276</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Motion to  Waive All Applicable Budgetary Discipline Re: Baldwin Amdt. No. 276; To create a point of order against legislation that would take away health care from seniors, including those receiving care in nursing homes, through cuts to the Medicaid program.</title>
+    </vote>
+    <vote>
+      <vote_number>00073</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 1156</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Wyden Amdt. No. 1156; To prevent millions of Americans from being kicked off their health coverage, suffering needlessly, getting sicker, and dying sooner.</title>
+    </vote>
+    <vote>
+      <vote_number>00072</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 407</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Ossoff Amdt. No. 407; To establish a deficit-neutral reserve fund relating to protecting access to maternal and pediatric health care through Medicaid.</title>
+    </vote>
+    <vote>
+      <vote_number>00071</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 776</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>49</yeas>
+        <nays>51</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Schumer Amdt. No. 776; To prevent tax cuts for the wealthy if a single dollar of Medicaid funding is cut.</title>
+    </vote>
+    <vote>
+      <vote_number>00070</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 1029</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Sullivan Amdt. No. 1029; To establish a deficit-neutral reserve fund relating to protecting Medicare and Medicaid.</title>
+    </vote>
+    <vote>
+      <vote_number>00069</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 316</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Schiff Amdt. No. 316; To establish a deficit-neutral reserve fund relating to supporting Federal wildland firefighters and associated personnel.</title>
+    </vote>
+    <vote>
+      <vote_number>00068</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 540</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Bennet Amdt. No. 540; To establish a deficit-neutral reserve fund relating to reinstating the fired Federal employees at the Forest Service, National Park Service, United States Fish and Wildlife Service, and Bureau of Land Management.</title>
+    </vote>
+    <vote>
+      <vote_number>00067</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 925</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Hickenlooper Amdt. No. 925; To create a point of order against legislation that would raise energy costs for Americans, including higher monthly electricity bills, building material expenses, and transportation costs.</title>
+    </vote>
+    <vote>
+      <vote_number>00066</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 878</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Murray Amdt. No. 878; To strike the reconciliation instructions and create a reserve fund to implement a bipartisan, multi-year agreement to provide up to $171,000,000,000 in discretionary funding for defense and up to $171,000,000,000 in discretionary funding for other programs, accounts, and activities to address border, veterans, farmers, food and nutrition, disaster relief, and other needs.</title>
+    </vote>
+    <vote>
+      <vote_number>00065</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 130</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>53</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Warner Amdt. No. 130; To create a point of order against any reconciliation bill that would not decrease the cost of housing for American families.</title>
+    </vote>
+    <vote>
+      <vote_number>00064</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 473</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Merkley Amdt. No. 473; To establish a deficit-neutral reserve fund relating to the impacts of hedge fund ownership of single-family homes and rent prices.</title>
+    </vote>
+    <vote>
+      <vote_number>00063</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 494</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Klobuchar Amdt. No. 494; To stop tax cuts for the ultra-rich while families struggle to put food on the table.</title>
+    </vote>
+    <vote>
+      <vote_number>00062</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion
+        <measure>S.Amdt. 454</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>47</yeas>
+        <nays>52</nays>
+      </vote_tally>
+      <title>Motion to Waive All Applicable Budgetary Discipline Re: Schumer Amdt. No. 454; To prevent unwarranted tax cuts for the ultra-rich.</title>
+    </vote>
+    <vote>
+      <vote_number>00061</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>PN12-35</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Confirmation: Kashyap Patel, of Nevada, to be Director of the Federal Bureau of Investigation</title>
+    </vote>
+    <vote>
+      <vote_number>00060</vote_number>
+      <vote_date>20-Feb</vote_date>
+      <issue>PN12-35</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Kashyap Patel to be Director of the Federal Bureau of Investigation</title>
+    </vote>
+    <vote>
+      <vote_number>00059</vote_number>
+      <vote_date>19-Feb</vote_date>
+      <issue>PN11-18</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Kelly Loeffler, of Georgia, to be Administrator of the Small Business Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00058</vote_number>
+      <vote_date>18-Feb</vote_date>
+      <issue>S.Con.Res. 7</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S.Con.Res. 7; An original concurrent resolution setting forth the congressional budget for the United States Government for fiscal year 2025 and setting forth the appropriate budgetary levels for fiscal years 2026 through 2034.</title>
+    </vote>
+    <vote>
+      <vote_number>00057</vote_number>
+      <vote_date>18-Feb</vote_date>
+      <issue>PN11-9</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Confirmation: Howard Lutnick, of New York, to be Secretary of Commerce</title>
+    </vote>
+    <vote>
+      <vote_number>00056</vote_number>
+      <vote_date>18-Feb</vote_date>
+      <issue>PN12-35</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>48</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to consider the nomination of Kashyap Patel</title>
+    </vote>
+    <vote>
+      <vote_number>00055</vote_number>
+      <vote_date>13-Feb</vote_date>
+      <issue>PN11-18</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>43</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Kelly Loeffler to be Administrator of the Small Business Administration</title>
+    </vote>
+    <vote>
+      <vote_number>00054</vote_number>
+      <vote_date>13-Feb</vote_date>
+      <issue>PN11-9</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Howard Lutnick to be Secretary of Commerce</title>
+    </vote>
+    <vote>
+      <vote_number>00053</vote_number>
+      <vote_date>13-Feb</vote_date>
+      <issue>PN11-12</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>72</yeas>
+        <nays>28</nays>
+      </vote_tally>
+      <title>Confirmation: Brooke Rollins, of TX, to be Secretary of Agriculture</title>
+    </vote>
+    <vote>
+      <vote_number>00052</vote_number>
+      <vote_date>13-Feb</vote_date>
+      <issue>PN11-8</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Confirmation: Robert F. Kennedy, Jr., of California, to be Secretary of Health and Human Services</title>
+    </vote>
+    <vote>
+      <vote_number>00051</vote_number>
+      <vote_date>12-Feb</vote_date>
+      <issue>PN11-8</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Robert F. Kennedy, Jr., to be Secretary of Health and Human Services</title>
+    </vote>
+    <vote>
+      <vote_number>00050</vote_number>
+      <vote_date>12-Feb</vote_date>
+      <issue>PN11-16</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>48</nays>
+      </vote_tally>
+      <title>Confirmation: Tulsi Gabbard, of HI, to be Director of National Intelligence</title>
+    </vote>
+    <vote>
+      <vote_number>00049</vote_number>
+      <vote_date>10-Feb</vote_date>
+      <issue>PN11-16</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Tulsi Gabbard to be Director of National Intelligence</title>
+    </vote>
+    <vote>
+      <vote_number>00048</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-18</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to Consider the Nomination of Kelly Loeffler</title>
+    </vote>
+    <vote>
+      <vote_number>00047</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-12</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Legislative Session</title>
+    </vote>
+    <vote>
+      <vote_number>00046</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-12</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to Consider the Nomination of Brooke Rollins</title>
+    </vote>
+    <vote>
+      <vote_number>00045</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-9</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Legislative Session</title>
+    </vote>
+    <vote>
+      <vote_number>00044</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-9</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to Consider the Nomination of Howard Lutnick</title>
+    </vote>
+    <vote>
+      <vote_number>00043</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-8</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Legislative Session</title>
+    </vote>
+    <vote>
+      <vote_number>00042</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-8</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to consider the Nomination of Robert F. Kennedy, Jr.</title>
+    </vote>
+    <vote>
+      <vote_number>00041</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-16</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Legislative Session</title>
+    </vote>
+    <vote>
+      <vote_number>00040</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-16</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to Consider the Nomination of Tulsi Gabbard</title>
+    </vote>
+    <vote>
+      <vote_number>00039</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-22</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Legislative Session</title>
+    </vote>
+    <vote>
+      <vote_number>00038</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-22</issue>
+      <question>On the Motion to Table
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Table the Motion to Reconsider Re: Vought Nomination</title>
+    </vote>
+    <vote>
+      <vote_number>00037</vote_number>
+      <vote_date>06-Feb</vote_date>
+      <issue>PN11-22</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Confirmation: Russell Vought, of Virginia, to be Director of the Office of Management and Budget</title>
+    </vote>
+    <vote>
+      <vote_number>00036</vote_number>
+      <vote_date>05-Feb</vote_date>
+      <issue>PN11-22</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Russell Vought to be Director of the Office of Management and Budget</title>
+    </vote>
+    <vote>
+      <vote_number>00035</vote_number>
+      <vote_date>05-Feb</vote_date>
+      <issue>PN11-14</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>55</yeas>
+        <nays>44</nays>
+      </vote_tally>
+      <title>Confirmation: Eric Turner, of Texas, to be Secretary of Housing and Urban Development</title>
+    </vote>
+    <vote>
+      <vote_number>00034</vote_number>
+      <vote_date>04-Feb</vote_date>
+      <issue>PN11-14</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>55</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Eric Turner to be Secretary of Housing and Urban Development</title>
+    </vote>
+    <vote>
+      <vote_number>00033</vote_number>
+      <vote_date>04-Feb</vote_date>
+      <issue>PN11-2</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Confirmation: Pamela Bondi, of Florida, to be Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00032</vote_number>
+      <vote_date>04-Feb</vote_date>
+      <issue>PN11-5</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>77</yeas>
+        <nays>23</nays>
+      </vote_tally>
+      <title>Confirmation: Douglas Collins, of Georgia, to be Secretary of Veterans Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00031</vote_number>
+      <vote_date>03-Feb</vote_date>
+      <issue>PN11-2</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Pamela Bondi to be Attorney General</title>
+    </vote>
+    <vote>
+      <vote_number>00030</vote_number>
+      <vote_date>03-Feb</vote_date>
+      <issue>PN11-15</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>38</nays>
+      </vote_tally>
+      <title>Confirmation: Christopher Wright, of Colorado, to be Secretary of Energy</title>
+    </vote>
+    <vote>
+      <vote_number>00029</vote_number>
+      <vote_date>03-Feb</vote_date>
+      <issue>PN11-22</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to Consider the Nomination of Russell Vought</title>
+    </vote>
+    <vote>
+      <vote_number>00028</vote_number>
+      <vote_date>30-Jan</vote_date>
+      <issue>PN11-5</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>83</yeas>
+        <nays>13</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Douglas Collins, of Georgia, to be Secretary of Veterans Affairs</title>
+    </vote>
+    <vote>
+      <vote_number>00027</vote_number>
+      <vote_date>30-Jan</vote_date>
+      <issue>PN11-15</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>62</yeas>
+        <nays>35</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Christopher Wright to be Secretary of Energy</title>
+    </vote>
+    <vote>
+      <vote_number>00026</vote_number>
+      <vote_date>30-Jan</vote_date>
+      <issue>PN11-3</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>80</yeas>
+        <nays>17</nays>
+      </vote_tally>
+      <title>Confirmation: Douglas Burgum, of N.D., to be Secretary of the Interior</title>
+    </vote>
+    <vote>
+      <vote_number>00025</vote_number>
+      <vote_date>29-Jan</vote_date>
+      <issue>PN11-3</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>78</yeas>
+        <nays>20</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Douglas Burgum to be Secretary of the Interior</title>
+    </vote>
+    <vote>
+      <vote_number>00024</vote_number>
+      <vote_date>29-Jan</vote_date>
+      <issue>PN11-23</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Confirmation: Lee Zeldin, of N.Y., to be Administrator of the Environmental Protection Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00023</vote_number>
+      <vote_date>29-Jan</vote_date>
+      <issue>PN11-23</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>56</yeas>
+        <nays>42</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Lee Zeldin to be Administrator of the Environmental Protection Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00022</vote_number>
+      <vote_date>28-Jan</vote_date>
+      <issue>H.R. 23</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to H.R. 23; A bill to impose sanctions with respect to the International Criminal Court engaged in any effort to investigate, arrest, detain, or prosecute any protected person of the United States and its allies.</title>
+    </vote>
+    <vote>
+      <vote_number>00021</vote_number>
+      <vote_date>28-Jan</vote_date>
+      <issue>PN11-6</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>77</yeas>
+        <nays>22</nays>
+      </vote_tally>
+      <title>Confirmation: Sean Duffy, of WI, to be Secretary of Transportation</title>
+    </vote>
+    <vote>
+      <vote_number>00020</vote_number>
+      <vote_date>27-Jan</vote_date>
+      <issue>PN11-6</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>97</yeas>
+        <nays>0</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Sean Duffy to be Secretary of Transportation</title>
+    </vote>
+    <vote>
+      <vote_number>00019</vote_number>
+      <vote_date>27-Jan</vote_date>
+      <issue>PN11-1</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>68</yeas>
+        <nays>29</nays>
+      </vote_tally>
+      <title>Confirmation: Scott Bessent, of S.C., to be Secretary of the Treasury</title>
+    </vote>
+    <vote>
+      <vote_number>00018</vote_number>
+      <vote_date>25-Jan</vote_date>
+      <issue>PN11-1</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>67</yeas>
+        <nays>23</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Scott Bessent to be Secretary of the Treasury</title>
+    </vote>
+    <vote>
+      <vote_number>00017</vote_number>
+      <vote_date>25-Jan</vote_date>
+      <issue>PN11-11</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>59</yeas>
+        <nays>34</nays>
+      </vote_tally>
+      <title>Confirmation: Kristi Noem, of South Dakota, to be Secretary of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00016</vote_number>
+      <vote_date>24-Jan</vote_date>
+      <issue>PN11-11</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>61</yeas>
+        <nays>39</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Kristi Noem to be Secretary of Homeland Security</title>
+    </vote>
+    <vote>
+      <vote_number>00015</vote_number>
+      <vote_date>24-Jan</vote_date>
+      <issue>PN11-7</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>50</yeas>
+        <nays>50</nays>
+      </vote_tally>
+      <title>Confirmation: Peter Hegseth, of Tennessee, to be Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00014</vote_number>
+      <vote_date>23-Jan</vote_date>
+      <issue>PN11-7</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>51</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Peter Hegseth to be Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00013</vote_number>
+      <vote_date>23-Jan</vote_date>
+      <issue>PN11-19</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>74</yeas>
+        <nays>25</nays>
+      </vote_tally>
+      <title>Confirmation: John Ratcliffe, of Texas, to be Director of the Central Intelligence Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00012</vote_number>
+      <vote_date>23-Jan</vote_date>
+      <issue>PN11-19</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>72</yeas>
+        <nays>26</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: John Ratcliffe to be Director of the Central Intelligence Agency</title>
+    </vote>
+    <vote>
+      <vote_number>00011</vote_number>
+      <vote_date>22-Jan</vote_date>
+      <issue>S. 6</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>52</yeas>
+        <nays>47</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S.6; A bill to amend title 18, United States Code, to prohibit a health care practitioner from failing to exercise the proper degree of care in the case of a child who survives an abortion or attempted abortion.</title>
+    </vote>
+    <vote>
+      <vote_number>00010</vote_number>
+      <vote_date>21-Jan</vote_date>
+      <issue>PN11-7</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>53</yeas>
+        <nays>45</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Executive Session to Consider the Nomination of Peter Hegseth to be Secretary of Defense</title>
+    </vote>
+    <vote>
+      <vote_number>00009</vote_number>
+      <vote_date>21-Jan</vote_date>
+      <issue>PN11-19</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>54</yeas>
+        <nays>46</nays>
+      </vote_tally>
+      <title>Motion to Proceed to Legislative Session</title>
+    </vote>
+    <vote>
+      <vote_number>00008</vote_number>
+      <vote_date>20-Jan</vote_date>
+      <issue>PN11-13</issue>
+      <question>On the Nomination
+         </question>
+      <result>Confirmed</result>
+      <vote_tally>
+        <yeas>99</yeas>
+        <nays>0</nays>
+      </vote_tally>
+      <title>Confirmation: Marco Rubio, of Florida, to be Secretary of State</title>
+    </vote>
+    <vote>
+      <vote_number>00007</vote_number>
+      <vote_date>20-Jan</vote_date>
+      <issue>S. 5</issue>
+      <question>On Passage of the Bill
+         </question>
+      <result>Passed</result>
+      <vote_tally>
+        <yeas>64</yeas>
+        <nays>35</nays>
+      </vote_tally>
+      <title>S. 5, As Amended; A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00006</vote_number>
+      <vote_date>20-Jan</vote_date>
+      <issue>S. 5</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 8</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>75</yeas>
+        <nays>24</nays>
+      </vote_tally>
+      <title>Ernst Amdt No. 8, As Amended; To include crimes resulting in death or serious bodily injury to the list of offenses that, if committed by an inadmissible alien, require mandatory detention.</title>
+    </vote>
+    <vote>
+      <vote_number>00005</vote_number>
+      <vote_date>17-Jan</vote_date>
+      <issue>S. 5</issue>
+      <question>On the Cloture Motion
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>61</yeas>
+        <nays>35</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: S. 5; A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00004</vote_number>
+      <vote_date>15-Jan</vote_date>
+      <issue>S. 5</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 23</measure></question>
+      <result>Rejected</result>
+      <vote_tally>
+        <yeas>46</yeas>
+        <nays>49</nays>
+      </vote_tally>
+      <title>Coons Amdt. No. 23; To strike the section that authorizes State attorneys general to sue Federal immigration authorities for alleged violations relating to the detention of aliens.</title>
+    </vote>
+    <vote>
+      <vote_number>00003</vote_number>
+      <vote_date>15-Jan</vote_date>
+      <issue>S. 5</issue>
+      <question>On the Amendment
+        <measure>S.Amdt. 14</measure></question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>70</yeas>
+        <nays>25</nays>
+      </vote_tally>
+      <title>Cornyn Amdt. No. 14; To expand the list of criminal offenses that subject inadmissible aliens to mandatory detention.</title>
+    </vote>
+    <vote>
+      <vote_number>00002</vote_number>
+      <vote_date>13-Jan</vote_date>
+      <issue>S. 5</issue>
+      <question>On the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>82</yeas>
+        <nays>10</nays>
+      </vote_tally>
+      <title>Motion to Proceed to S. 5; A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</title>
+    </vote>
+    <vote>
+      <vote_number>00001</vote_number>
+      <vote_date>09-Jan</vote_date>
+      <issue>S. 5</issue>
+      <question>On Cloture on the Motion to Proceed
+         </question>
+      <result>Agreed to</result>
+      <vote_tally>
+        <yeas>84</yeas>
+        <nays>9</nays>
+      </vote_tally>
+      <title>Motion to Invoke Cloture: Motion to Proceed to S. 5; A bill to require the Secretary of Homeland Security to take into custody aliens who have been charged in the United States with theft, and for other purposes.</title>
+    </vote>
+  </votes>
+</vote_summary>


### PR DESCRIPTION
## Summary

- Adds implementation plans for both halves of the Votes phase: **Phase 3a (House)** via `api.congress.gov`, and **Phase 3b (Senate)** via senate.gov LIS XML.
- Updates the roadmap to reflect the **chamber-based split** that replaced the original metadata-vs-positions split. Driving fact (from API spike): `api.congress.gov` has no Senate vote endpoint at all, and the House API exposes full per-member positions — so the natural seam is chamber, not metadata-vs-positions.
- Captures the discovery-spike API/XML fixtures under `tests/fixtures/api/votes/` and `tests/fixtures/senate/` so a fresh agent can execute either plan without re-running spikes.

Companion ADRs (0010 — chamber-based phasing; 0011 — Party Unity Score methodology) land with the Phase 3a implementation PR, not in this docs-only commit.

## Test plan

- [ ] Read [`docs/plans/phase-3a-votes-house.md`](https://github.com/johnmarcampbell/concord/blob/claude/jovial-beaver-f6e53f/docs/plans/phase-3a-votes-house.md) top-to-bottom — confirm it reads as self-contained and could be executed by a fresh agent.
- [ ] Read [`docs/plans/phase-3b-votes-senate.md`](https://github.com/johnmarcampbell/concord/blob/claude/jovial-beaver-f6e53f/docs/plans/phase-3b-votes-senate.md) — same.
- [ ] Skim the roadmap diff to confirm the Phase 3 section now mirrors the Phase 2 split structure.
- [ ] Spot-check a few of the captured fixtures (`detail_house_119_1_240.json`, `detail_119_1_00003_amendment.xml`) — they're the basis for the loader tests the plans specify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)