### PR TITLE
feat(web): hand-curated "Top bills" section on /bills landing

### DIFF
--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -41,6 +41,7 @@ from concord.storage.sqlite import ensure_schema
 
 from . import search as search_mod
 from .snippets import keyword_snippet, semantic_snippet
+from .top_bills import CURATED_TOP_BILLS
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     pass
@@ -407,6 +408,31 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR
             limit=BILLS_PAGE_SIZE,
             offset=offset,
         )
+        # "Top bills" highlight section: landing-page only — hide once
+        # the user has narrowed by filter or paged past the first page.
+        is_landing = (
+            page == 1
+            and chamber_filter is None
+            and not policy_area
+            and congress is None
+            and not sponsor
+        )
+        top_bills: list[dict[str, Any]] = []
+        if is_landing:
+            keys = [(c.congress, c.bill_type, c.bill_number) for c in CURATED_TOP_BILLS]
+            resolved = search_mod.get_curated_bills(db, keys)
+            for entry in CURATED_TOP_BILLS:
+                key = (entry.congress, entry.bill_type, entry.bill_number)
+                hit = resolved.get(key)
+                if hit is None:
+                    continue
+                top_bills.append(
+                    {
+                        "bill": hit,
+                        "label": entry.label,
+                        "blurb": entry.blurb,
+                    }
+                )
         context = {
             "bills": hits,
             "total": total,
@@ -418,6 +444,7 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR
             "policy_area": policy_area or "",
             "congress": congress,
             "sponsor": sponsor or "",
+            "top_bills": top_bills,
         }
         return templates.TemplateResponse(  # type: ignore[no-any-return]
             request, "bills/list.html", context

--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -38,10 +38,10 @@ from slowapi.util import get_remote_address
 
 from concord.embedding import Embedder
 from concord.storage.sqlite import ensure_schema
+from concord.web.top_bills import CURATED_TOP_BILLS
 
 from . import search as search_mod
 from .snippets import keyword_snippet, semantic_snippet
-from .top_bills import CURATED_TOP_BILLS
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     pass

--- a/src/concord/web/search.py
+++ b/src/concord/web/search.py
@@ -506,6 +506,49 @@ def list_bills(
     return [_bill_hit_from_row(r) for r in rows], int(total)
 
 
+def get_curated_bills(
+    db: sqlite3.Connection,
+    keys: list[tuple[int, str, int]],
+) -> dict[tuple[int, str, int], BillHit]:
+    """Resolve a curated list of ``(congress, bill_type, bill_number)`` keys.
+
+    Returns a mapping keyed by the input tuple so callers can preserve
+    their editorial order. Missing rows are simply absent from the map —
+    a curated entry that hasn't been scraped yet is skipped by the
+    caller rather than rendered as a broken card.
+    """
+    if not keys:
+        return {}
+    placeholders = ",".join(["(?, ?, ?)"] * len(keys))
+    params: list[Any] = []
+    for congress, bill_type, bill_number in keys:
+        params.extend((congress, bill_type.lower(), bill_number))
+    rows = db.execute(
+        f"""
+        SELECT
+            b.bill_id              AS bill_id,
+            b.congress             AS congress,
+            b.bill_type            AS bill_type,
+            b.bill_number          AS bill_number,
+            b.title                AS title,
+            b.origin_chamber       AS origin_chamber,
+            b.policy_area          AS policy_area,
+            b.latest_action_date   AS latest_action_date,
+            b.sponsor_bioguide_id  AS sponsor_bioguide_id,
+            m.display_name         AS sponsor_display_name
+        FROM bills b
+        LEFT JOIN members m ON m.bioguide_id = b.sponsor_bioguide_id
+        WHERE (b.congress, b.bill_type, b.bill_number) IN ({placeholders})
+        """,
+        params,
+    ).fetchall()
+    out: dict[tuple[int, str, int], BillHit] = {}
+    for r in rows:
+        hit = _bill_hit_from_row(r)
+        out[(hit.congress, hit.bill_type, hit.bill_number)] = hit
+    return out
+
+
 def get_bill(
     db: sqlite3.Connection,
     *,

--- a/src/concord/web/templates/bills/list.html
+++ b/src/concord/web/templates/bills/list.html
@@ -7,6 +7,35 @@
     <span class="text-sm text-stone-500">{{ total }} matching</span>
   </div>
 
+  {% if top_bills %}
+    <section class="mb-8">
+      <h2 class="text-xs uppercase tracking-wide text-stone-500 mb-3">Top bills</h2>
+      <ul class="grid gap-3 sm:grid-cols-2">
+        {% for item in top_bills %}
+          {% set b = item.bill %}
+          <li class="border border-stone-200 rounded p-3 bg-amber-50/40">
+            <div class="flex items-baseline gap-2 mb-1">
+              <span class="text-xs uppercase tracking-wide px-2 py-0.5 rounded
+                {% if b.origin_chamber == 'House' %}bg-blue-50 text-blue-800{% else %}bg-amber-50 text-amber-800{% endif %}">
+                {{ b.origin_chamber }}
+              </span>
+              <a
+                href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+                class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
+              >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
+              <span class="text-xs text-stone-400">· {{ b.congress }}th Congress</span>
+            </div>
+            <a
+              href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+              class="block font-serif text-stone-900 hover:text-stone-700"
+            >{{ item.label }}</a>
+            <p class="text-sm text-stone-600 mt-1">{{ item.blurb }}</p>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
   <form method="get" action="/bills" class="mb-6 flex flex-wrap gap-4 text-sm text-stone-600">
     <fieldset class="flex flex-wrap gap-3">
       <legend class="text-stone-500 uppercase tracking-wide text-xs mr-2">Chamber</legend>

--- a/src/concord/web/top_bills.py
+++ b/src/concord/web/top_bills.py
@@ -1,0 +1,131 @@
+"""Hand-curated list of notable Bills to highlight on ``/bills``.
+
+The entries point at real ``(congress, bill_type, bill_number)`` tuples
+that may or may not have been scraped yet — the renderer skips any that
+aren't in the local SQLite store, so the section degrades gracefully on
+a partial dataset.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class CuratedBill(NamedTuple):
+    """One curated highlight entry."""
+
+    congress: int
+    bill_type: str
+    bill_number: int
+    label: str
+    blurb: str
+
+
+#: Order is editorial — most-impactful / most-recognizable first.
+CURATED_TOP_BILLS: tuple[CuratedBill, ...] = (
+    CuratedBill(
+        congress=119,
+        bill_type="hr",
+        bill_number=1,
+        label="One Big Beautiful Bill Act",
+        blurb=(
+            "A 2025 reconciliation law making broad changes across tax, "
+            "spending, health, energy, defense, and immigration policy."
+        ),
+    ),
+    CuratedBill(
+        congress=119,
+        bill_type="s",
+        bill_number=146,
+        label="TAKE IT DOWN Act",
+        blurb=(
+            "A 2025 tech-safety law criminalizing nonconsensual intimate "
+            "imagery, including AI-generated deepfakes, and requiring "
+            "platforms to remove flagged content."
+        ),
+    ),
+    CuratedBill(
+        congress=118,
+        bill_type="hr",
+        bill_number=3746,
+        label="Fiscal Responsibility Act of 2023",
+        blurb=(
+            "Suspended the debt ceiling while setting spending caps after "
+            "the 2023 debt-limit standoff."
+        ),
+    ),
+    CuratedBill(
+        congress=118,
+        bill_type="hr",
+        bill_number=3935,
+        label="FAA Reauthorization Act of 2024",
+        blurb=(
+            "Reauthorized the Federal Aviation Administration through "
+            "fiscal year 2028 and updated aviation safety and civil "
+            "aviation programs."
+        ),
+    ),
+    CuratedBill(
+        congress=117,
+        bill_type="hr",
+        bill_number=5376,
+        label="Inflation Reduction Act",
+        blurb=(
+            "A major climate, energy, tax, and health-care law, including "
+            "clean-energy incentives and Medicare drug-pricing provisions."
+        ),
+    ),
+    CuratedBill(
+        congress=117,
+        bill_type="hr",
+        bill_number=4346,
+        label="CHIPS and Science Act",
+        blurb=(
+            "A semiconductor and science-R&D law intended to boost "
+            "domestic chip manufacturing and strengthen U.S. technological "
+            "competitiveness."
+        ),
+    ),
+    CuratedBill(
+        congress=117,
+        bill_type="hr",
+        bill_number=3684,
+        label="Infrastructure Investment and Jobs Act",
+        blurb=(
+            "A $1.2 trillion infrastructure package funding transportation, "
+            "broadband, water systems, energy, and other public works."
+        ),
+    ),
+    CuratedBill(
+        congress=117,
+        bill_type="s",
+        bill_number=3373,
+        label="PACT Act",
+        blurb=(
+            "Expanded VA health care and benefits for veterans exposed to "
+            "burn pits, Agent Orange, and other toxic substances."
+        ),
+    ),
+    CuratedBill(
+        congress=117,
+        bill_type="s",
+        bill_number=2938,
+        label="Bipartisan Safer Communities Act",
+        blurb=(
+            "A gun-safety and mental-health law that added enhanced "
+            "background checks for buyers under 21 and funded "
+            "school/community safety programs."
+        ),
+    ),
+    CuratedBill(
+        congress=117,
+        bill_type="hr",
+        bill_number=1319,
+        label="American Rescue Plan Act",
+        blurb=(
+            "A $1.9 trillion COVID-era relief law aimed at public health, "
+            "direct economic aid, schools, state/local governments, and "
+            "pandemic recovery."
+        ),
+    ),
+)

--- a/src/concord/web/top_bills.py
+++ b/src/concord/web/top_bills.py
@@ -6,8 +6,6 @@ aren't in the local SQLite store, so the section degrades gracefully on
 a partial dataset.
 """
 
-from __future__ import annotations
-
 from typing import NamedTuple
 
 

--- a/tests/test_web_bills.py
+++ b/tests/test_web_bills.py
@@ -189,6 +189,24 @@ class TestBillsIndex:
         assert "Lower Energy Costs Act" in body
         assert "Safeguard American Voter Eligibility Act" not in body
 
+    def test_top_bills_section_on_landing(self, client: TestClient) -> None:
+        # The seed includes 119-hr-1, which is in CURATED_TOP_BILLS as the
+        # "One Big Beautiful Bill Act" — the curated label/blurb come from
+        # the constant, not the DB row's title.
+        resp = client.get("/bills")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Top bills" in body
+        assert "One Big Beautiful Bill Act" in body
+        # Curated entries whose underlying bill isn't seeded are skipped
+        # rather than rendered as broken cards.
+        assert "CHIPS and Science Act" not in body
+
+    def test_top_bills_hidden_when_filtered(self, client: TestClient) -> None:
+        resp = client.get("/bills?chamber=Senate")
+        assert resp.status_code == 200
+        assert "Top bills" not in resp.text
+
 
 class TestBillProfile:
     def test_renders_known_bill(self, client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- New `src/concord/web/top_bills.py` constant holds ten editorial entries — American Rescue Plan, IIJA, CHIPS, PACT, IRA, Bipartisan Safer Communities, Fiscal Responsibility Act, FAA Reauthorization 2024, One Big Beautiful Bill Act, TAKE IT DOWN Act — as `(congress, bill_type, bill_number, label, blurb)` tuples.
- `search.get_curated_bills()` resolves the tuples to `BillHit`s in one query (sponsor join included); missing rows are simply absent so the renderer skips them.
- The `/bills` route only builds the section on the landing view (page 1, no filters) so it doesn't duplicate the main list once the user has narrowed.
- `bills/list.html` renders the section as a 2-column card grid above the filter form, each card linking to the bill's profile.

## Test plan
- [x] `uv run ruff check`, `ruff format --check`, `mypy src` — clean
- [x] `uv run pytest` — 552 passed (incl. two new cases in `tests/test_web_bills.py` covering landing-only rendering and graceful skipping when a curated bill isn't scraped)
- [ ] Smoke-check `/bills` in a browser with a real scrape to confirm cards render with correct labels/blurbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)