### PR TITLE
chore: gitignore .env files to prevent secret leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ venv/
 
 # OS
 .DS_Store
+
+# Secrets
+.env
+.env.*


### PR DESCRIPTION
## Summary
Add `.env` and `.env.*` to `.gitignore` under a new `# Secrets` section so a stray `git add .` can't commit `CONGRESS_API_KEY` / `OPENAI_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)