### PR TITLE
Web layer bootstraps empty SQLite schema on startup

### DIFF
--- a/docs/adr/0012-web-bootstraps-empty-schema-on-startup.md
+++ b/docs/adr/0012-web-bootstraps-empty-schema-on-startup.md
@@ -1,0 +1,49 @@
+# 0012 — Web layer bootstraps an empty schema on startup
+
+**Status**: Accepted, 2026-05-26.
+
+## Context
+
+`concord serve` historically refused to start if its `--db` path didn't exist: the CLI did a `db_path.exists()` check up front and exited with code 2 if the file wasn't there. That was fine when the only path to a running web app went through `concord scrape` → `concord load` → `concord index` on a developer's machine — the DB is created as a side effect of the pipeline, and "no DB" almost always means "you forgot to run the pipeline."
+
+That assumption breaks the moment we ship a Dockerfile. The intended Docker first-run UX is: pull the image, `docker run`, hit `localhost:8000`, see an empty Concord with the search box and "no results yet" copy, then optionally exec into the container to run a scrape. With the old behavior, the container crash-loops on first boot with `error: database not found: /data/proceedings.db` until the user knows to pre-create the file — terrible first impression and not how a derived store of size zero should behave.
+
+The schema itself is already idempotent — every DDL in `_BASE_SCHEMA` / `_VEC_SCHEMA` is `CREATE … IF NOT EXISTS`, and `SqliteStorage.__init__` already runs the whole script and `mkdir -p`s the parent directory. So the missing piece was purely *who* runs it on the serve path.
+
+Two places could plausibly own the bootstrap:
+
+1. **CLI** — keep `serve_command` in charge and have it call the schema-create helper before constructing the app.
+2. **Web app** — have `create_app()` call the helper itself, on the way to opening any per-request connections that assume tables exist.
+
+## Decision
+
+The web layer owns it. A new `concord.storage.sqlite.ensure_schema(db_path)` function — defined alongside the existing DDL so the "schema of record" stays in one place — creates the file (and parent directory) and applies the full schema. `create_app()` calls `ensure_schema(db_path)` near the top, before any connection is opened. The CLI's pre-flight `db_path.exists()` check in `serve_command` is removed; `concord serve` against a missing DB now boots successfully into an empty app.
+
+Out of scope for this ADR: whether `serve` should require `OPENAI_API_KEY`. The `_require_openai_key()` check stays as-is. The semantic-search path needs the key; the non-semantic browsing paths arguably don't. That's a separate decision and a separate ADR if we ever change it.
+
+## Consequences
+
+**Trade-offs accepted:**
+
+- **`create_app()` now has a side effect on disk.** Constructing the app may create a SQLite file. Previously `create_app()` only read state. In practice this is the same side effect `SqliteStorage(path)` already had — the pipeline has always created the DB on first construction — so the surprise is small, and it's documented at the call site and in the ADR.
+- **A typo in `--db` produces a working, empty Concord instead of an error.** Old behavior caught the typo loudly. New behavior creates `/tmp/typoo.db` and serves "no results yet" against it. Acceptable: the failure mode is visible (the user sees an empty UI and immediately questions what DB they pointed at) and the cost of the wrong choice is one empty SQLite file. Worth it for the first-run experience.
+- **`concord serve` no longer signals "you forgot to run the pipeline."** Anyone who used the exit-code-2 as a reminder will lose that nudge. The empty-state UI is the new nudge.
+
+**Things this buys:**
+
+- **Docker first-run works without ceremony.** `docker run concord serve` against a fresh volume just works — no entrypoint scripts that pre-touch the DB, no `docker exec … concord init`. The follow-up Dockerfile PR depends on this landing.
+- **The CLI's `serve` becomes a one-liner over `create_app()`.** No more redundant existence check; the layer that knows what schema it needs is also the one that creates it.
+- **`ensure_schema()` is a usable primitive for future entry points.** Anything else that wants to mount a fresh SQLite (test fixtures, future bootstrap commands, a hypothetical `concord init`) can call it instead of duplicating the construct-then-close pattern.
+
+**What stays open:**
+
+- **`OPENAI_API_KEY` requirement for `serve`.** Still enforced by `_require_openai_key()`. Whether browsing-only deployments should be runnable without an OpenAI key — and what the search box does in that mode — is unresolved; revisit when there's a concrete deployment that wants it.
+- **No "is the schema at the version this binary expects?" check.** The DDL is `IF NOT EXISTS`, so a stale-schema file produces silent missing-column errors at query time rather than a startup failure. Acceptable today because the schema is append-only across releases; if/when we introduce a destructive migration, this becomes a real migrations story (probably a `schema_version` table and a migrate step). Out of scope here.
+
+## Rejected: CLI owns the bootstrap
+
+`serve_command` could call `ensure_schema()` itself before constructing the app, and `create_app()` could stay pure. Rejected because it leaves a footgun: any other entry point that calls `create_app()` (tests, a future ASGI factory consumed by gunicorn / a Docker `CMD` that points at the FastAPI app object directly, an embedded usage) gets the old "tables missing" failure. Putting the bootstrap in the layer that needs the tables means there's exactly one path; nobody can construct the app wrong.
+
+## Rejected: keep the existence check, fix it in the Dockerfile
+
+The Docker entrypoint could `touch` the DB before invoking `concord serve`, or run a separate `concord init` first. Rejected because it pushes a Concord invariant ("the web app needs a schema") into the deployment substrate, and every new deployment shape would have to re-discover it. The web layer is the right place to own its own preconditions.

