### PR TITLE
fix: retry on 403 from congress.gov (rate-limit signal)

### DIFF
--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -76,6 +76,7 @@ MAX_5XX_RETRIES = 5
 _BACKOFF_BASE = 2.0
 
 #: HTTP status codes we treat specially.
+HTTP_FORBIDDEN = 403
 HTTP_TOO_MANY_REQUESTS = 429
 HTTP_SERVER_ERROR_MIN = 500
 HTTP_SERVER_ERROR_MAX = 600  # exclusive upper bound

--- a/src/concord/text.py
+++ b/src/concord/text.py
@@ -14,8 +14,10 @@ Retry policy
 
 The ``www.congress.gov`` HTML tier is a separate service from
 ``api.congress.gov`` and has its own (undocumented) rate limit — bulk pulls
-of many articles can trip 429s. Retries mirror :mod:`concord.api`:
+of many articles can trip 429s or 403s. Retries mirror :mod:`concord.api`:
 
+* HTTP 403: congress.gov uses 403 as a rate-limit signal in addition to 429.
+  Treated identically to 429: retry **indefinitely** with exponential backoff.
 * HTTP 429: retry **indefinitely**, honoring ``Retry-After`` and otherwise
   backing off exponentially capped at :data:`MAX_BACKOFF`.
 * HTTP 5xx and transport errors (DNS, timeout, connection reset): retry up
@@ -33,7 +35,12 @@ from html.parser import HTMLParser
 
 import httpx
 
-from concord.api import HTTP_SERVER_ERROR_MAX, HTTP_SERVER_ERROR_MIN, HTTP_TOO_MANY_REQUESTS
+from concord.api import (
+    HTTP_FORBIDDEN,
+    HTTP_SERVER_ERROR_MAX,
+    HTTP_SERVER_ERROR_MIN,
+    HTTP_TOO_MANY_REQUESTS,
+)
 
 #: Cap on a single backoff delay, in seconds. Applied to both the exponential
 #: schedule and Retry-After values so a server-suggested 1-hour wait can't
@@ -144,6 +151,17 @@ def _get_with_retry(
             continue
 
         status = response.status_code
+
+        if status == HTTP_FORBIDDEN:
+            # congress.gov returns 403 instead of 429 when rate-limiting bulk
+            # fetches. Treat it the same as 429: back off and retry indefinitely
+            # rather than surfacing a permanent failure. Retries do not count
+            # against transient_attempts — being throttled is a wait condition,
+            # not a fault.
+            delay = _retry_after_seconds(response) or _backoff_seconds(transient_attempts)
+            _log.warning("403 from %s (rate-limited?); backing off %.1fs before retry", url, delay)
+            sleep(delay)
+            continue
 
         if status == HTTP_TOO_MANY_REQUESTS:
             delay = _retry_after_seconds(response) or _backoff_seconds(transient_attempts)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -191,6 +191,41 @@ class TestFetchTextRateLimit:
             text = fetch_text(SAMPLE_URL, client, sleep=lambda _s: None)
         assert text == "finally"
 
+    def test_403_retries_until_success(self) -> None:
+        # congress.gov uses 403 as a rate-limit signal; must back off and retry.
+        responses = iter(
+            [
+                httpx.Response(403),
+                httpx.Response(403),
+                _ok("<pre>after 403 backoff</pre>"),
+            ]
+        )
+        slept: list[float] = []
+        with _client(lambda r: next(responses)) as client:
+            text = fetch_text(SAMPLE_URL, client, sleep=slept.append)
+        assert text == "after 403 backoff"
+        assert len(slept) == 2
+
+    def test_403_honors_retry_after_header(self) -> None:
+        responses = iter(
+            [
+                httpx.Response(403, headers={"retry-after": "5"}),
+                _ok("<pre>ok</pre>"),
+            ]
+        )
+        slept: list[float] = []
+        with _client(lambda r: next(responses)) as client:
+            fetch_text(SAMPLE_URL, client, sleep=slept.append)
+        assert slept == [5.0]
+
+    def test_403_does_not_count_against_5xx_budget(self) -> None:
+        # Many 403s followed by success must not exhaust the 5xx retry budget.
+        sequence = [httpx.Response(403)] * 20 + [_ok("<pre>finally</pre>")]
+        responses = iter(sequence)
+        with _client(lambda r: next(responses)) as client:
+            text = fetch_text(SAMPLE_URL, client, sleep=lambda _s: None)
+        assert text == "finally"
+
 
 # -- redirect handling --------------------------------------------------------
 


### PR DESCRIPTION
## Problem

congress.gov returns **403 Forbidden** instead of 429 when throttling bulk HTML fetches. The previous code treated 403 as an immediate fatal error, so a rate-limited article was skipped with no backoff — and then every subsequent article in the same run hit the same wall just as fast.

## Fix

Treat 403 identically to 429 in `_get_with_retry()`: exponential backoff (capped at `MAX_BACKOFF = 60 s`) + indefinite retry. Like 429, a 403 doesn't count against the `transient_attempts` budget, so a sustained throttle window won't exhaust the 5xx retry cap.

The log line is `403 from <url> (rate-limited?); backing off Xs before retry` so it's easy to spot in long runs.

## Changes

| File | Change |
|------|--------|
| `src/concord/api.py` | Add `HTTP_FORBIDDEN = 403` constant |
| `src/concord/text.py` | New 403 branch in `_get_with_retry()` before the 429 branch; update module docstring |
| `tests/test_text.py` | Three new cases: retry-to-success, `Retry-After` header, budget isolation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)