### PR TITLE
Bump pyproject version to 0.2.1rc1 for TestPyPI dry-run

### DIFF
--- a/docs/adr/0014-publish-to-pypi-cli-first.md
+++ b/docs/adr/0014-publish-to-pypi-cli-first.md
@@ -46,9 +46,13 @@ This requires one-time manual setup in the PyPI and TestPyPI web UIs: register `
 
 `concord.__version__` is exposed at the package root via `importlib.metadata.version("congress-concord")` rather than a hard-coded string. That way the version is never duplicated, and editable installs (where `importlib.metadata` may raise) fall back to `"0.0.0+unknown"`.
 
-### First published version: `0.2.0`
+### First published version: `0.2.1`
 
-The codebase has grown substantially since `0.1.0` was set (Members, Bills, Votes, web layer, semantic search, ~100× the LOC). Starting fresh PyPI history at `0.2.0` honestly signals "there was a before" even though that before never shipped publicly. `1.0.0` is reserved for the day the CLI contract is firm enough to be worth promising — not today.
+The codebase has grown substantially since `0.1.0` was set (Members, Bills, Votes, web layer, semantic search, ~100× the LOC), so starting fresh PyPI history below the `0.2.x` line wouldn't honestly reflect where the project is. `1.0.0` is reserved for the day the CLI contract is firm enough to be worth promising — not today.
+
+The actual first-published version is `0.2.1`, not `0.2.0`. `v0.2.0` already existed as a GitHub release (created before this ADR landed and before `release.yml` had a PyPI publish job), so the version was effectively "burned" in the project's release history even though no wheel ever reached PyPI. Rather than retroactively recycle it, the first PyPI publish skips ahead one patch: `v0.2.1rc1` for the TestPyPI dry-run, `v0.2.1` for real PyPI.
+
+The pyproject.toml version is the **source of truth for what gets published**, not the git tag. `uv build` reads `[project].version` from pyproject and bakes it into the wheel filename and metadata; the git tag is only a workflow trigger. So every release requires two coordinated changes: bump `pyproject.toml` (committed and merged to master) *then* publish a GitHub release whose tag matches that version. Forgetting either step is the manual-bump tradeoff this ADR accepts; the alternative (`hatch-vcs` deriving version from the tag) was rejected for the reasons above.
 
 ## Consequences
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "congress-concord"
-version = "0.2.0"
+version = "0.2.1rc1"
 description = "Collect, index, and search U.S. Congress data — Congressional Record, Members, Bills, Votes — via api.congress.gov."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,7 @@ wheels = [
 
 [[package]]
 name = "congress-concord"
-version = "0.2.0"
+version = "0.2.1rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Follow-up to #70, which merged with `version = "0.2.0"` still in `pyproject.toml`. That version is already claimed by an existing GitHub release (`v0.2.0`, created before PyPI publishing was wired up). Rather than recycle it, the first PyPI publish skips ahead one patch: `0.2.1rc1` for the TestPyPI dry-run, `0.2.1` for the real publish.

**Why this matters:** the workflow's `uv build` step reads `[project].version` from `pyproject.toml`, **not** from the git tag — the tag is only a workflow trigger. So `pyproject.toml` must be bumped to match the intended release version *before* the GitHub release is created. Otherwise the wheel ships under whatever pyproject says, ignoring the tag, and the tag/version mismatch becomes permanent on PyPI.

This PR was meant to be part of #70 (was pushed to the branch *after* the rename commit) but didn't make it into the squash — it's getting opened separately now.

## Changes

- `pyproject.toml`: `version = "0.2.0"` → `version = "0.2.1rc1"`
- `docs/adr/0014-publish-to-pypi-cli-first.md`: updated the "First published version" section to reflect the skip from 0.2.0 to 0.2.1, and added a paragraph explicitly noting that pyproject.toml (not the git tag) is the source of truth for what gets published.
- `uv.lock`: regenerated for the new version.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run mypy src` — clean
- [x] `uv run pytest` — 550 passed
- [x] `uv build` produces `congress_concord-0.2.1rc1-py3-none-any.whl` + `.tar.gz`
- [x] `uv run python -c "import concord; print(concord.__version__)"` returns `'0.2.1rc1'`

After merge: create `v0.2.1rc1` GitHub release with the pre-release box checked → `publish-testpypi` job fires → TestPyPI gets 0.2.1rc1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)