--- a/src/concord/cli.py
+++ b/src/concord/cli.py
@@ -1696,10 +1696,10 @@ def serve_command(
     Reads ``OPENAI_API_KEY`` from the environment. Production deployments
     bind to ``127.0.0.1`` and live behind Hostinger's TLS-terminating
     reverse proxy.
+
+    A missing DB file is created with an empty schema on startup (ADR 0012);
+    `serve` is the only top-level command that bootstraps rather than fails.
     """
-    if not db_path.exists():
-        typer.echo(f"error: database not found: {db_path}", err=True)
-        raise typer.Exit(code=2)
     _require_openai_key()
 
     # Lazy imports so `concord --help` doesn't pay the FastAPI/uvicorn cost.

--- a/src/concord/storage/__init__.py
+++ b/src/concord/storage/__init__.py
@@ -14,6 +14,6 @@ The :class:`Storage` Protocol is the contract every backend implements.
 from .base import Storage
 from .jsonl import JsonlStorage
 from .mongo import MongoStorage
-from .sqlite import SqliteStorage
+from .sqlite import SqliteStorage, ensure_schema
 
-__all__ = ["JsonlStorage", "MongoStorage", "SqliteStorage", "Storage"]
+__all__ = ["JsonlStorage", "MongoStorage", "SqliteStorage", "Storage", "ensure_schema"]

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -576,6 +576,16 @@ _CHUNK_INSERT_SQL = (
 _VEC_INSERT_SQL = "INSERT OR REPLACE INTO chunks_vec(rowid, embedding) VALUES (?, ?)"
 
 
+def ensure_schema(db_path: Path | str) -> None:
+    """Create the SQLite file (and parent dir) and apply the full schema.
+
+    Idempotent: every DDL statement is ``CREATE … IF NOT EXISTS``, so this
+    is safe to call against an existing DB. Used by the web layer to
+    bootstrap an empty store on first boot — see ADR 0012.
+    """
+    SqliteStorage(db_path).close()
+
+
 class SqliteStorage:
     """SQLite-backed :class:`Storage` implementation."""
 

--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -37,6 +37,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
 from concord.embedding import Embedder
+from concord.storage.sqlite import ensure_schema
 
 from . import search as search_mod
 from .snippets import keyword_snippet, semantic_snippet
@@ -111,6 +112,10 @@ def create_app(
         Tests pass a stub to avoid network and OpenAI key requirements.
     """
     db_path = Path(db_path)
+    # First-boot bootstrap: if the DB file is missing, create it and apply
+    # the schema so the rest of create_app() (and incoming requests) can
+    # assume the tables exist. See ADR 0012.
+    ensure_schema(db_path)
 
     if embedder is None:
         import openai  # noqa: PLC0415 — guarded so tests can import this module without openai

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -706,18 +706,31 @@ class TestServeCommand:
         for flag in ["--db", "--host", "--port", "--reload"]:
             assert flag in plain
 
-    def test_missing_db_exits_cleanly(
+    def test_missing_db_bootstraps_empty_schema(
         self,
         runner: CliRunner,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """Serve against a missing DB creates it on the fly (ADR 0012)."""
         monkeypatch.setenv(cli_module.ENV_OPENAI_API_KEY, "sk-test")
-        result = runner.invoke(cli_module.app, ["serve", "--db", str(tmp_path / "missing.db")])
-        assert result.exit_code == 2
-        plain = _strip(result.output) + _strip(result.stderr or "")
-        assert "not found" in plain
-        assert "Traceback" not in plain
+        db = tmp_path / "missing.db"
+
+        # Stub uvicorn so we don't actually bind a port; stub openai so the
+        # embedder constructor doesn't need a real key.
+        monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: None)
+
+        class _Fake:
+            class embeddings:  # noqa: N801 — mirrors openai SDK attribute name
+                @staticmethod
+                def create(*, model: str, input: list[str]) -> Any:
+                    raise AssertionError("should not be called during serve startup")
+
+        monkeypatch.setattr(openai, "OpenAI", lambda *a, **kw: _Fake())
+
+        result = runner.invoke(cli_module.app, ["serve", "--db", str(db)])
+        assert result.exit_code == 0, result.output
+        assert db.exists()
 
     def test_missing_openai_api_key_exits_cleanly(
         self,

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -119,6 +119,28 @@ class TestBasicRoutes:
         assert "font-serif" in r.text
 
 
+class TestBootstrapMissingDb:
+    """ADR 0012: create_app() against a missing DB path bootstraps a fresh,
+    empty schema rather than failing. Backs the Docker first-run UX."""
+
+    def test_missing_db_yields_working_empty_app(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "does-not-yet-exist.db"
+        assert not db_path.exists()
+
+        app = create_app(db_path, embedder=Embedder(_StubClient()))
+        assert db_path.exists()
+
+        client = TestClient(app, raise_server_exceptions=False)
+
+        r = client.get("/healthz")
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+        r = client.get("/")
+        assert r.status_code == 200
+        assert "Concord" in r.text
+
+
 # -- search endpoint ----------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Adds `ensure_schema(db_path)` in `src/concord/storage/sqlite.py` and wires `create_app()` to call it before opening any connection — `concord serve` against a missing DB file now boots into an empty Concord instead of exiting with code 2.
- Removes the now-redundant `db_path.exists()` pre-flight check in `serve_command`.
- Captures the decision in [ADR 0012](docs/adr/0012-web-bootstraps-empty-schema-on-startup.md). The web layer (not the CLI) owns the bootstrap so any entry point that calls `create_app()` — tests, Docker, a future ASGI factory — gets the same guarantee.

## Why

Backs the Docker first-run UX: `docker run` against a fresh volume should land on an empty search box with "no results yet" copy, not a crash-looping container. The follow-up Dockerfile PR depends on this landing first (or in the same window).

Out of scope: the `_require_openai_key()` check in `serve_command` stays as-is — whether browse-only deployments should run without an OpenAI key is a separate decision.

## Test plan

- [x] `uv run pytest` — full suite (517 passed)
- [x] New test `TestBootstrapMissingDb::test_missing_db_yields_working_empty_app` in `tests/test_web_routes.py` — `create_app()` against a non-existent path creates the file and serves `/healthz` + `/`.
- [x] Updated `tests/test_cli.py::TestServeCommand::test_missing_db_bootstraps_empty_schema` — end-to-end through the CLI, confirms `concord serve --db /missing.db` exits 0 and creates the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)