### PR TITLE
docs: add docs/releases.md with the recurring release workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - 0012 — `concord serve` bootstraps an empty SQLite schema on startup.
   - 0014 — Published on PyPI as `congress-concord`; CLI shape is the stable contract, Python imports are best-effort.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — style rules the linter enforces (line 100, absolute imports only, type-hint everything in `src/`, `# noqa` requires an inline reason, etc.). Read it before silencing a lint warning.
+- [docs/releases.md](docs/releases.md) — recurring release workflow for `congress-concord` on PyPI. Read it before cutting a release; the TestPyPI dry-run has a non-obvious dependency-resolution footgun that the doc documents.
 
 If a proposed change conflicts with an ADR, the right move is to discuss whether to write a new ADR (or amend the existing one) — not to silently diverge. ADRs are appended, not edited away.
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ What semver does *not* track (yet):
 
 - Python imports. `from concord.storage.sqlite import ...` and similar internal imports may move between minor versions as the codebase refactors. Build CLI workflows on top of `concord`, not Python integrations, until 1.0.
 
-See [ADR 0014](docs/adr/0014-publish-to-pypi-cli-first.md) for the reasoning.
+See [ADR 0014](docs/adr/0014-publish-to-pypi-cli-first.md) for the reasoning. Maintainers: [docs/releases.md](docs/releases.md) is the recipe for cutting a release.
 
 ## License
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,103 @@
+# Releasing `congress-concord`
+
+This document covers the **recurring** release workflow — what to do every time you want to push a new version to PyPI. The one-time setup (registering the PyPI/TestPyPI pending publishers, creating the `pypi` and `testpypi` GitHub environments) and the rationale behind these choices live in [ADR 0014](adr/0014-publish-to-pypi-cli-first.md).
+
+## At a glance
+
+| Step | Where | Effect |
+| ---- | ----- | ------ |
+| 1. Bump `[project].version` in `pyproject.toml` to e.g. `0.3.0rc1` | PR + merge | Pyproject now reflects the next dry-run version |
+| 2. Create a GitHub Release tagged `v0.3.0rc1`, **"Set as a pre-release" ✅** | GitHub UI | Fires `publish-testpypi` only — TestPyPI gets the wheel |
+| 3. Smoke-test the TestPyPI wheel (see [recipe](#testpypi-smoke-test-recipe)) | Your machine | Confirms install + import + CLI work |
+| 4. Bump `[project].version` to the real version, e.g. `0.3.0` | PR + merge | Drops the `rc1` suffix |
+| 5. Create a GitHub Release tagged `v0.3.0`, pre-release **❌ unchecked** | GitHub UI | Fires `publish-pypi` + Docker→GHCR; real PyPI gets the wheel |
+| 6. Verify on https://pypi.org/project/congress-concord/ | PyPI page | Eyeball the release page, README rendering, classifiers |
+
+That's the whole loop. Each version-bump PR is a single one-line `pyproject.toml` change — fast to write, fast to review.
+
+## The big footgun: pyproject version vs git tag
+
+The release workflow runs `uv build`, which reads `[project].version` from `pyproject.toml`. **The git tag is only a workflow trigger** — it doesn't influence the version baked into the wheel filename or metadata. So:
+
+- `pyproject.toml` is the source of truth for what gets published.
+- The git tag is convention; it should match `pyproject.toml`'s version, but nothing in the workflow checks that.
+- The wheel's declared version is what PyPI files it under. If the tag says `v0.3.0` and pyproject still says `0.2.1rc1`, you'll ship a wheel called `congress_concord-0.2.1rc1-...` regardless of the tag.
+
+If you forget to bump `pyproject.toml`, the symptoms depend on the situation:
+
+- **Best case**: PyPI rejects the upload because the version already exists. You bump pyproject, merge, and re-cut the release.
+- **Worst case**: the version *doesn't* already exist on PyPI (e.g. you bumped to `0.2.1rc1`, then forgot to bump to `0.2.1` for the real release, but never published `0.2.1rc1` to real PyPI). You'd ship a release-candidate version to the real PyPI under the wrong tag. Recoverable via yank-then-republish-as-next-patch, but messy.
+
+Easiest discipline: the bump-PR's title should match the GitHub release's tag (e.g. PR titled "Bump to 0.3.0" pairs with release `v0.3.0`).
+
+## TestPyPI smoke-test recipe
+
+The pattern most tutorials suggest — `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ <package>` — **is unsafe** for our use case. Here's why, and what to do instead.
+
+### Why `--extra-index-url` is broken for this
+
+`--extra-index-url` doesn't prefer one index over the other. pip searches both and picks the highest-version match. TestPyPI is full of typosquats, abandoned experiments, and broken placeholders that real PyPI long since cleaned up — and some of those placeholders happen to have higher version numbers than the legitimate package on real PyPI.
+
+The failure we hit in our first dry-run: pip's resolver picked `FASTAPI-1.0.tar.gz` from TestPyPI (an abandoned 2.5 KB stub with `summary: "A small api that uses fastapi-users"`) over the real `fastapi-0.136+` on PyPI, because `1.0 > 0.136`. Install then crashed building the stub (`FileNotFoundError: 'DESCRIPTION.txt'`).
+
+### The recipe that works
+
+Download only our wheel from TestPyPI, then install it as a local file. pip resolves the wheel's declared dependencies from the default index (real PyPI) without touching TestPyPI for anything else.
+
+```sh
+# Clean slate
+deactivate 2>/dev/null
+rm -rf /tmp/concord-test /tmp/concord-dl
+
+# Fresh venv (use 3.12 or 3.13 — newer Pythons may lag on dep wheels)
+python3.12 -m venv /tmp/concord-test
+source /tmp/concord-test/bin/activate
+
+# Download ONLY our wheel from TestPyPI, no deps
+pip download --index-url https://test.pypi.org/simple/ \
+             --no-deps \
+             --dest /tmp/concord-dl \
+             congress-concord==X.Y.ZrcN
+
+# Install from the local file; deps come from real PyPI
+pip install /tmp/concord-dl/congress_concord-X.Y.ZrcN-py3-none-any.whl
+
+# Smoke test
+concord --help
+python -c "import concord; print(concord.__version__)"  # → X.Y.ZrcN
+```
+
+Also eyeball https://test.pypi.org/project/congress-concord/ — the README should render, classifiers should appear in the sidebar, and the "Project links" panel should resolve.
+
+## Pre-release vs release: what the checkbox does
+
+The "Set as a pre-release" checkbox on the GitHub Release form is the single switch that routes the workflow:
+
+- **Checked** → `github.event.release.prerelease == true` → only `publish-testpypi` fires. The Docker job and `publish-pypi` are both gated on `prerelease == false` and get skipped.
+- **Unchecked** → `publish-pypi` + the Docker→GHCR build both fire. `publish-testpypi` gets skipped.
+
+You can repeat the dry-run as many times as you need — `rc1`, `rc2`, ... — without ever leaking a Docker image to GHCR or a wheel to real PyPI.
+
+## Recovery: real PyPI rejected the upload
+
+PyPI rejects re-uploads of a version that's already been published, even after a yank. If `publish-pypi` fails with `File already exists` or similar:
+
+1. Check https://pypi.org/project/congress-concord/ for the latest published version.
+2. Bump `pyproject.toml` to the next patch number.
+3. Re-do steps 4–5 from the table.
+
+Yanking hides broken releases from the dependency resolver but does not free up the version number. There is no way to "redo" a version on PyPI.
+
+## Recovery: the workflow didn't fire
+
+If you cut a GitHub Release and nothing happened, common causes:
+
+- The release was saved as a **draft**, not published. Drafts don't fire `release.published`.
+- The `pypi` or `testpypi` GitHub environment doesn't exist in repo settings, or its name doesn't match the workflow's `environment:` field.
+- The PyPI/TestPyPI pending-publisher config doesn't match the actual workflow filename (`release.yml`), repo (`johnmarcampbell/concord`), or environment name. Verify on https://pypi.org/manage/account/publishing/ and the equivalent on TestPyPI.
+
+Check the **Actions** tab:
+
+- If the workflow appears but a publish job shows **Skipped**, the `if:` gate didn't match — usually the pre-release checkbox state was wrong.
+- If the workflow doesn't appear at all, the trigger didn't fire — the release is probably still a draft.
+- If the workflow appears but fails with `OIDC token mismatch` or similar, the trusted-publisher config on PyPI doesn't match what the workflow is sending. Check the publisher's claimed `workflow_filename`, `environment`, and `repository` against the workflow file.


### PR DESCRIPTION
## Summary

Documents the recurring release workflow for `congress-concord`, including the two non-obvious footguns we hit during the first TestPyPI dry-run:

1. **pyproject.toml is the source of truth for the published version**, not the git tag. The workflow's `uv build` reads `[project].version`; the git tag is only a workflow trigger.

2. **The standard TestPyPI install recipe (`--extra-index-url https://pypi.org/simple/`) is unsafe** — `--extra-index-url` searches both indexes and picks the highest version, and TestPyPI is full of typosquats that may "outrank" the real packages. Our first dry-run picked a 2.5 KB `FASTAPI-1.0.tar.gz` stub instead of real fastapi. The doc gives the recipe that actually works: `pip download --no-deps` the wheel from TestPyPI, then `pip install` it as a local file so deps resolve from real PyPI.

ADR 0014 covers the *why* and the one-time setup; this doc is the *runbook* for the recurring loop.

## Changes

- `docs/releases.md` — new. Step-by-step table, the pyproject-vs-tag footgun, the TestPyPI smoke-test recipe, what the pre-release checkbox does, and recovery flows for two common failure modes.
- `CLAUDE.md` — "Read these before touching anything" list now points at `docs/releases.md` alongside `CONTRIBUTING.md`.
- `README.md` — the "Versioning and API stability" section ends with a maintainer-facing pointer at the new doc.

## Test plan

- [x] CI passes (only `.md` changes, no code paths touched)
- [x] Verified factual claims in the doc against `release.yml`: Docker job gated on `prerelease == false` ✓; both publish jobs use trusted publishing ✓; trigger is `release: types: [published]` (so drafts don't fire) ✓
- [x] Verified the TestPyPI project URL resolves (https://test.pypi.org/project/congress-concord/ → 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)