### PR TITLE
Add Dockerfile for portable, deployment-agnostic image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# Belt-and-suspenders for the build context. The Dockerfile uses
+# explicit COPY directives rather than `COPY . .`, so this list mostly
+# exists to keep the build context small and to defend against a future
+# COPY refactor accidentally pulling in junk.
+
+# Version control
+.git/
+.gitignore
+.github/
+
+# Python build / cache artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+build/
+dist/
+
+# Tool caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
+# Local virtualenvs
+.venv/
+venv/
+
+# Project data — never bake a developer's locally-scraped JSONL / DB
+# into a published image.
+data/
+
+# Editor / OS junk
+.DS_Store
+*.swp
+*.swo
+.idea/
+.vscode/
+
+# Agent / worktree state
+.claude/
+
+# Repo docs that don't belong in the runtime image
+tests/
+docs/
+CONTRIBUTING.md
+CONTEXT.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,95 @@
+# syntax=docker/dockerfile:1.7
+#
+# Concord container image.
+#
+# A generic, deployment-agnostic image. The default command runs the web
+# server, but the image exposes the full `concord` CLI — override the
+# command to run pipeline subcommands (`pull`, `load`, `index`, ...).
+#
+# State lives under /app/data, which is meant to be a bind mount or
+# named volume. See docs/docker.md for usage.
+
+# ---------------------------------------------------------------------------
+# Builder: resolve and install dependencies with uv into /app/.venv.
+# ---------------------------------------------------------------------------
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+WORKDIR /app
+
+# Install third-party dependencies first, before copying any source.
+# This layer is cached as long as pyproject.toml + uv.lock are unchanged,
+# so day-to-day edits to src/ don't re-run dependency resolution.
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
+
+# Now install the project itself. Fast — deps are already in place.
+COPY src/ src/
+COPY README.md ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+# ---------------------------------------------------------------------------
+# Runtime: slim Python image carrying just the venv, the source, and a
+# small set of debug niceties.
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim AS runtime
+
+# - ca-certificates: HTTPS to api.congress.gov + OpenAI.
+# - curl: used by the HEALTHCHECK and handy for in-container debugging.
+# - htop, sqlite3, less: debug conveniences. The whole project's state
+#   is one SQLite file — `sqlite3 /app/data/proceedings.db` is the
+#   fastest way to inspect FTS5 / vec / row counts when something is off.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        htop \
+        less \
+        sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user with a fixed UID/GID so host bind mounts have a stable
+# ownership target. See docs/docker.md for the one-time `chown` step
+# host-side machines need when their login user is not UID 1000.
+# `--system` would force a UID < 1000, fighting the explicit `--uid 1000`
+# (UID 1000 is what we want for bind-mount UID matching). So this is a
+# regular user account that simply never logs in (nologin shell).
+RUN groupadd --gid 1000 concord \
+    && useradd  --uid 1000 --gid 1000 --no-create-home \
+                --home-dir /app --shell /sbin/nologin concord
+
+WORKDIR /app
+
+COPY --from=builder --chown=concord:concord /app/.venv          /app/.venv
+COPY --from=builder --chown=concord:concord /app/src            /app/src
+COPY --from=builder --chown=concord:concord /app/pyproject.toml /app/pyproject.toml
+COPY --from=builder --chown=concord:concord /app/README.md      /app/README.md
+
+# /app/data is the convention for the mounted data volume. Create it so
+# the container can boot even without a mount — the web app's first-boot
+# bootstrap (ADR 0012) will create an empty proceedings.db on demand.
+RUN mkdir -p /app/data && chown concord:concord /app/data
+
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+USER concord
+
+EXPOSE 8000
+
+# Hit the dedicated /healthz endpoint rather than /, which would render
+# Jinja templates and do real work on every probe.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD curl -fsS http://localhost:8000/healthz || exit 1
+
+# Default: serve the web app on 0.0.0.0:8000. Override CMD to run any
+# other `concord` subcommand (pull, load, index, ...).
+# Note: the CLI default is --host 127.0.0.1, which is wrong inside a
+# container — we override it here, not in the CLI itself.
+CMD ["concord", "serve", "--host", "0.0.0.0", "--port", "8000"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,134 @@
+# Running Concord in Docker
+
+The repository ships a generic Dockerfile. The image exposes the full
+`concord` CLI; the default command runs the web server, and any other
+subcommand can be invoked by overriding the command at `docker run`.
+
+The image is deliberately deployment-agnostic — no Hostinger-specific
+or reverse-proxy logic lives in it. Wire up environment variables,
+volumes, ports, and TLS in your `docker-compose.yml` (or equivalent)
+where the image is actually deployed.
+
+## Build
+
+```sh
+docker build -t concord .
+```
+
+## Run the web server
+
+```sh
+docker run --rm \
+    -p 8000:8000 \
+    -v "$(pwd)/data:/app/data" \
+    -e OPENAI_API_KEY=sk-... \
+    concord
+```
+
+The server binds `0.0.0.0:8000` inside the container; map it to
+whatever host port you like with `-p`. State lives under `/app/data`
+(SQLite `proceedings.db`, the canonical JSONL stores, and any
+entity-specific stores under that directory).
+
+On first start against an empty `/app/data`, the web app bootstraps an
+empty SQLite schema (per [ADR 0012](adr/0012-web-bootstraps-empty-schema-on-startup.md)).
+The UI loads, but search and entity pages return nothing until you
+ingest data.
+
+## Run a pipeline command
+
+The image is a generic CLI image — override the command:
+
+```sh
+docker run --rm \
+    -v "$(pwd)/data:/app/data" \
+    -e CONGRESS_API_KEY=... \
+    -e OPENAI_API_KEY=sk-... \
+    concord \
+    concord pull --from 2026-05-01 --to 2026-05-22
+```
+
+`concord load`, `concord index`, and the entity-specific pipelines
+(`concord pull-members`, `concord pull-bills`, ...) all follow the
+same pattern. Pass `concord --help` as the command to see the full
+list.
+
+## Host directory ownership
+
+The container runs as a non-root user with fixed UID/GID **`1000:1000`**.
+For host bind mounts to be writable by the container:
+
+```sh
+mkdir -p ./data
+sudo chown -R 1000:1000 ./data
+```
+
+No host user needs to *exist* with UID 1000 — the kernel only checks
+the number.
+
+Two footnotes:
+
+- **If your host login user is already UID 1000** (common on
+  single-admin Linux boxes — check with `id`), skip the `chown`. Files
+  written by the container will show up as owned by your login user on
+  the host, which is convenient for `ls`.
+- **If your host login user is *not* UID 1000**, the `chown` works
+  fine, but `ls -l ./data` on the host shows files owned by a numeric
+  UID with no name. Cosmetic, not functional.
+
+macOS users running Docker Desktop don't need to think about any of
+this — Docker Desktop's file-sharing layer handles UID translation.
+
+## Required environment variables
+
+- **`OPENAI_API_KEY`** — required by `concord serve` (semantic
+  search) and `concord index` (embedding generation).
+- **`CONGRESS_API_KEY`** — required by the scraper subcommands
+  (`pull`, `pull-members`, `pull-bills`, ...).
+
+Both are read from the process environment; the image does not bundle
+any defaults or fallbacks.
+
+## Compose
+
+A minimal `docker-compose.yml` for a single-host deployment:
+
+```yaml
+services:
+  concord:
+    build: .                       # or: image: ghcr.io/<you>/concord:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8000:8000"      # behind a reverse proxy
+    volumes:
+      - ./data:/app/data
+    environment:
+      - OPENAI_API_KEY
+      - CONGRESS_API_KEY
+    env_file:
+      - .env                       # not committed
+```
+
+Pipeline jobs run as one-shot containers off the same image:
+
+```sh
+docker compose run --rm concord concord pull --from "$(date -u +%F)" --to "$(date -u +%F)"
+docker compose run --rm concord concord load
+docker compose run --rm concord concord index
+```
+
+Schedule those via host-side `cron` (or `systemd` timers) — the image
+itself stays single-purpose.
+
+## Image internals
+
+- **Base:** `python:3.12-slim` (Debian bookworm, glibc — required by
+  the `sqlite_vec` wheel and by stdlib `sqlite3`'s loadable-extension
+  support).
+- **Build:** multi-stage via the official `ghcr.io/astral-sh/uv`
+  builder image. Runtime carries only `/app/.venv` and the source tree
+  — no `uv`, no build toolchain.
+- **Debug tools baked in:** `htop`, `sqlite3`, `curl`, `less`. Useful
+  for poking at a running container with `docker compose exec`.
+- **Healthcheck:** `curl -fsS http://localhost:8000/healthz`.
+- **User:** non-root, UID/GID `1000:1000`.


### PR DESCRIPTION
## Summary

- Generic Docker image exposing the full `concord` CLI; default command runs the web server. Override `CMD` to invoke pipeline subcommands (`pull`, `load`, `index`, ...).
- Multi-stage build via `uv` (`ghcr.io/astral-sh/uv:python3.12-bookworm-slim` builder → `python:3.12-slim` runtime). No `uv` in the runtime image; just `.venv` + source.
- Runs as a non-root user with fixed UID/GID `1000:1000` so host bind mounts have a stable ownership target.
- Includes a small debug toolkit baked into the runtime image (`htop`, `sqlite3`, `curl`, `less`) — the whole project's state is one SQLite file, so `docker compose exec concord sqlite3 /app/data/proceedings.db` is a useful escape hatch when something is off.
- `HEALTHCHECK` hits the existing `/healthz` endpoint.
- Deployment-specific glue (env vars, volumes, reverse proxy, scheduling) deliberately stays *out* of the repo. Compose lives on the deploying host. `docs/docker.md` documents the conventions a host-side compose file needs.

## Design notes

- **Depends on the ADR-0012 bootstrap** (#59, already merged). The image expects `concord serve` to create an empty schema on first boot when `/app/data/proceedings.db` is missing — without that, `docker run -p 8000:8000 concord` against an empty mount would have exit-2'd. With it, the UI loads against an empty volume and the user can ingest data when they're ready.
- **Data layout: `WORKDIR /app`, mount `/app/data`.** No new env-var indirection — the CLI's existing defaults (`./data/proceedings.db`, `./data/` for entity stores) Just Work.
- **`--host 0.0.0.0` in CMD, not in the CLI default.** Container-only override; the systemd/host story stays `127.0.0.1`.

## Follow-ups (not in this PR)

- `docs/deployment.md` overlaps with the new `docs/docker.md` — the systemd + cron + `uv sync`-on-host content is now redundant for the documented deployment path. Worth either trimming it down to a pointer or moving the host-specific content out of the repo, but that's a separate decision.

## Test plan

- [x] `docker build -t concord .` succeeds with no warnings.
- [x] `docker run -d -p 8765:8000 -e OPENAI_API_KEY=sk-dummy concord` boots; uvicorn binds `0.0.0.0:8000`.
- [x] `curl http://localhost:8765/healthz` → `{"ok":true}`.
- [x] First boot against an empty mount: `/app/data/proceedings.db` is created (~290 KB), owned by `concord:concord`.
- [ ] On the Hostinger VPS: `chown 1000:1000` the data dir, `docker compose up`, point the reverse proxy at the mapped port, confirm the public demo serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)