### PR TITLE
Bump version to 0.2.1 for first real PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "congress-concord"
-version = "0.2.1rc1"
+version = "0.2.1"
 description = "Collect, index, and search U.S. Congress data — Congressional Record, Members, Bills, Votes — via api.congress.gov."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,7 @@ wheels = [
 
 [[package]]
 name = "congress-concord"
-version = "0.2.1rc1"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

TestPyPI dry-run of `0.2.1rc1` passed — wheel built, uploaded, and installed cleanly from a fresh venv (using the recipe in [docs/releases.md](docs/releases.md)). Drops the `rc1` suffix so the next GitHub Release publishes `0.2.1` to real PyPI.

One-line change to `pyproject.toml`: `version = "0.2.1rc1"` → `version = "0.2.1"`. `uv.lock` regenerates automatically.

## After merge

- Create GitHub Release `v0.2.1`, pre-release box **unchecked**
- `publish-pypi` and `build-and-push` (Docker) jobs both fire
- Wheel lands on https://pypi.org/project/congress-concord/
- Docker image lands on `ghcr.io/johnmarcampbell/concord:0.2.1`

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run mypy src` — clean
- [x] `uv run pytest` — 550 passed
- [x] `uv build` produces `congress_concord-0.2.1-py3-none-any.whl` + `.tar.gz`
- [x] `python -c "import concord; print(concord.__version__)"` → `'0.2.1'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)