### PR TITLE
PyPI-readiness — `concord-congress` 0.2.0 (ADR 0014)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,10 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # Docker image → GHCR.
+  # Skipped for prereleases — those are dry-runs to TestPyPI only (ADR 0014).
   build-and-push:
+    if: ${{ github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -50,3 +53,51 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Wheel + sdist → real PyPI. Trusted publishing via OIDC (ADR 0014); no
+  # PYPI_API_TOKEN secret. Requires `concord-congress` to be registered on
+  # pypi.org with this repo + workflow + environment as a trusted publisher.
+  publish-pypi:
+    if: ${{ github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # required for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Build wheel + sdist
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Wheel + sdist → TestPyPI. Same flow, fires on prereleases only — those
+  # are dry-runs to validate the pipeline end-to-end before a real publish.
+  # Requires the same trusted-publisher setup on test.pypi.org.
+  publish-testpypi:
+    if: ${{ github.event.release.prerelease == true }}
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Build wheel + sdist
+        run: uv build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   # Wheel + sdist → real PyPI. Trusted publishing via OIDC (ADR 0014); no
-  # PYPI_API_TOKEN secret. Requires `concord-congress` to be registered on
+  # PYPI_API_TOKEN secret. Requires `congress-concord` to be registered on
   # pypi.org with this repo + workflow + environment as a trusted publisher.
   publish-pypi:
     if: ${{ github.event.release.prerelease == false }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - 0007 — Stage 0 + Stage 1 are parallel per entity type; Stage 2/3 are shared.
   - 0010 / 0011 — Votes phased by chamber (3a House via api.congress.gov, 3b Senate via senate.gov LIS XML); Party Unity Score is the CQ-style methodology, chamber-scoped.
   - 0012 — `concord serve` bootstraps an empty SQLite schema on startup.
-  - 0014 — Published on PyPI as `concord-congress`; CLI shape is the stable contract, Python imports are best-effort.
+  - 0014 — Published on PyPI as `congress-concord`; CLI shape is the stable contract, Python imports are best-effort.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — style rules the linter enforces (line 100, absolute imports only, type-hint everything in `src/`, `# noqa` requires an inline reason, etc.). Read it before silencing a lint warning.
 
 If a proposed change conflicts with an ADR, the right move is to discuss whether to write a new ADR (or amend the existing one) — not to silently diverge. ADRs are appended, not edited away.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - 0007 — Stage 0 + Stage 1 are parallel per entity type; Stage 2/3 are shared.
   - 0010 / 0011 — Votes phased by chamber (3a House via api.congress.gov, 3b Senate via senate.gov LIS XML); Party Unity Score is the CQ-style methodology, chamber-scoped.
   - 0012 — `concord serve` bootstraps an empty SQLite schema on startup.
+  - 0014 — Published on PyPI as `concord-congress`; CLI shape is the stable contract, Python imports are best-effort.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — style rules the linter enforces (line 100, absolute imports only, type-hint everything in `src/`, `# noqa` requires an inline reason, etc.). Read it before silencing a lint warning.
 
 If a proposed change conflicts with an ADR, the right move is to discuss whether to write a new ADR (or amend the existing one) — not to silently diverge. ADRs are appended, not edited away.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 John Campbell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,26 +2,39 @@
 
 A pipeline for collecting U.S. Congress data — currently the daily [Congressional Record](https://www.congress.gov/congressional-record) (proceedings) and the directory of [Members](https://www.congress.gov/members) — via [api.congress.gov](https://api.congress.gov/). Stores everything locally as JSON Lines + SQLite, with a FastAPI search demo on top.
 
+Distributed on PyPI as **`concord-congress`**; imported in Python as **`concord`** (the bare `concord` name on PyPI was already taken).
+
+## Install
+
+```sh
+pip install concord-congress
+```
+
+Requires Python 3.12+. The install is batteries-included — every `concord` subcommand (`scrape`, `load`, `index`, `run`, `serve`) works out of the box.
+
 ## Quick start
 
-Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/).
+```sh
+export CONGRESS_API_KEY=...  # free key from https://api.data.gov/signup/
+export OPENAI_API_KEY=...    # required for proceedings indexing (semantic search)
+
+# Proceedings — one day's articles, end-to-end:
+concord run proceedings --from 2026-05-22 --to 2026-05-22
+
+# Members — current Congress, end-to-end:
+concord run members --congresses 119
+
+# Serve the web demo:
+concord serve
+```
+
+To work on Concord itself (rather than just use it), clone the repo and `uv sync` instead:
 
 ```sh
 git clone https://github.com/johnmarcampbell/concord
 cd concord
 uv sync
-
-export CONGRESS_API_KEY=...  # free key from https://api.data.gov/signup/
-export OPENAI_API_KEY=...    # required for proceedings indexing (semantic search)
-
-# Proceedings — one day's articles, end-to-end:
 uv run concord run proceedings --from 2026-05-22 --to 2026-05-22
-
-# Members — current Congress, end-to-end:
-uv run concord run members --congresses 119
-
-# Serve the web demo:
-uv run concord serve
 ```
 
 Output for `run proceedings`:
@@ -186,6 +199,19 @@ uv run pytest
 
 The `pre-commit` hook runs `ruff format` and `ruff check --fix` on every commit; CI runs all four checks above plus `pytest`.
 
+## Versioning and API stability
+
+Concord is below 1.0 and is *not* committing to a stable Python API yet. What semver does track for `concord-congress` releases:
+
+- `concord <subcommand>` shape, flag names, exit codes, and the format of the success-summary lines printed to stdout
+- The on-disk JSONL and SQLite formats that the CLI produces (other tools may read these)
+
+What semver does *not* track (yet):
+
+- Python imports. `from concord.storage.sqlite import ...` and similar internal imports may move between minor versions as the codebase refactors. Build CLI workflows on top of `concord`, not Python integrations, until 1.0.
+
+See [ADR 0014](docs/adr/0014-publish-to-pypi-cli-first.md) for the reasoning.
+
 ## License
 
-MIT.
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 A pipeline for collecting U.S. Congress data — currently the daily [Congressional Record](https://www.congress.gov/congressional-record) (proceedings) and the directory of [Members](https://www.congress.gov/members) — via [api.congress.gov](https://api.congress.gov/). Stores everything locally as JSON Lines + SQLite, with a FastAPI search demo on top.
 
-Distributed on PyPI as **`concord-congress`**; imported in Python as **`concord`** (the bare `concord` name on PyPI was already taken).
+Distributed on PyPI as **`congress-concord`**; imported in Python as **`concord`** (the bare `concord` name on PyPI was already taken).
 
 ## Install
 
 ```sh
-pip install concord-congress
+pip install congress-concord
 ```
 
 Requires Python 3.12+. The install is batteries-included — every `concord` subcommand (`scrape`, `load`, `index`, `run`, `serve`) works out of the box.
@@ -201,7 +201,7 @@ The `pre-commit` hook runs `ruff format` and `ruff check --fix` on every commit;
 
 ## Versioning and API stability
 
-Concord is below 1.0 and is *not* committing to a stable Python API yet. What semver does track for `concord-congress` releases:
+Concord is below 1.0 and is *not* committing to a stable Python API yet. What semver does track for `congress-concord` releases:
 
 - `concord <subcommand>` shape, flag names, exit codes, and the format of the success-summary lines printed to stdout
 - The on-disk JSONL and SQLite formats that the CLI produces (other tools may read these)

--- a/docs/adr/0014-publish-to-pypi-cli-first.md
+++ b/docs/adr/0014-publish-to-pypi-cli-first.md
@@ -1,4 +1,4 @@
-# 0014 — Publish to PyPI as `concord-congress`, CLI-first
+# 0014 — Publish to PyPI as `congress-concord`, CLI-first
 
 **Status**: Accepted, 2026-05-27.
 
@@ -15,9 +15,11 @@ The four decisions this ADR covers:
 
 ## Decision
 
-### Distribution name: `concord-congress`; import name: `concord`
+### Distribution name: `congress-concord`; import name: `concord`
 
-`[project].name = "concord-congress"` on PyPI; `from concord import ...` in Python. Following the same dist-name-≠-import-name pattern as `scikit-learn`/`sklearn`. No code churn from the rename — only `pyproject.toml` changes.
+`[project].name = "congress-concord"` on PyPI; `from concord import ...` in Python. Following the same dist-name-≠-import-name pattern as `scikit-learn`/`sklearn`. No code churn from the rename — only `pyproject.toml` changes.
+
+The first-choice name was `concord-congress` (the natural reading: "Concord, for Congress"). PyPI's "Add a new pending publisher" form rejected it with `Invalid project name`. The most likely explanation is PyPI's anti-typosquatting check that blocks new names which structurally look like extensions of an existing project: `<existing>-<suffix>` is treated as confusable with `<existing>`. Since `concord` (Concord Systems' CLI tools) exists on PyPI, `concord-*` is closed off. `congress-concord` doesn't start with `concord-`, so it doesn't trip the rule.
 
 ### CLI is the stable contract
 
@@ -36,13 +38,13 @@ Two publish jobs split by prerelease status:
 
 The existing Docker job also gets the `prerelease == false` gate — prerelease tags are dry-runs and shouldn't leak Docker images to GHCR's `latest`.
 
-This requires one-time manual setup in the PyPI and TestPyPI web UIs: register `concord-congress` on each, configure the GitHub repo + workflow file + environment name as a trusted publisher. Not automatable; documented in the PyPI-readiness PR's description.
+This requires one-time manual setup in the PyPI and TestPyPI web UIs: register `congress-concord` on each, configure the GitHub repo + workflow file + environment name as a trusted publisher. Not automatable; documented in the PyPI-readiness PR's description.
 
 ### Version source: manual bump in `pyproject.toml`, exposed via `importlib.metadata`
 
 `[project].version` is the single source of truth. To cut a release, you edit the version, commit, push, then publish a GitHub Release matching the new tag. The release event fires the workflow.
 
-`concord.__version__` is exposed at the package root via `importlib.metadata.version("concord-congress")` rather than a hard-coded string. That way the version is never duplicated, and editable installs (where `importlib.metadata` may raise) fall back to `"0.0.0+unknown"`.
+`concord.__version__` is exposed at the package root via `importlib.metadata.version("congress-concord")` rather than a hard-coded string. That way the version is never duplicated, and editable installs (where `importlib.metadata` may raise) fall back to `"0.0.0+unknown"`.
 
 ### First published version: `0.2.0`
 
@@ -52,7 +54,7 @@ The codebase has grown substantially since `0.1.0` was set (Members, Bills, Vote
 
 **Trade-offs accepted:**
 
-- **Two names for one thing.** Users see `pip install concord-congress` but `import concord` in their code. Surprises some people the first time. Mitigated by leading the README with both names side-by-side. The alternative — renaming the import path — would have rippled through every file in the codebase, every ADR, every doc; not warranted.
+- **Two names for one thing.** Users see `pip install congress-concord` but `import concord` in their code. Surprises some people the first time. Mitigated by leading the README with both names side-by-side. The alternative — renaming the import path — would have rippled through every file in the codebase, every ADR, every doc; not warranted.
 - **No protection for downstream Python importers.** Anyone who writes `from concord.storage.sqlite import SqliteStorage` does so at their own risk. As the project refactors, they may have to keep up. Honest given the project's age and one-author shape; revisitable if a real library-API user shows up.
 - **Trusted publishing requires manual one-time setup on PyPI's side.** Can't be fully automated. Has to be done once per project per index (PyPI + TestPyPI = two setups).
 - **PyPI versions are permanent.** Anything we publish, even a typo, lives forever (yanking is possible but messy and visible). Mitigated by the TestPyPI dry-run before the real first publish.
@@ -60,7 +62,7 @@ The codebase has grown substantially since `0.1.0` was set (Members, Bills, Vote
 
 **Things this buys:**
 
-- **A real install story.** `pip install concord-congress` and the CLI works. No `git clone` + `uv sync` required for users who just want to run a scrape.
+- **A real install story.** `pip install congress-concord` and the CLI works. No `git clone` + `uv sync` required for users who just want to run a scrape.
 - **Forever-no-token-rotation.** Trusted publishing means we never have to manage a PyPI API token, never have to rotate one, never have to worry about one leaking. Modern default.
 - **A free dry-run channel.** TestPyPI is the same software as PyPI; publishing to it validates the entire pipeline (wheel building, classifier rendering, README rendering, install + import smoke test) before we touch the real index.
 - **Refactor freedom.** Internal modules can be reorganized without breaking semver as long as the CLI shape doesn't change. Cleanup work doesn't cost a major version bump.

--- a/docs/adr/0014-publish-to-pypi-cli-first.md
+++ b/docs/adr/0014-publish-to-pypi-cli-first.md
@@ -1,0 +1,83 @@
+# 0014 — Publish to PyPI as `concord-congress`, CLI-first
+
+**Status**: Accepted, 2026-05-27.
+
+## Context
+
+Concord has been a private repo with `uv sync` as its install story. Making it `pip install`-able from PyPI turns it into a thing other people can actually depend on, which forces several decisions the repo has been getting away with leaving implicit. None of these decisions is hard on its own, but each one has alternatives that would point the project in a different direction long-term, so they're worth recording together.
+
+The four decisions this ADR covers:
+
+1. **What name to publish under.** `concord` was already taken on PyPI (Concord Systems' CLI tools, ~6 years old, last release 0.2.9). We had to pick something else for the distribution name.
+2. **What we promise on the public API.** Once the package is on PyPI, semver becomes meaningful: every version-number bump implies a contract about what does and doesn't break. We had to decide what's covered.
+3. **How releases get cut.** PyPI accepts uploads from anywhere with a token, but the modern best practice (since 2023) is trusted publishing via OIDC — PyPI authenticates GitHub Actions directly, no long-lived token to manage.
+4. **Where the version string lives.** Either hand-bumped in `pyproject.toml`, or derived from git tags via something like hatch-vcs. These produce very different day-to-day "cut a release" experiences.
+
+## Decision
+
+### Distribution name: `concord-congress`; import name: `concord`
+
+`[project].name = "concord-congress"` on PyPI; `from concord import ...` in Python. Following the same dist-name-≠-import-name pattern as `scikit-learn`/`sklearn`. No code churn from the rename — only `pyproject.toml` changes.
+
+### CLI is the stable contract
+
+What semver tracks: `concord <subcommand>` shape, flag names, exit codes, the format of success-summary lines on stdout, and the on-disk JSONL + SQLite formats that the CLI produces (other tools may read these files).
+
+What semver does *not* track: Python imports. `from concord.storage.sqlite import SqliteStorage` may break between minor versions as the codebase refactors. The README says so explicitly. If a downstream Python user shows up wanting library-stable imports, that's a future ADR and a future contract — not a thing we promise at first publish.
+
+### Trusted publishing via OIDC on GitHub Release published
+
+The existing `release.yml` fires on Release published (it already builds and pushes a Docker image to GHCR). The PyPI publish jobs piggyback on the same event, in parallel. No `PYPI_API_TOKEN` in GitHub Secrets — PyPI authenticates the workflow via short-lived OIDC tokens issued by GitHub.
+
+Two publish jobs split by prerelease status:
+
+- `publish-testpypi` fires when `github.event.release.prerelease == true`. Publishes to test.pypi.org.
+- `publish-pypi` fires when `prerelease == false`. Publishes to pypi.org.
+
+The existing Docker job also gets the `prerelease == false` gate — prerelease tags are dry-runs and shouldn't leak Docker images to GHCR's `latest`.
+
+This requires one-time manual setup in the PyPI and TestPyPI web UIs: register `concord-congress` on each, configure the GitHub repo + workflow file + environment name as a trusted publisher. Not automatable; documented in the PyPI-readiness PR's description.
+
+### Version source: manual bump in `pyproject.toml`, exposed via `importlib.metadata`
+
+`[project].version` is the single source of truth. To cut a release, you edit the version, commit, push, then publish a GitHub Release matching the new tag. The release event fires the workflow.
+
+`concord.__version__` is exposed at the package root via `importlib.metadata.version("concord-congress")` rather than a hard-coded string. That way the version is never duplicated, and editable installs (where `importlib.metadata` may raise) fall back to `"0.0.0+unknown"`.
+
+### First published version: `0.2.0`
+
+The codebase has grown substantially since `0.1.0` was set (Members, Bills, Votes, web layer, semantic search, ~100× the LOC). Starting fresh PyPI history at `0.2.0` honestly signals "there was a before" even though that before never shipped publicly. `1.0.0` is reserved for the day the CLI contract is firm enough to be worth promising — not today.
+
+## Consequences
+
+**Trade-offs accepted:**
+
+- **Two names for one thing.** Users see `pip install concord-congress` but `import concord` in their code. Surprises some people the first time. Mitigated by leading the README with both names side-by-side. The alternative — renaming the import path — would have rippled through every file in the codebase, every ADR, every doc; not warranted.
+- **No protection for downstream Python importers.** Anyone who writes `from concord.storage.sqlite import SqliteStorage` does so at their own risk. As the project refactors, they may have to keep up. Honest given the project's age and one-author shape; revisitable if a real library-API user shows up.
+- **Trusted publishing requires manual one-time setup on PyPI's side.** Can't be fully automated. Has to be done once per project per index (PyPI + TestPyPI = two setups).
+- **PyPI versions are permanent.** Anything we publish, even a typo, lives forever (yanking is possible but messy and visible). Mitigated by the TestPyPI dry-run before the real first publish.
+- **Manual version bumps can be forgotten.** PyPI rejects re-uploads of the same version, so forgetting to bump is recoverable but annoying. Alternative (hatch-vcs from git tags) would prevent this entirely but adds tooling and produces messy dev-build version strings.
+
+**Things this buys:**
+
+- **A real install story.** `pip install concord-congress` and the CLI works. No `git clone` + `uv sync` required for users who just want to run a scrape.
+- **Forever-no-token-rotation.** Trusted publishing means we never have to manage a PyPI API token, never have to rotate one, never have to worry about one leaking. Modern default.
+- **A free dry-run channel.** TestPyPI is the same software as PyPI; publishing to it validates the entire pipeline (wheel building, classifier rendering, README rendering, install + import smoke test) before we touch the real index.
+- **Refactor freedom.** Internal modules can be reorganized without breaking semver as long as the CLI shape doesn't change. Cleanup work doesn't cost a major version bump.
+- **Version single-sourcing.** `pyproject.toml` carries the version; `concord.__version__` reads it. Can't drift out of sync.
+
+## Rejected: hatch-vcs (version derived from git tags)
+
+Cleaner in principle (the git tag is the version, full stop), but produces dev-build version strings like `0.2.0.dev3+gabc1234` that confuse users running editable installs, and adds the hatch-vcs dependency. Manual bumping is fine for a slow release cadence.
+
+## Rejected: full library API surface as part of semver
+
+Would give downstream Python users a real contract to depend on. Also makes every refactor potentially a breaking change, which is unsustainable for a one-author project. Revisitable if Concord ever has a meaningful library-API user base.
+
+## Rejected: long-lived `PYPI_API_TOKEN` secret
+
+Works, used to be standard, requires manual token rotation and creates a secret-management burden. Trusted publishing is strictly better for any project that uses GitHub Actions.
+
+## Rejected: `CHANGELOG.md` in the repo
+
+GitHub Release notes serve the same purpose with less duplication. If a real CHANGELOG need shows up (e.g. someone running `concord` air-gapped wanting a local copy of release history), revisit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "concord-congress"
+name = "congress-concord"
 version = "0.2.0"
 description = "Collect, index, and search U.S. Congress data — Congressional Record, Members, Bills, Votes — via api.congress.gov."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,41 @@
 [project]
-name = "concord"
-version = "0.1.0"
-description = "Pipeline for collecting the daily Congressional Record via api.congress.gov."
+name = "concord-congress"
+version = "0.2.0"
+description = "Collect, index, and search U.S. Congress data — Congressional Record, Members, Bills, Votes — via api.congress.gov."
 readme = "README.md"
 requires-python = ">=3.12"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "John Campbell" }]
+keywords = [
+    "congress",
+    "congressional-record",
+    "legislation",
+    "senate",
+    "house",
+    "voting",
+    "bills",
+    "search",
+    "sqlite",
+    "fts5",
+    "vector-search",
+    "hybrid-search",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Environment :: Web Environment",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Database",
+    "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
+    "Topic :: Sociology",
+    "Typing :: Typed",
+]
 dependencies = [
     "fastapi>=0.136.3",
     "httpx>=0.28.1",
@@ -18,6 +48,12 @@ dependencies = [
     "typer>=0.25.1",
     "uvicorn[standard]>=0.48.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/johnmarcampbell/concord"
+Source = "https://github.com/johnmarcampbell/concord"
+Issues = "https://github.com/johnmarcampbell/concord/issues"
+Releases = "https://github.com/johnmarcampbell/concord/releases"
 
 [project.scripts]
 concord = "concord.cli:main"

--- a/src/concord/__init__.py
+++ b/src/concord/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("concord-congress")
+    __version__ = version("congress-concord")
 except PackageNotFoundError:  # pragma: no cover — only happens in odd dev setups
     # The package isn't installed (e.g. running from a source checkout without
     # `uv sync` having materialised the install metadata). Use a sentinel that

--- a/src/concord/__init__.py
+++ b/src/concord/__init__.py
@@ -1,3 +1,13 @@
-"""Concord: collect the daily Congressional Record via api.congress.gov."""
+"""Concord: collect, index, and search U.S. Congress data."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("concord-congress")
+except PackageNotFoundError:  # pragma: no cover — only happens in odd dev setups
+    # The package isn't installed (e.g. running from a source checkout without
+    # `uv sync` having materialised the install metadata). Use a sentinel that
+    # sorts below every real version so downstream version checks fail safely.
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -190,8 +190,8 @@ wheels = [
 ]
 
 [[package]]
-name = "concord"
-version = "0.1.0"
+name = "concord-congress"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -190,7 +190,7 @@ wheels = [
 ]
 
 [[package]]
-name = "concord-congress"
+name = "congress-concord"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary

Wires the repo up for publishing to PyPI as `concord-congress`. Lands ADR 0014 plus every code/config change that doesn't require manual PyPI-side setup. The decisions came out of a `/grill-with-docs` session covering the dist name, the API-stability posture, the auth model, the version source, and the first-publish strategy — see [ADR 0014](docs/adr/0014-publish-to-pypi-cli-first.md) for the full reasoning.

**What this PR changes:**

- `pyproject.toml` — rename to `concord-congress`, bump to `0.2.0`, modernize license to PEP 639 (`license = "MIT"` + `license-files = ["LICENSE"]`), add classifiers, project URLs, keywords.
- `LICENSE` — standard MIT file at the repo root (was previously only a string in `pyproject.toml`).
- `src/concord/__init__.py` — expose `__version__` via `importlib.metadata.version("concord-congress")`. Single source of truth.
- `README.md` — leads with `pip install concord-congress`, clarifies the dist-name vs import-name story, adds a "Versioning and API stability" section pointing at ADR 0014.
- `.github/workflows/release.yml` — adds `publish-pypi` + `publish-testpypi` jobs using trusted publishing (OIDC). Both fire on `release.published`; split by `github.event.release.prerelease` (true → TestPyPI, false → real PyPI). The existing Docker→GHCR job now also gates on `prerelease == false`, so prerelease dry-runs don't leak Docker images.
- `CLAUDE.md` — adds 0014 to the foundational ADR index.

**Still to do before the first real publish (manual one-time work, not in this PR):**

1. Register `concord-congress` on [pypi.org](https://pypi.org) and [test.pypi.org](https://test.pypi.org).
2. On each, configure this repo + `release.yml` + the matching environment name as a trusted publisher.
3. Create two GitHub environments in this repo: `pypi` and `testpypi`.
4. Cut a `v0.2.0rc1` pre-release as a TestPyPI dry-run; verify the wheel installs and `concord` works from a clean venv.
5. Cut the real `v0.2.0` release.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean (70 files)
- [x] `uv run mypy src` — clean (37 source files)
- [x] `uv run pytest` — 550 passed
- [x] `uv build` produces `concord_congress-0.2.0-py3-none-any.whl` and `.tar.gz`
- [x] Wheel METADATA reflects new name, version, license expression, classifiers, URLs, and keywords
- [x] `uv run python -c "import concord; print(concord.__version__)"` returns `'0.2.0'`
- [ ] After merge: complete steps 1–3 above on the PyPI side
- [ ] After merge: TestPyPI dry-run via `v0.2.0rc1` pre-release
- [ ] After merge: real `v0.2.0` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)