### PR TITLE
ci: publish Docker image to GHCR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # semver tag from the release (e.g. v1.2.3 → 1.2.3, 1.2, 1)
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # always update :latest on a new release
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` — a workflow that builds and pushes the container image to `ghcr.io/johnmarcampbell/concord` whenever a GitHub release is published.

### Tags produced

Given a release tagged `v1.2.3`, the workflow pushes:
- `ghcr.io/johnmarcampbell/concord:1.2.3`
- `ghcr.io/johnmarcampbell/concord:1.2`
- `ghcr.io/johnmarcampbell/concord:1`
- `ghcr.io/johnmarcampbell/concord:latest`

### Details
- **Auth**: uses `GITHUB_TOKEN` with `packages: write` — no extra secrets needed
- **Cache**: GHA layer cache (`type=gha`) speeds up repeat builds by reusing unchanged layers (especially the uv dependency layer)
- **Trigger**: `release: published` only — drafts and pre-releases don't fire it

🤖 Generated with [Claude Code](https://claude.com/claude-code)