### PR TITLE
feat(scraper): --skip-unchanged for Bills/Members/Votes (ADR 0015)

### DIFF
--- a/docs/adr/0015-staleness-aware-rescrape.md
+++ b/docs/adr/0015-staleness-aware-rescrape.md
@@ -1,0 +1,80 @@
+# 0015 — Staleness-aware re-scrape for mutable entities
+
+**Status**: Accepted, 2026-05-27.
+
+## Context
+
+[ADR 0002](./0002-jsonl-as-canonical-raw-store.md) makes JSONL the canonical raw store and SQLite a derived projection. The contract is "every fetch appends a line"; re-running a Stage 0 scrape always issues every per-record HTTP call again. [ADR 0006](./0006-snapshot-on-fetch-for-mutable-entities.md) layers the snapshot-on-fetch envelope (`{fetched_at, key, payload}`) on top of that for mutable entities (Members, Bills, Votes). Re-running converges to a correct projection because Stage 1 picks the latest snapshot per key.
+
+The cost of that contract is paid per record. For Bills, `scrape_basic` issues one detail call per Bill (≈10K per Congress at v1 scope) and `scrape_enrichment` issues five sub-endpoint calls per Bill (per [ADR 0009](./0009-multi-endpoint-entities-split-jsonl.md)). A scrape of two Congresses that crashes 60 % through refetches every previously-snapshotted Bill on retry. House votes pay a 2× cost (detail + per-member positions). Members pay only the list-walk (single-fetch), so the per-record cost is the JSONL write itself, not an HTTP call.
+
+The api.congress.gov list-endpoint stubs carry a per-record `updateDate` (and Bill stubs additionally carry `updateDateIncludingText`). Walking that stub is free — pagination has to happen regardless. Comparing the stub's `updateDate` against the latest `fetched_at` already in JSONL lets the scraper skip the per-record detail/enrichment fetch when the server hasn't moved since we last looked. Senate votes are different: senate.gov LIS menu XML (`vote_menu_{c}_{s}.xml`) carries no per-roll modify-date, so the comparison degrades to presence-only.
+
+## Decision
+
+Add an **opt-in** `--skip-unchanged` flag to `concord scrape bills`, `concord scrape members`, and `concord scrape votes`. With the flag set, the scraper skips the per-record detail/enrichment fetch when the upstream `updateDate` has not advanced past the latest `fetched_at` already in JSONL for that key. With the flag absent, behavior is identical to today.
+
+Per-entity staleness signal:
+
+| Entity | Signal field | Freshness map source | Skip rule |
+|---|---|---|---|
+| Bills basic (`bills.jsonl`) | `max(updateDate, updateDateIncludingText)` on stub | `bills.jsonl` keyed `(congress, bill_type, bill_number)` | skip detail fetch if signal ≤ last `fetched_at` |
+| Bills enrichment (`bill_<section>.jsonl` × 5) | `max(updateDate, updateDateIncludingText)` from `bills.jsonl` payload | one map per section file, same key | skip that section's fetch if signal ≤ last `fetched_at` in that section's map |
+| Members (`members.jsonl`) | `updateDate` on payload | `members.jsonl` keyed `(bioguide_id, congress)` | skip JSONL write if signal ≤ last `fetched_at` |
+| House votes detail (`house_votes.jsonl`) | `updateDate` on stub | `house_votes.jsonl` keyed `(chamber, congress, session, roll_number)` | skip detail fetch if signal ≤ last `fetched_at` |
+| House votes positions (`house_vote_positions.jsonl`) | `updateDate` on stub | `house_vote_positions.jsonl`, same key | independent decision — skip positions fetch if signal ≤ last `fetched_at` in positions map |
+| Senate votes (`senate_votes.jsonl`) | *none — menu XML carries no per-roll timestamp* | `senate_votes.jsonl`, same key (presence only) | skip detail fetch if any snapshot exists for the key |
+| Senate roster (`senate_roster.jsonl`) | *not gated* | n/a | always fetched (one call per scrape) |
+
+Comparison rules:
+
+- Both sides parse via `datetime.fromisoformat()` (Python 3.12+ accepts `Z` and offsets). Date-only strings are coerced to midnight UTC. Naive `fetched_at` values are coerced to UTC. Equality counts as "skip."
+- If either side fails to parse, treat the record as stale and fetch. The failure mode is one extra HTTP call, never a missed update.
+- A missing freshness entry (no prior snapshot for the key) always falls through to "fetch."
+
+The mechanism is implemented in `src/concord/scraper/_common.py` (`load_freshness_map`, `parse_signal_timestamp`, `is_stub_unchanged`, `load_bill_signal_map`). Per [ADR 0007](./0007-parallel-pipelines-per-entity.md) this is a thin utility, not a base class — each entity scraper consults it directly.
+
+## Consequences
+
+**Trade-offs accepted:**
+
+- **The "every fetch appends a line" contract weakens under `--skip-unchanged`.** ADR 0002's strict idempotency assumes every re-run issues every HTTP call. The flag opts out per record. Default behavior is unchanged; the weaker guarantee applies only when the flag is set, and is documented here so a reader can find it.
+- **Senate errata corrections are silently missed under the flag.** ADR 0006 notes Senate rolls are "mostly immutable once closed, but errata corrections do appear." Presence-only skipping cannot detect a re-issued vote XML for a roll we've already snapshotted. Workaround: re-run without the flag periodically.
+- **The signal lives on the list-endpoint stub, not on the detail payload.** We trust api.congress.gov to advance `updateDate` whenever any part of the detail or sub-resource changed. If they don't, we'll skip records that have in fact moved. No mitigation; the alternative (fetch the detail to compare) defeats the entire purpose of the flag.
+- **One extra full pass through each JSONL file at scrape entry.** `load_freshness_map` reads the file line-by-line once per invocation. At v1 scale (≤50K lines per file) this is well under a second. Acceptable.
+
+**Things this buys:**
+
+- **Resume-after-crash becomes free.** A two-Congress scrape that died after Congress 117 finished and Congress 118 reached 6,000/10,000 bills now retries Congress 118 with 6,000 skips and 4,000 fetches instead of paying full HTTP cost on all 10,000.
+- **"Daily incremental" is just `--skip-unchanged`.** No new orchestration, no cursor file. The list-walk is the cursor; the JSONL is the state.
+- **Per-section refresh is honoured.** A Bill whose `/actions` we re-pulled this morning but whose `/cosponsors` is stale only re-fetches `/cosponsors`. Falls out of ADR 0009's per-section JSONL split — which explicitly named this as a buy.
+- **Detail and positions for House votes refresh independently.** A previous run that wrote `house_votes.jsonl` but failed `house_vote_positions.jsonl` (which is already best-effort per the existing scraper) retries only positions on the next run. The flag does not strand the roll permanently.
+
+**What stays open:**
+
+- **Compaction interacts cleanly.** ADR 0006 leaves compaction as future work. A compacted JSONL still surfaces the latest snapshot per key, so `load_freshness_map` works unchanged.
+- **No `--force <key>` escape hatch.** If usage shows Senate errata corrections (or any other "refetch this one record despite the flag") matters in practice, add it later. Today's workaround is "run without the flag."
+- **No wall-clock `--refresh-after 72h` knob.** See "Rejected" below.
+
+## Rejected: wall-clock refresh window
+
+An earlier design floated a `--refresh-after 72h` flag — fetch any record whose latest snapshot is older than 72 hours, regardless of `updateDate`. Rejected because:
+
+1. **`updateDate` is the sharper signal.** It says "the upstream record actually changed." Wall-clock age says "it might have changed and we haven't checked." For Bills (where `updateDate` is reliable), age is strictly worse — it forces refetches of records the server tells us are still current.
+2. **Two flags would need precedence rules.** "Skip unchanged" and "refresh after N hours" can both fire on the same record. Documenting which wins is doable but adds API surface for a knob we don't actually need yet.
+3. **The age fallback is already covered by "don't pass `--skip-unchanged`."** A nightly cron that wants to brute-force a refresh runs without the flag; an incremental cron wants the sharpest signal available. No middle ground worth shipping.
+
+Revisit if a real workflow appears that needs "refresh records we haven't touched in N days even though `updateDate` says they're current."
+
+## Rejected: uniform bill-level enrichment freshness
+
+The simplest enrichment shape was "one freshness check per Bill — if the latest snapshot in any of the five `bill_<section>.jsonl` files is at or after `updateDate`, skip all five sub-endpoint fetches." Rejected because:
+
+1. **It throws away the per-section granularity ADR 0009 explicitly bought.** If `/cosponsors` succeeded yesterday and `/actions` failed yesterday, a bill-level check would mark the Bill "fresh" and skip the `/actions` retry permanently (or until `updateDate` advances). The whole point of split JSONL is that each sub-endpoint refreshes independently.
+2. **It pessimises the common case.** Most enrichment failures we've seen are single-section (rate limit, transient 5xx). Per-section freshness retries exactly the section that failed; bill-level freshness either retries all five (wasteful when four are fine) or none (silently strands the failing section).
+
+Per-section freshness maps cost one extra `load_freshness_map` call per section at scrape entry — five total, all O(N) on small files. The marginal cost is negligible; the upside is correctness.
+
+## Rejected: comparing against payload-level timestamps after a detail fetch
+
+Another option was "fetch the detail, then compare the detail's `updateDate` to the snapshot's `fetched_at`, and skip the JSONL write if equal." Rejected because the HTTP cost is the cost we're trying to avoid — by the time we have the detail in hand, the work is done. Reading `updateDate` off the *stub* is the only place a skip saves anything.

--- a/src/concord/cli/bills.py
+++ b/src/concord/cli/bills.py
@@ -12,6 +12,7 @@ from concord.api import ENV_API_KEY, ApiError, Client
 from concord.pipeline.index_bills import index as index_bills
 from concord.pipeline.load_bills import load as load_bills
 from concord.scraper import bills as bills_scraper
+from concord.scraper._common import load_bill_signal_map
 from concord.scraper.bills import BILL_ENRICHMENT_SECTIONS, BILLS_JSONL_NAME
 
 from ._apps import index_app, load_app, run_app, scrape_app
@@ -137,6 +138,7 @@ def _run_scrape_bills(
     storage_dir: Path,
     limit: int | None,
     show_progress: bool,
+    skip_unchanged: bool = False,
 ) -> int:
     try:
         api_client = Client()
@@ -169,14 +171,16 @@ def _run_scrape_bills(
                 bill_types=bill_types,
                 limit=limit,
                 progress=_on_progress if show_progress else None,
+                skip_unchanged=skip_unchanged,
             )
     finally:
         progress.commit()
 
+    suffix = f" ({stats.bills_skipped} skipped)" if stats.bills_skipped else ""
     typer.echo(
         f"Wrote {stats.bills_written} bill snapshot(s) to "
         f"{storage_dir / BILLS_JSONL_NAME} "
-        f"across {len(congresses)} congress(es) x {len(bill_types)} bill type(s)."
+        f"across {len(congresses)} congress(es) x {len(bill_types)} bill type(s){suffix}."
     )
     return stats.bills_written
 
@@ -188,6 +192,7 @@ def _run_scrape_bills_enrich(
     storage_dir: Path,
     limit: int | None,
     show_progress: bool,
+    skip_unchanged: bool = False,
 ) -> int:
     try:
         api_client = Client()
@@ -205,6 +210,8 @@ def _run_scrape_bills_enrich(
         suffix = f"   ({section_failures} section error(s))" if section_failures else ""
         progress.update("  " + tracker.tick(event.bills_done) + suffix)
 
+    bill_signal_map = load_bill_signal_map(storage_dir / BILLS_JSONL_NAME) if skip_unchanged else {}
+
     try:
         with api_client:
             stats = bills_scraper.scrape_enrichment(
@@ -216,6 +223,8 @@ def _run_scrape_bills_enrich(
                 limit=limit,
                 bills_total=len(bill_keys),
                 progress=_on_progress if show_progress else None,
+                skip_unchanged=skip_unchanged,
+                bill_signal_lookup=bill_signal_map.get if skip_unchanged else None,
             )
     finally:
         progress.commit()
@@ -224,6 +233,7 @@ def _run_scrape_bills_enrich(
         f"Enriched {stats.bills_enriched} bill(s); "
         f"wrote {stats.snapshots_written} snapshot(s) to {storage_dir}"
         + (f" ({stats.section_failures} section failure(s))" if stats.section_failures else "")
+        + (f" ({stats.sections_skipped} section skip(s))" if stats.sections_skipped else "")
         + "."
     )
     return stats.snapshots_written
@@ -321,6 +331,16 @@ def scrape_bills_command(
             help="Print a stderr line per (congress, bill_type) pair.",
         ),
     ] = True,
+    skip_unchanged: Annotated[
+        bool,
+        typer.Option(
+            "--skip-unchanged",
+            help=(
+                "Skip records whose upstream updateDate has not advanced "
+                "since the last snapshot. See ADR 0015."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Snapshot Bill identity records into ``<storage-dir>/bills.jsonl``.
 
@@ -342,6 +362,7 @@ def scrape_bills_command(
         storage_dir=storage_dir,
         limit=limit,
         show_progress=show_progress,
+        skip_unchanged=skip_unchanged,
     )
 
 
@@ -397,6 +418,16 @@ def scrape_bills_enrich_command(
             help="Print a stderr line per bill enriched.",
         ),
     ] = True,
+    skip_unchanged: Annotated[
+        bool,
+        typer.Option(
+            "--skip-unchanged",
+            help=(
+                "Skip per-section fetches whose upstream updateDate has not "
+                "advanced since the last snapshot. See ADR 0015."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Fetch tier-2 sub-endpoints for selected Bills.
 
@@ -429,6 +460,7 @@ def scrape_bills_enrich_command(
         storage_dir=storage_dir,
         limit=limit,
         show_progress=show_progress,
+        skip_unchanged=skip_unchanged,
     )
 
 

--- a/src/concord/cli/members.py
+++ b/src/concord/cli/members.py
@@ -32,6 +32,7 @@ def _run_scrape_members(
     congresses: list[int],
     storage_path: Path,
     show_progress: bool,
+    skip_unchanged: bool = False,
 ) -> int:
     try:
         api_client = Client()
@@ -56,21 +57,23 @@ def _run_scrape_members(
 
     try:
         with api_client:
-            written = members_scraper.scrape(
+            stats = members_scraper.scrape(
                 client=api_client,
                 congresses=congresses,
                 storage_path=storage_path,
                 fetched_at=datetime.now(UTC),
                 progress=_on_progress if show_progress else None,
+                skip_unchanged=skip_unchanged,
             )
     finally:
         progress.commit()
 
+    suffix = f" ({stats.members_skipped} skipped)" if stats.members_skipped else ""
     typer.echo(
-        f"Wrote {written} member snapshot(s) to {storage_path} "
-        f"across {len(congresses)} congress(es)."
+        f"Wrote {stats.members_written} member snapshot(s) to {storage_path} "
+        f"across {len(congresses)} congress(es){suffix}."
     )
-    return written
+    return stats.members_written
 
 
 def _run_load_members(
@@ -135,6 +138,16 @@ def scrape_members_command(
             help="Print a stderr line per congress as the scrape proceeds.",
         ),
     ] = True,
+    skip_unchanged: Annotated[
+        bool,
+        typer.Option(
+            "--skip-unchanged",
+            help=(
+                "Skip members whose upstream updateDate has not advanced "
+                "since the last snapshot. See ADR 0015."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Snapshot every Member of the given Congresses into JSONL.
 
@@ -148,6 +161,7 @@ def scrape_members_command(
         congresses=parsed,
         storage_path=storage_path,
         show_progress=show_progress,
+        skip_unchanged=skip_unchanged,
     )
 
 

--- a/src/concord/cli/votes.py
+++ b/src/concord/cli/votes.py
@@ -71,6 +71,7 @@ def _run_scrape_votes(
     storage_dir: Path,
     limit: int | None,
     show_progress: bool,
+    skip_unchanged: bool = False,
 ) -> int:
     fetched_at = datetime.now(UTC)
     progress = Progress(enabled=show_progress)
@@ -90,6 +91,8 @@ def _run_scrape_votes(
 
     total_votes = 0
     total_positions = 0
+    total_skipped = 0
+    total_positions_skipped = 0
 
     try:
         if "house" in chambers:
@@ -107,9 +110,12 @@ def _run_scrape_votes(
                     sessions=tuple(sessions),
                     limit=limit,
                     progress=_on_progress if show_progress else None,
+                    skip_unchanged=skip_unchanged,
                 )
             total_votes += stats.votes_written
             total_positions += stats.positions_written
+            total_skipped += stats.votes_skipped
+            total_positions_skipped += stats.positions_skipped
 
         if "senate" in chambers:
             with SenateClient() as senate_client:
@@ -121,14 +127,21 @@ def _run_scrape_votes(
                     sessions=tuple(sessions),
                     limit=limit,
                     progress=_on_progress if show_progress else None,
+                    skip_unchanged=skip_unchanged,
                 )
             total_votes += stats.votes_written
+            total_skipped += stats.votes_skipped
     finally:
         progress.commit()
 
+    skip_suffix = ""
+    if total_skipped or total_positions_skipped:
+        skip_suffix = (
+            f" ({total_skipped} vote skip(s), {total_positions_skipped} positions skip(s))"
+        )
     typer.echo(
         f"Wrote {total_votes} vote detail snapshot(s) and "
-        f"{total_positions} member-positions snapshot(s) to {storage_dir}."
+        f"{total_positions} member-positions snapshot(s) to {storage_dir}{skip_suffix}."
     )
     return total_votes
 
@@ -227,6 +240,17 @@ def scrape_votes_command(
             help="Print a stderr line per (congress, session) pair.",
         ),
     ] = True,
+    skip_unchanged: Annotated[
+        bool,
+        typer.Option(
+            "--skip-unchanged",
+            help=(
+                "Skip records whose upstream updateDate has not advanced "
+                "since the last snapshot. Senate votes: skip if any "
+                "snapshot already exists for the roll. See ADR 0015."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Snapshot roll-call votes into ``<storage-dir>/{house,senate}_votes*.jsonl``."""
     parsed_congresses = _parse_congresses(congresses)
@@ -239,6 +263,7 @@ def scrape_votes_command(
         storage_dir=storage_dir,
         limit=limit,
         show_progress=show_progress,
+        skip_unchanged=skip_unchanged,
     )
 
 

--- a/src/concord/scraper/_common.py
+++ b/src/concord/scraper/_common.py
@@ -1,0 +1,177 @@
+"""Shared helpers for staleness-aware re-scrape (ADR 0015).
+
+This is a thin utility module — *not* a base class. Per
+[ADR 0007](../../../docs/adr/0007-parallel-pipelines-per-entity.md), each
+entity's scraper stays a standalone module; the helpers here only encode
+the JSONL freshness-map mechanics that every entity needs identically.
+
+The three exports are:
+
+* :func:`load_freshness_map` — read a JSONL file once and return
+  ``{key_tuple: latest fetched_at}``.
+* :func:`parse_signal_timestamp` — parse the per-record ``updateDate``
+  found on api.congress.gov list stubs (or detail payloads).
+* :func:`is_stub_unchanged` — the per-record skip decision.
+* :func:`load_bill_signal_map` — Bills-specific helper that reads
+  ``bills.jsonl`` and returns ``{key: max(updateDate, updateDateIncludingText)}``
+  off each line's ``payload``; used to gate enrichment fetches.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_log = logging.getLogger("concord.scraper._common")
+
+
+def _coerce_utc(dt: datetime) -> datetime:
+    """Ensure ``dt`` is timezone-aware; assume UTC if naive."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
+def parse_signal_timestamp(raw: str | None) -> datetime | None:
+    """Parse a ``updateDate``-style string into a timezone-aware datetime.
+
+    Accepts both date-only (``"2026-04-01"``) and full ISO-8601 forms
+    (``"2026-04-10T08:00:00Z"``, ``"2025-09-09T18:53:19-04:00"``).
+    Date-only values are coerced to midnight UTC. Naive datetimes are
+    coerced to UTC. ``None`` input or parse failure returns ``None`` —
+    the caller treats that as "stale, don't skip."
+    """
+    if raw is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except (TypeError, ValueError):
+        return None
+    return _coerce_utc(parsed)
+
+
+def load_freshness_map(
+    path: Path,
+    key_fields: tuple[str, ...],
+) -> dict[tuple[Any, ...], datetime]:
+    """Return ``{tuple(envelope.key[k] for k in key_fields): latest fetched_at}``.
+
+    Reads ``path`` line-by-line, parses each ADR 0006 envelope, and
+    retains the latest ``fetched_at`` per key. Malformed lines are
+    logged and skipped — the failure mode for a corrupt JSONL line is
+    "treat the record as stale," never crash. Missing file returns ``{}``.
+
+    The returned datetimes are always timezone-aware (UTC if the line
+    stored a naive value).
+    """
+    if not path.exists():
+        return {}
+
+    out: dict[tuple[Any, ...], datetime] = {}
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                envelope = json.loads(line)
+                key = tuple(envelope["key"][k] for k in key_fields)
+                fetched_at = datetime.fromisoformat(envelope["fetched_at"])
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+                _log.warning(
+                    "freshness map: skipping malformed line %d of %s: %s",
+                    lineno,
+                    path,
+                    exc,
+                )
+                continue
+            fetched_at = _coerce_utc(fetched_at)
+            prior = out.get(key)
+            if prior is None or fetched_at > prior:
+                out[key] = fetched_at
+    return out
+
+
+def is_stub_unchanged(
+    *,
+    freshness: dict[tuple[Any, ...], datetime],
+    key: tuple[Any, ...],
+    signal: datetime | None,
+) -> bool:
+    """Return True iff we already have a snapshot at or after ``signal``.
+
+    Skip rule: ``key`` must be present in ``freshness`` *and* ``signal``
+    must be a parsed datetime *and* ``signal <= freshness[key]``. Any
+    other condition returns False — i.e. fail-safe, fetch the record.
+    Equality counts as "skip" because the upstream advertised change
+    landed at or before our last snapshot.
+    """
+    if signal is None:
+        return False
+    prior = freshness.get(key)
+    if prior is None:
+        return False
+    return signal <= prior
+
+
+def load_bill_signal_map(
+    bills_jsonl_path: Path,
+) -> dict[tuple[int, str, int], datetime]:
+    """Return ``{(congress, bill_type, bill_number): max(updateDate, updateDateIncludingText)}``.
+
+    Drives the enrichment-fetch decision: the signal lives on the
+    *bill* (from ``bills.jsonl``'s payload), but is compared against
+    per-section ``bill_<section>.jsonl`` freshness maps. ``None`` payload
+    fields are ignored; only the parseable values participate in the
+    ``max``. A bill with no parseable signal at all is omitted from the
+    returned map (the caller falls through to "fetch").
+    """
+    if not bills_jsonl_path.exists():
+        return {}
+
+    out: dict[tuple[int, str, int], datetime] = {}
+    with bills_jsonl_path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                envelope = json.loads(line)
+                key_obj = envelope["key"]
+                key = (
+                    int(key_obj["congress"]),
+                    str(key_obj["bill_type"]),
+                    int(key_obj["bill_number"]),
+                )
+                payload = envelope.get("payload") or {}
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+                _log.warning(
+                    "bill signal map: skipping malformed line %d of %s: %s",
+                    lineno,
+                    bills_jsonl_path,
+                    exc,
+                )
+                continue
+            candidates = (
+                parse_signal_timestamp(payload.get("updateDate")),
+                parse_signal_timestamp(payload.get("updateDateIncludingText")),
+            )
+            parsed = [c for c in candidates if c is not None]
+            if not parsed:
+                continue
+            signal = max(parsed)
+            prior = out.get(key)
+            if prior is None or signal > prior:
+                out[key] = signal
+    return out
+
+
+__all__ = [
+    "is_stub_unchanged",
+    "load_bill_signal_map",
+    "load_freshness_map",
+    "parse_signal_timestamp",
+]

--- a/src/concord/scraper/_common.py
+++ b/src/concord/scraper/_common.py
@@ -17,8 +17,6 @@ The three exports are:
   off each line's ``payload``; used to gate enrichment fetches.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 from datetime import UTC, datetime

--- a/src/concord/scraper/bills.py
+++ b/src/concord/scraper/bills.py
@@ -23,6 +23,11 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 from concord.api import Client
+from concord.scraper._common import (
+    is_stub_unchanged,
+    load_freshness_map,
+    parse_signal_timestamp,
+)
 
 _log = logging.getLogger("concord.scraper.bills")
 
@@ -86,6 +91,94 @@ class ScrapeStats(NamedTuple):
 
     bills_written: int
     bills_seen: int
+    bills_skipped: int = 0
+
+
+def _bill_stub_signal(stub: dict[str, Any]) -> datetime | None:
+    """Return the max of ``updateDate`` / ``updateDateIncludingText`` on a stub."""
+    candidates = (
+        parse_signal_timestamp(stub.get("updateDate")),
+        parse_signal_timestamp(stub.get("updateDateIncludingText")),
+    )
+    parsed = [c for c in candidates if c is not None]
+    return max(parsed) if parsed else None
+
+
+class _BasicPairResult(NamedTuple):
+    seen: int
+    written: int
+    skipped: int
+    done: bool
+
+
+def _scrape_basic_pair(  # noqa: PLR0913 — per-pair worker, all kwargs are state forwarded from scrape_basic
+    *,
+    client: Client,
+    congress: int,
+    bt: str,
+    fh: Any,
+    iso: str,
+    remaining: float,
+    skip_unchanged: bool,
+    freshness: dict[tuple[Any, ...], datetime],
+    progress: Callable[[ScrapeProgressEvent], None] | None,
+) -> _BasicPairResult:
+    """Walk one ``(congress, bill_type)`` slot; write detail envelopes."""
+    pair_seen = 0
+    pair_written = 0
+    pair_skipped = 0
+    pair_total: list[int | None] = [None]
+    done = False
+    for stub in client.list_bills(congress, bt, on_total=lambda t: pair_total.__setitem__(0, t)):
+        pair_seen += 1
+        bill_number = _parse_bill_number(stub)
+        if bill_number is None:
+            continue
+        if skip_unchanged and is_stub_unchanged(
+            freshness=freshness,
+            key=(congress, bt, bill_number),
+            signal=_bill_stub_signal(stub),
+        ):
+            pair_skipped += 1
+            continue
+        detail = client.get_bill_detail(congress, bt, bill_number)
+        envelope = {
+            "fetched_at": iso,
+            "key": {
+                "congress": congress,
+                "bill_type": bt,
+                "bill_number": bill_number,
+            },
+            "payload": detail,
+        }
+        fh.write(json.dumps(envelope, ensure_ascii=False))
+        fh.write("\n")
+        pair_written += 1
+        if progress is not None:
+            progress(
+                ScrapeProgressEvent(
+                    congress=congress,
+                    bill_type=bt,
+                    bills_seen=pair_seen,
+                    bills_written=pair_written,
+                    category_total=pair_total[0],
+                )
+            )
+        if pair_written >= remaining:
+            done = True
+            break
+    if progress is not None:
+        progress(
+            ScrapeProgressEvent(
+                congress=congress,
+                bill_type=bt,
+                bills_seen=pair_seen,
+                bills_written=pair_written,
+                is_pair_done=True,
+                category_total=pair_total[0],
+            )
+        )
+    return _BasicPairResult(seen=pair_seen, written=pair_written, skipped=pair_skipped, done=done)
 
 
 def scrape_basic(
@@ -97,6 +190,7 @@ def scrape_basic(
     bill_types: Iterable[str] | None = None,
     limit: int | None = None,
     progress: Callable[[ScrapeProgressEvent], None] | None = None,
+    skip_unchanged: bool = False,
 ) -> ScrapeStats:
     """Append one detail snapshot per Bill to ``<storage_dir>/bills.jsonl``.
 
@@ -109,6 +203,11 @@ def scrape_basic(
     * If ``limit`` is set, stop once ``limit`` detail envelopes have been
       written across all pairs.
 
+    When ``skip_unchanged`` is set, stubs whose ``updateDate`` /
+    ``updateDateIncludingText`` is not newer than the latest snapshot in
+    ``bills.jsonl`` are skipped (no detail fetch, no JSONL write). See
+    ADR 0015.
+
     The output file is opened in append mode; the storage directory is
     created if missing.
     """
@@ -117,14 +216,18 @@ def scrape_basic(
     iso = fetched_at.isoformat()
 
     types = tuple(bill_types) if bill_types is not None else DEFAULT_BILL_TYPES
-    # Pre-compute a write cap that avoids a boolean compound check inside the
-    # inner loop (keeps scrape_basic within the mccabe complexity budget).
     _limit: float = float("inf") if limit is None else limit
+
+    freshness = (
+        load_freshness_map(out_path, ("congress", "bill_type", "bill_number"))
+        if skip_unchanged
+        else {}
+    )
 
     written = 0
     seen = 0
+    skipped = 0
     done = False
-    pair_total: list[int | None] = [None]  # mutable cell; reset per pair
     with out_path.open("a", encoding="utf-8") as fh:
         for congress in congresses:
             if done:
@@ -132,58 +235,25 @@ def scrape_basic(
             for bill_type in types:
                 if done:
                     break
-                bt = bill_type.lower()
-                pair_seen = 0
-                pair_written = 0
-                pair_total[0] = None
-                for stub in client.list_bills(
-                    congress, bt, on_total=lambda t: pair_total.__setitem__(0, t)
-                ):
-                    pair_seen += 1
-                    seen += 1
-                    bill_number = _parse_bill_number(stub)
-                    if bill_number is None:
-                        continue
-                    detail = client.get_bill_detail(congress, bt, bill_number)
-                    envelope = {
-                        "fetched_at": iso,
-                        "key": {
-                            "congress": congress,
-                            "bill_type": bt,
-                            "bill_number": bill_number,
-                        },
-                        "payload": detail,
-                    }
-                    fh.write(json.dumps(envelope, ensure_ascii=False))
-                    fh.write("\n")
-                    pair_written += 1
-                    written += 1
-                    if progress is not None:
-                        progress(
-                            ScrapeProgressEvent(
-                                congress=congress,
-                                bill_type=bt,
-                                bills_seen=pair_seen,
-                                bills_written=pair_written,
-                                category_total=pair_total[0],
-                            )
-                        )
-                    if written >= _limit:
-                        done = True
-                        break
-                if progress is not None:
-                    progress(
-                        ScrapeProgressEvent(
-                            congress=congress,
-                            bill_type=bt,
-                            bills_seen=pair_seen,
-                            bills_written=pair_written,
-                            is_pair_done=True,
-                            category_total=pair_total[0],
-                        )
-                    )
+                remaining = _limit - written
+                pair = _scrape_basic_pair(
+                    client=client,
+                    congress=congress,
+                    bt=bill_type.lower(),
+                    fh=fh,
+                    iso=iso,
+                    remaining=remaining,
+                    skip_unchanged=skip_unchanged,
+                    freshness=freshness,
+                    progress=progress,
+                )
+                seen += pair.seen
+                written += pair.written
+                skipped += pair.skipped
+                if pair.done:
+                    done = True
 
-    return ScrapeStats(bills_written=written, bills_seen=seen)
+    return ScrapeStats(bills_written=written, bills_seen=seen, bills_skipped=skipped)
 
 
 class EnrichProgressEvent(NamedTuple):
@@ -208,6 +278,7 @@ class EnrichStats(NamedTuple):
     bills_enriched: int
     snapshots_written: int
     section_failures: int
+    sections_skipped: int = 0
 
 
 _ENRICHMENT_FETCHERS: dict[str, str] = {
@@ -219,7 +290,73 @@ _ENRICHMENT_FETCHERS: dict[str, str] = {
 }
 
 
-def scrape_enrichment(
+class _BillEnrichResult(NamedTuple):
+    written: int
+    failures: int
+    skipped: int
+    partial: tuple[str, ...]
+
+
+def _enrich_one_bill(
+    *,
+    client: Client,
+    bill_key: tuple[int, str, int],
+    requested_sections: tuple[str, ...],
+    handles: dict[str, Any],
+    iso: str,
+    skip_unchanged: bool,
+    section_freshness: dict[str, dict[tuple[Any, ...], datetime]],
+    signal: datetime | None,
+) -> _BillEnrichResult:
+    """Fetch enrichment sections for one bill; write per-section envelopes."""
+    congress, bill_type, bill_number = bill_key
+    bt = bill_type.lower()
+    normalized_key = (congress, bt, bill_number)
+    written = 0
+    failures = 0
+    skipped = 0
+    partial: list[str] = []
+    for section in requested_sections:
+        if skip_unchanged and is_stub_unchanged(
+            freshness=section_freshness[section],
+            key=normalized_key,
+            signal=signal,
+        ):
+            skipped += 1
+            continue
+        method = getattr(client, _ENRICHMENT_FETCHERS[section])
+        try:
+            payload = method(congress, bt, bill_number)
+        except Exception as exc:
+            _log.warning(
+                "enrichment fetch failed for %s/%s/%s/%s: %s",
+                congress,
+                bt,
+                bill_number,
+                section,
+                exc,
+            )
+            partial.append(section)
+            failures += 1
+            continue
+        envelope = {
+            "fetched_at": iso,
+            "key": {
+                "congress": congress,
+                "bill_type": bt,
+                "bill_number": bill_number,
+            },
+            "payload": payload,
+        }
+        handles[section].write(json.dumps(envelope, ensure_ascii=False))
+        handles[section].write("\n")
+        written += 1
+    return _BillEnrichResult(
+        written=written, failures=failures, skipped=skipped, partial=tuple(partial)
+    )
+
+
+def scrape_enrichment(  # noqa: PLR0913 — one kwarg per knob; collapsing into an options object hides the call sites
     *,
     client: Client,
     bill_keys: Iterable[tuple[int, str, int]],
@@ -229,6 +366,8 @@ def scrape_enrichment(
     limit: int | None = None,
     bills_total: int | None = None,
     progress: Callable[[EnrichProgressEvent], None] | None = None,
+    skip_unchanged: bool = False,
+    bill_signal_lookup: Callable[[tuple[int, str, int]], datetime | None] | None = None,
 ) -> EnrichStats:
     """Append one ADR 0006 envelope per (bill, section) to ``data/bill_<section>.jsonl``.
 
@@ -253,6 +392,17 @@ def scrape_enrichment(
             )
 
     iso = fetched_at.isoformat()
+    # Per-section freshness maps gate which sub-endpoint fetches we
+    # skip when ``skip_unchanged`` is set (ADR 0015). Each section can
+    # refresh independently — see ADR 0009.
+    section_freshness: dict[str, dict[tuple[Any, ...], datetime]] = {}
+    if skip_unchanged:
+        for section in requested_sections:
+            section_freshness[section] = load_freshness_map(
+                storage_dir / enrichment_jsonl_name(section),
+                ("congress", "bill_type", "bill_number"),
+            )
+
     # Open every requested section's file once; the per-bill loop writes
     # to whichever it just fetched.
     handles: dict[str, Any] = {}
@@ -265,47 +415,36 @@ def scrape_enrichment(
         bills_enriched = 0
         snapshots_written = 0
         section_failures = 0
+        sections_skipped = 0
         for bill_key in bill_keys:
             congress, bill_type, bill_number = bill_key
             bt = bill_type.lower()
-            sections_written = 0
-            partial: list[str] = []
-            for section in requested_sections:
-                method = getattr(client, _ENRICHMENT_FETCHERS[section])
-                try:
-                    payload = method(congress, bt, bill_number)
-                except Exception as exc:
-                    _log.warning(
-                        "enrichment fetch failed for %s/%s/%s/%s: %s",
-                        congress,
-                        bt,
-                        bill_number,
-                        section,
-                        exc,
-                    )
-                    partial.append(section)
-                    section_failures += 1
-                    continue
-                envelope = {
-                    "fetched_at": iso,
-                    "key": {
-                        "congress": congress,
-                        "bill_type": bt,
-                        "bill_number": bill_number,
-                    },
-                    "payload": payload,
-                }
-                handles[section].write(json.dumps(envelope, ensure_ascii=False))
-                handles[section].write("\n")
-                snapshots_written += 1
-                sections_written += 1
+            normalized_key = (congress, bt, bill_number)
+            signal = (
+                bill_signal_lookup(normalized_key)
+                if skip_unchanged and bill_signal_lookup is not None
+                else None
+            )
+            result = _enrich_one_bill(
+                client=client,
+                bill_key=bill_key,
+                requested_sections=requested_sections,
+                handles=handles,
+                iso=iso,
+                skip_unchanged=skip_unchanged,
+                section_freshness=section_freshness,
+                signal=signal,
+            )
+            snapshots_written += result.written
+            section_failures += result.failures
+            sections_skipped += result.skipped
             bills_enriched += 1
             if progress is not None:
                 progress(
                     EnrichProgressEvent(
                         bill_key=(congress, bt, bill_number),
-                        sections_written=sections_written,
-                        partial_failures=tuple(partial),
+                        sections_written=result.written,
+                        partial_failures=result.partial,
                         bills_done=bills_enriched,
                         bills_total=bills_total,
                     )
@@ -320,6 +459,7 @@ def scrape_enrichment(
         bills_enriched=bills_enriched,
         snapshots_written=snapshots_written,
         section_failures=section_failures,
+        sections_skipped=sections_skipped,
     )
 
 

--- a/src/concord/scraper/members.py
+++ b/src/concord/scraper/members.py
@@ -17,6 +17,11 @@ from pathlib import Path
 from typing import NamedTuple
 
 from concord.api import Client
+from concord.scraper._common import (
+    is_stub_unchanged,
+    load_freshness_map,
+    parse_signal_timestamp,
+)
 
 
 class ScrapeProgressEvent(NamedTuple):
@@ -30,6 +35,13 @@ class ScrapeProgressEvent(NamedTuple):
     category_total: int | None = None
 
 
+class ScrapeStats(NamedTuple):
+    """Outcome of one :func:`scrape` invocation."""
+
+    members_written: int
+    members_skipped: int = 0
+
+
 def scrape(
     *,
     client: Client,
@@ -37,16 +49,28 @@ def scrape(
     storage_path: Path,
     fetched_at: datetime,
     progress: Callable[[ScrapeProgressEvent], None] | None = None,
-) -> int:
+    skip_unchanged: bool = False,
+) -> ScrapeStats:
     """Append one snapshot envelope per Member to ``storage_path``.
 
-    Returns the total number of snapshots written. The output file is
-    opened in append mode (created if missing); the parent directory is
-    created if needed.
+    Returns ``ScrapeStats`` (``members_written``, ``members_skipped``).
+    The output file is opened in append mode (created if missing); the
+    parent directory is created if needed.
+
+    When ``skip_unchanged`` is set, members whose ``updateDate`` is not
+    newer than the latest snapshot's ``fetched_at`` for the same
+    ``(bioguide_id, congress)`` key are skipped (no JSONL write). Note
+    that Members are single-fetch — the list endpoint returns the full
+    payload — so the saving here is the JSONL write + downstream parse
+    cost, not an HTTP call. See ADR 0015.
     """
     storage_path.parent.mkdir(parents=True, exist_ok=True)
-    total = 0
     iso = fetched_at.isoformat()
+    freshness = (
+        load_freshness_map(storage_path, ("bioguide_id", "congress")) if skip_unchanged else {}
+    )
+    total_written = 0
+    total_skipped = 0
     with storage_path.open("a", encoding="utf-8") as fh:
         for congress in congresses:
             written_in_congress = 0
@@ -62,6 +86,13 @@ def scrape(
                     # Defensive: a Member without a bioguide_id can't be
                     # keyed; skip rather than write an un-loadable line.
                     continue
+                if skip_unchanged and is_stub_unchanged(
+                    freshness=freshness,
+                    key=(bioguide_id, congress),
+                    signal=parse_signal_timestamp(payload.get("updateDate")),
+                ):
+                    total_skipped += 1
+                    continue
                 envelope = {
                     "fetched_at": iso,
                     # Composite key: the same Member appears in the listing
@@ -76,13 +107,13 @@ def scrape(
                 fh.write(json.dumps(envelope, ensure_ascii=False))
                 fh.write("\n")
                 written_in_congress += 1
-                total += 1
+                total_written += 1
                 if progress is not None:
                     progress(
                         ScrapeProgressEvent(
                             congress=congress,
                             written_in_congress=written_in_congress,
-                            total_written=total,
+                            total_written=total_written,
                             category_total=congress_total,
                         )
                     )
@@ -91,12 +122,12 @@ def scrape(
                     ScrapeProgressEvent(
                         congress=congress,
                         written_in_congress=written_in_congress,
-                        total_written=total,
+                        total_written=total_written,
                         is_congress_done=True,
                         category_total=congress_total,
                     )
                 )
-    return total
+    return ScrapeStats(members_written=total_written, members_skipped=total_skipped)
 
 
-__all__ = ["ScrapeProgressEvent", "scrape"]
+__all__ = ["ScrapeProgressEvent", "ScrapeStats", "scrape"]

--- a/src/concord/scraper/votes.py
+++ b/src/concord/scraper/votes.py
@@ -25,6 +25,11 @@ from pathlib import Path
 from typing import IO, Any, NamedTuple
 
 from concord.api import Client
+from concord.scraper._common import (
+    is_stub_unchanged,
+    load_freshness_map,
+    parse_signal_timestamp,
+)
 from concord.senate_xml import DETAIL_REQUEST_SLEEP_SECONDS, SenateClient
 
 _log = logging.getLogger("concord.scraper.votes")
@@ -56,11 +61,13 @@ class ScrapeProgressEvent(NamedTuple):
 
 
 class ScrapeStats(NamedTuple):
-    """Outcome of one :func:`scrape_house` invocation."""
+    """Outcome of one :func:`scrape_house` or :func:`scrape_senate` invocation."""
 
     votes_written: int
     positions_written: int
     votes_seen: int
+    votes_skipped: int = 0
+    positions_skipped: int = 0
 
 
 class _PairResult(NamedTuple):
@@ -69,6 +76,8 @@ class _PairResult(NamedTuple):
     positions_written: int
     done: bool
     pair_total: int | None = None
+    skipped: int = 0
+    positions_skipped: int = 0
 
 
 def scrape_house(
@@ -80,6 +89,7 @@ def scrape_house(
     sessions: Iterable[int] = (1, 2),
     limit: int | None = None,
     progress: Callable[[ScrapeProgressEvent], None] | None = None,
+    skip_unchanged: bool = False,
 ) -> ScrapeStats:
     """Append one detail + one members snapshot per House vote.
 
@@ -99,9 +109,18 @@ def scrape_house(
     iso = fetched_at.isoformat()
     sessions_tuple = tuple(sessions)
 
+    # Detail and positions refresh independently under ``skip_unchanged``
+    # (ADR 0015) — so a positions-only failure on the previous run
+    # doesn't strand the roll when detail is fresh.
+    key_fields = ("chamber", "congress", "session", "roll_number")
+    detail_freshness = load_freshness_map(detail_path, key_fields) if skip_unchanged else {}
+    positions_freshness = load_freshness_map(members_path, key_fields) if skip_unchanged else {}
+
     total_written = 0
     total_positions = 0
     total_seen = 0
+    total_skipped = 0
+    total_positions_skipped = 0
     done = False
     with (
         detail_path.open("a", encoding="utf-8") as detail_fh,
@@ -122,10 +141,15 @@ def scrape_house(
                     members_fh=members_fh,
                     iso=iso,
                     remaining=remaining,
+                    skip_unchanged=skip_unchanged,
+                    detail_freshness=detail_freshness,
+                    positions_freshness=positions_freshness,
                 )
                 total_seen += pair.seen
                 total_written += pair.written
                 total_positions += pair.positions_written
+                total_skipped += pair.skipped
+                total_positions_skipped += pair.positions_skipped
                 if pair.done:
                     done = True
                 if progress is not None:
@@ -145,10 +169,12 @@ def scrape_house(
         votes_written=total_written,
         positions_written=total_positions,
         votes_seen=total_seen,
+        votes_skipped=total_skipped,
+        positions_skipped=total_positions_skipped,
     )
 
 
-def _scrape_pair(
+def _scrape_pair(  # noqa: PLR0913 — pair worker forwards state from scrape_house
     *,
     client: Client,
     congress: int,
@@ -158,11 +184,18 @@ def _scrape_pair(
     iso: str,
     remaining: int | None,
     per_vote_progress: Callable[[ScrapeProgressEvent], None] | None = None,
+    skip_unchanged: bool = False,
+    detail_freshness: dict[tuple[Any, ...], datetime] | None = None,
+    positions_freshness: dict[tuple[Any, ...], datetime] | None = None,
 ) -> _PairResult:
     """Walk one ``(congress, session)`` slot; write detail + members envelopes."""
+    detail_freshness = detail_freshness or {}
+    positions_freshness = positions_freshness or {}
     seen = 0
     written = 0
+    skipped = 0
     positions_written = 0
+    positions_skipped = 0
     done = False
     pair_total: int | None = None
 
@@ -175,17 +208,37 @@ def _scrape_pair(
         roll_number = _parse_roll_number(stub)
         if roll_number is None:
             continue
-        detail = client.get_house_vote_detail(congress, session, roll_number)
+        roll_key: tuple[Any, ...] = ("house", congress, session, roll_number)
+        signal = parse_signal_timestamp(stub.get("updateDate")) if skip_unchanged else None
+        skip_detail = skip_unchanged and is_stub_unchanged(
+            freshness=detail_freshness, key=roll_key, signal=signal
+        )
+        skip_positions = skip_unchanged and is_stub_unchanged(
+            freshness=positions_freshness, key=roll_key, signal=signal
+        )
+        if skip_detail and skip_positions:
+            skipped += 1
+            positions_skipped += 1
+            continue
         key = {
             "chamber": "house",
             "congress": congress,
             "session": session,
             "roll_number": roll_number,
         }
-        _append_envelope(detail_fh, iso=iso, key=key, payload=detail)
-        if _fetch_and_write_members(client, congress, session, roll_number, members_fh, iso, key):
-            positions_written += 1
-        written += 1
+        if not skip_detail:
+            detail = client.get_house_vote_detail(congress, session, roll_number)
+            _append_envelope(detail_fh, iso=iso, key=key, payload=detail)
+            written += 1
+        else:
+            skipped += 1
+        if not skip_positions:
+            if _fetch_and_write_members(
+                client, congress, session, roll_number, members_fh, iso, key
+            ):
+                positions_written += 1
+        else:
+            positions_skipped += 1
         if per_vote_progress is not None:
             per_vote_progress(
                 ScrapeProgressEvent(
@@ -206,6 +259,8 @@ def _scrape_pair(
         positions_written=positions_written,
         done=done,
         pair_total=pair_total,
+        skipped=skipped,
+        positions_skipped=positions_skipped,
     )
 
 
@@ -259,7 +314,7 @@ def _fetch_and_write_members(
     return True
 
 
-def scrape_senate(
+def scrape_senate(  # noqa: PLR0913 — kwargs match scrape_house surface
     *,
     client_xml: SenateClient,
     congresses: Iterable[int],
@@ -269,6 +324,7 @@ def scrape_senate(
     limit: int | None = None,
     progress: Callable[[ScrapeProgressEvent], None] | None = None,
     sleep: Callable[[float], None] = time.sleep,
+    skip_unchanged: bool = False,
 ) -> ScrapeStats:
     """Append snapshot envelopes for every Senate roll-call vote.
 
@@ -300,8 +356,22 @@ def scrape_senate(
             payload=roster_xml,
         )
 
+    # Senate menu XML carries no per-roll modify-date (ADR 0015) — skip
+    # is presence-only. ``known_keys`` is the set of rolls already
+    # snapshotted in senate_votes.jsonl.
+    known_keys: set[tuple[Any, ...]] = (
+        set(
+            load_freshness_map(
+                detail_path, ("chamber", "congress", "session", "roll_number")
+            ).keys()
+        )
+        if skip_unchanged
+        else set()
+    )
+
     total_written = 0
     total_seen = 0
+    total_skipped = 0
     done = False
 
     with detail_path.open("a", encoding="utf-8") as detail_fh:
@@ -311,62 +381,105 @@ def scrape_senate(
             for session in sessions_tuple:
                 if done:
                     break
-                remaining = None if limit is None else max(0, limit - total_written)
-                roll_numbers = client_xml.list_roll_call_numbers(congress, session)
-                seen = len(roll_numbers)
-                senate_pair_total = len(roll_numbers)
-                total_seen += seen
-                pair_written = 0
-                for roll_number in roll_numbers:
-                    detail_bytes = client_xml.get_roll_call_xml(congress, session, roll_number)
-                    detail_xml = detail_bytes.decode("utf-8")
-                    _append_envelope(
-                        detail_fh,
-                        iso=iso,
-                        key={
-                            "chamber": "senate",
-                            "congress": congress,
-                            "session": session,
-                            "roll_number": roll_number,
-                        },
-                        payload=detail_xml,
-                    )
-                    pair_written += 1
-                    total_written += 1
-                    if progress is not None:
-                        progress(
-                            ScrapeProgressEvent(
-                                chamber="senate",
-                                congress=congress,
-                                session=session,
-                                votes_seen=seen,
-                                votes_written=pair_written,
-                                category_total=senate_pair_total,
-                            )
-                        )
-                    if remaining is not None and pair_written >= remaining:
-                        done = True
-                        break
-                    if DETAIL_REQUEST_SLEEP_SECONDS > 0:
-                        sleep(DETAIL_REQUEST_SLEEP_SECONDS)
-                if progress is not None:
-                    progress(
-                        ScrapeProgressEvent(
-                            chamber="senate",
-                            congress=congress,
-                            session=session,
-                            votes_seen=seen,
-                            votes_written=pair_written,
-                            is_pair_done=True,
-                            category_total=senate_pair_total,
-                        )
-                    )
+                pair = _scrape_senate_pair(
+                    client_xml=client_xml,
+                    congress=congress,
+                    session=session,
+                    detail_fh=detail_fh,
+                    iso=iso,
+                    remaining=None if limit is None else max(0, limit - total_written),
+                    skip_unchanged=skip_unchanged,
+                    known_keys=known_keys,
+                    sleep=sleep,
+                    progress=progress,
+                )
+                total_seen += pair.seen
+                total_written += pair.written
+                total_skipped += pair.skipped
+                if pair.done:
+                    done = True
 
     return ScrapeStats(
         votes_written=total_written,
         positions_written=0,
         votes_seen=total_seen,
+        votes_skipped=total_skipped,
     )
+
+
+class _SenatePairResult(NamedTuple):
+    seen: int
+    written: int
+    skipped: int
+    done: bool
+
+
+def _scrape_senate_pair(  # noqa: PLR0913 — pair worker forwards state from scrape_senate
+    *,
+    client_xml: SenateClient,
+    congress: int,
+    session: int,
+    detail_fh: IO[str],
+    iso: str,
+    remaining: int | None,
+    skip_unchanged: bool,
+    known_keys: set[tuple[Any, ...]],
+    sleep: Callable[[float], None],
+    progress: Callable[[ScrapeProgressEvent], None] | None,
+) -> _SenatePairResult:
+    roll_numbers = client_xml.list_roll_call_numbers(congress, session)
+    seen = len(roll_numbers)
+    senate_pair_total = len(roll_numbers)
+    pair_written = 0
+    pair_skipped = 0
+    done = False
+    for roll_number in roll_numbers:
+        if skip_unchanged and ("senate", congress, session, roll_number) in known_keys:
+            pair_skipped += 1
+            continue
+        detail_bytes = client_xml.get_roll_call_xml(congress, session, roll_number)
+        detail_xml = detail_bytes.decode("utf-8")
+        _append_envelope(
+            detail_fh,
+            iso=iso,
+            key={
+                "chamber": "senate",
+                "congress": congress,
+                "session": session,
+                "roll_number": roll_number,
+            },
+            payload=detail_xml,
+        )
+        pair_written += 1
+        if progress is not None:
+            progress(
+                ScrapeProgressEvent(
+                    chamber="senate",
+                    congress=congress,
+                    session=session,
+                    votes_seen=seen,
+                    votes_written=pair_written,
+                    category_total=senate_pair_total,
+                )
+            )
+        if remaining is not None and pair_written >= remaining:
+            done = True
+            break
+        if DETAIL_REQUEST_SLEEP_SECONDS > 0:
+            sleep(DETAIL_REQUEST_SLEEP_SECONDS)
+    if progress is not None:
+        progress(
+            ScrapeProgressEvent(
+                chamber="senate",
+                congress=congress,
+                session=session,
+                votes_seen=seen,
+                votes_written=pair_written,
+                is_pair_done=True,
+                category_total=senate_pair_total,
+            )
+        )
+    return _SenatePairResult(seen=seen, written=pair_written, skipped=pair_skipped, done=done)
 
 
 __all__ = [

--- a/tests/test_scraper_bills.py
+++ b/tests/test_scraper_bills.py
@@ -327,3 +327,277 @@ class TestScrapeEnrichment:
                 fetched_at=FIXED_FETCHED_AT,
                 sections=["nonsense"],
             )
+
+
+# ---------------------------------------------------------------------------
+# --skip-unchanged (ADR 0015)
+# ---------------------------------------------------------------------------
+
+
+def _seed_bills_jsonl(
+    path: Path,
+    *,
+    fetched_at: str,
+    keys: list[tuple[int, str, int]],
+    payload: dict[str, Any] | None = None,
+) -> None:
+    payload = payload or {}
+    with path.open("a", encoding="utf-8") as fh:
+        for congress, bt, number in keys:
+            fh.write(
+                json.dumps(
+                    {
+                        "fetched_at": fetched_at,
+                        "key": {
+                            "congress": congress,
+                            "bill_type": bt,
+                            "bill_number": number,
+                        },
+                        "payload": payload,
+                    }
+                )
+            )
+            fh.write("\n")
+
+
+def _stub_list(*stubs: dict[str, Any]) -> dict[str, Any]:
+    return {"bills": list(stubs), "pagination": {"count": len(stubs)}}
+
+
+class TestScrapeBasicSkipUnchanged:
+    def test_flag_off_unchanged_behavior(self, tmp_path: Path) -> None:
+        client = _client_serving(
+            _stub_list(
+                {"number": "1", "type": "HR", "updateDate": "2026-04-01"},
+            ),
+            {1: _fixture("detail_119_hr_1.json")},
+        )
+        with client:
+            stats = scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+            )
+        assert stats.bills_written == 1
+        assert stats.bills_skipped == 0
+
+    def test_empty_jsonl_no_skip(self, tmp_path: Path) -> None:
+        client = _client_serving(
+            _stub_list({"number": "1", "type": "HR", "updateDate": "2026-04-01"}),
+            {1: _fixture("detail_119_hr_1.json")},
+        )
+        with client:
+            stats = scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+                skip_unchanged=True,
+            )
+        assert stats.bills_written == 1
+        assert stats.bills_skipped == 0
+
+    def test_stub_older_than_snapshot_skips(self, tmp_path: Path) -> None:
+        out = tmp_path / BILLS_JSONL_NAME
+        _seed_bills_jsonl(
+            out,
+            fetched_at="2026-05-01T00:00:00Z",
+            keys=[(119, "hr", 1)],
+        )
+        client = _client_serving(
+            _stub_list({"number": "1", "type": "HR", "updateDate": "2026-01-01"}),
+            {1: _fixture("detail_119_hr_1.json")},
+        )
+        with client:
+            stats = scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+                skip_unchanged=True,
+            )
+        assert stats.bills_written == 0
+        assert stats.bills_skipped == 1
+        # Seed line preserved, no new line.
+        assert len(out.read_text().splitlines()) == 1
+
+    def test_stub_newer_than_snapshot_fetches(self, tmp_path: Path) -> None:
+        out = tmp_path / BILLS_JSONL_NAME
+        _seed_bills_jsonl(
+            out,
+            fetched_at="2026-01-01T00:00:00Z",
+            keys=[(119, "hr", 1)],
+        )
+        client = _client_serving(
+            _stub_list({"number": "1", "type": "HR", "updateDate": "2026-04-01"}),
+            {1: _fixture("detail_119_hr_1.json")},
+        )
+        with client:
+            stats = scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+                skip_unchanged=True,
+            )
+        assert stats.bills_written == 1
+        assert stats.bills_skipped == 0
+
+    def test_stub_equal_to_snapshot_skips(self, tmp_path: Path) -> None:
+        out = tmp_path / BILLS_JSONL_NAME
+        _seed_bills_jsonl(
+            out,
+            fetched_at="2026-04-01T00:00:00Z",
+            keys=[(119, "hr", 1)],
+        )
+        client = _client_serving(
+            _stub_list({"number": "1", "type": "HR", "updateDate": "2026-04-01"}),
+            {1: _fixture("detail_119_hr_1.json")},
+        )
+        with client:
+            stats = scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+                skip_unchanged=True,
+            )
+        assert stats.bills_skipped == 1
+
+    def test_date_only_stub_vs_full_iso_snapshot(self, tmp_path: Path) -> None:
+        # Stub "2026-04-01" → midnight UTC. Snapshot fetched_at = 05:00:00Z → after.
+        out = tmp_path / BILLS_JSONL_NAME
+        _seed_bills_jsonl(
+            out,
+            fetched_at="2026-04-01T05:00:00Z",
+            keys=[(119, "hr", 1)],
+        )
+        client = _client_serving(
+            _stub_list({"number": "1", "type": "HR", "updateDate": "2026-04-01"}),
+            {1: _fixture("detail_119_hr_1.json")},
+        )
+        with client:
+            stats = scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+                skip_unchanged=True,
+            )
+        assert stats.bills_skipped == 1
+
+    def test_missing_update_date_fetches(self, tmp_path: Path) -> None:
+        out = tmp_path / BILLS_JSONL_NAME
+        _seed_bills_jsonl(
+            out,
+            fetched_at="2026-05-01T00:00:00Z",
+            keys=[(119, "hr", 1)],
+        )
+        client = _client_serving(
+            _stub_list({"number": "1", "type": "HR"}),  # no updateDate
+            {1: _fixture("detail_119_hr_1.json")},
+        )
+        with client:
+            stats = scrape_basic(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                bill_types=["hr"],
+                skip_unchanged=True,
+            )
+        # Fail-safe: unparseable signal → fetch.
+        assert stats.bills_written == 1
+        assert stats.bills_skipped == 0
+
+
+class TestScrapeEnrichmentSkipUnchanged:
+    def test_per_section_freshness(self, tmp_path: Path) -> None:
+        # cosponsors was fetched fresh; the other four are missing → fetch them.
+        existing_cosponsors = tmp_path / enrichment_jsonl_name("cosponsors")
+        existing_cosponsors.write_text(
+            json.dumps(
+                {
+                    "fetched_at": "2026-05-01T00:00:00Z",
+                    "key": {"congress": 119, "bill_type": "hr", "bill_number": 1},
+                    "payload": {},
+                }
+            )
+            + "\n"
+        )
+
+        def _signal_lookup(key: tuple[int, str, int]) -> datetime | None:
+            # Bill stub updated 2026-04-01 (older than cosponsors' 2026-05-01)
+            return datetime(2026, 4, 1, tzinfo=UTC)
+
+        client = _enrichment_client()
+        with client:
+            stats = scrape_enrichment(
+                client=client,
+                bill_keys=[(119, "hr", 1)],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                skip_unchanged=True,
+                bill_signal_lookup=_signal_lookup,
+            )
+        # 4 fetched (actions, subjects, titles, summaries); 1 skipped (cosponsors).
+        assert stats.snapshots_written == 4
+        assert stats.sections_skipped == 1
+        # cosponsors file unchanged: one line.
+        assert len(existing_cosponsors.read_text().splitlines()) == 1
+
+    def test_flag_off_fetches_all(self, tmp_path: Path) -> None:
+        existing_cosponsors = tmp_path / enrichment_jsonl_name("cosponsors")
+        existing_cosponsors.write_text(
+            json.dumps(
+                {
+                    "fetched_at": "2026-05-01T00:00:00Z",
+                    "key": {"congress": 119, "bill_type": "hr", "bill_number": 1},
+                    "payload": {},
+                }
+            )
+            + "\n"
+        )
+        client = _enrichment_client()
+        with client:
+            stats = scrape_enrichment(
+                client=client,
+                bill_keys=[(119, "hr", 1)],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+            )
+        assert stats.snapshots_written == 5
+        assert stats.sections_skipped == 0
+
+    def test_no_signal_lookup_falls_through(self, tmp_path: Path) -> None:
+        # skip_unchanged set but no signal lookup → can't decide, fetch.
+        existing_cosponsors = tmp_path / enrichment_jsonl_name("cosponsors")
+        existing_cosponsors.write_text(
+            json.dumps(
+                {
+                    "fetched_at": "2026-05-01T00:00:00Z",
+                    "key": {"congress": 119, "bill_type": "hr", "bill_number": 1},
+                    "payload": {},
+                }
+            )
+            + "\n"
+        )
+        client = _enrichment_client()
+        with client:
+            stats = scrape_enrichment(
+                client=client,
+                bill_keys=[(119, "hr", 1)],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                skip_unchanged=True,
+                bill_signal_lookup=None,
+            )
+        assert stats.snapshots_written == 5
+        assert stats.sections_skipped == 0

--- a/tests/test_scraper_common.py
+++ b/tests/test_scraper_common.py
@@ -1,0 +1,194 @@
+"""Unit tests for :mod:`concord.scraper._common` (ADR 0015 helpers)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
+
+from concord.scraper._common import (
+    is_stub_unchanged,
+    load_bill_signal_map,
+    load_freshness_map,
+    parse_signal_timestamp,
+)
+
+
+def _write_envelope(path: Path, *, key: dict, fetched_at: str, payload: dict | None = None) -> None:
+    line = json.dumps({"fetched_at": fetched_at, "key": key, "payload": payload or {}})
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+class TestParseSignalTimestamp:
+    def test_date_only_coerced_to_midnight_utc(self) -> None:
+        dt = parse_signal_timestamp("2026-04-01")
+        assert dt == datetime(2026, 4, 1, tzinfo=UTC)
+
+    def test_full_iso_with_z(self) -> None:
+        dt = parse_signal_timestamp("2026-04-10T08:00:00Z")
+        assert dt == datetime(2026, 4, 10, 8, 0, 0, tzinfo=UTC)
+
+    def test_full_iso_with_offset(self) -> None:
+        dt = parse_signal_timestamp("2025-09-09T18:53:19-04:00")
+        assert dt is not None
+        assert dt.utcoffset() == timedelta(hours=-4)
+
+    def test_none_input(self) -> None:
+        assert parse_signal_timestamp(None) is None
+
+    def test_malformed_string(self) -> None:
+        assert parse_signal_timestamp("not a date") is None
+
+
+class TestLoadFreshnessMap:
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert load_freshness_map(tmp_path / "nope.jsonl", ("bioguide_id", "congress")) == {}
+
+    def test_empty_file_returns_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "members.jsonl"
+        path.touch()
+        assert load_freshness_map(path, ("bioguide_id", "congress")) == {}
+
+    def test_one_envelope_one_entry(self, tmp_path: Path) -> None:
+        path = tmp_path / "members.jsonl"
+        _write_envelope(
+            path,
+            key={"bioguide_id": "A000001", "congress": 119},
+            fetched_at="2026-04-01T00:00:00Z",
+        )
+        result = load_freshness_map(path, ("bioguide_id", "congress"))
+        assert result == {("A000001", 119): datetime(2026, 4, 1, tzinfo=UTC)}
+
+    def test_duplicate_keys_keeps_max(self, tmp_path: Path) -> None:
+        path = tmp_path / "members.jsonl"
+        _write_envelope(
+            path,
+            key={"bioguide_id": "A000001", "congress": 119},
+            fetched_at="2026-04-01T00:00:00Z",
+        )
+        _write_envelope(
+            path,
+            key={"bioguide_id": "A000001", "congress": 119},
+            fetched_at="2026-05-15T00:00:00Z",
+        )
+        result = load_freshness_map(path, ("bioguide_id", "congress"))
+        assert result[("A000001", 119)] == datetime(2026, 5, 15, tzinfo=UTC)
+
+    def test_malformed_line_skipped(self, tmp_path: Path) -> None:
+        path = tmp_path / "members.jsonl"
+        _write_envelope(
+            path,
+            key={"bioguide_id": "A000001", "congress": 119},
+            fetched_at="2026-04-01T00:00:00Z",
+        )
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write("this is not json\n")
+        _write_envelope(
+            path,
+            key={"bioguide_id": "B000002", "congress": 119},
+            fetched_at="2026-05-01T00:00:00Z",
+        )
+        result = load_freshness_map(path, ("bioguide_id", "congress"))
+        assert set(result.keys()) == {("A000001", 119), ("B000002", 119)}
+
+    def test_naive_fetched_at_coerced_to_utc(self, tmp_path: Path) -> None:
+        path = tmp_path / "members.jsonl"
+        _write_envelope(
+            path,
+            key={"bioguide_id": "A000001", "congress": 119},
+            fetched_at="2026-04-01T00:00:00",
+        )
+        result = load_freshness_map(path, ("bioguide_id", "congress"))
+        dt = result[("A000001", 119)]
+        assert dt.tzinfo is not None
+        assert dt == datetime(2026, 4, 1, tzinfo=UTC)
+
+
+class TestIsStubUnchanged:
+    def _fresh(self) -> dict:
+        return {("A", 119): datetime(2026, 4, 1, tzinfo=UTC)}
+
+    def test_key_absent_returns_false(self) -> None:
+        assert (
+            is_stub_unchanged(freshness={}, key=("A", 119), signal=datetime(2026, 4, 1, tzinfo=UTC))
+            is False
+        )
+
+    def test_signal_none_returns_false(self) -> None:
+        assert is_stub_unchanged(freshness=self._fresh(), key=("A", 119), signal=None) is False
+
+    def test_signal_equal_returns_true(self) -> None:
+        assert (
+            is_stub_unchanged(
+                freshness=self._fresh(), key=("A", 119), signal=datetime(2026, 4, 1, tzinfo=UTC)
+            )
+            is True
+        )
+
+    def test_signal_older_returns_true(self) -> None:
+        assert (
+            is_stub_unchanged(
+                freshness=self._fresh(), key=("A", 119), signal=datetime(2026, 1, 1, tzinfo=UTC)
+            )
+            is True
+        )
+
+    def test_signal_newer_returns_false(self) -> None:
+        assert (
+            is_stub_unchanged(
+                freshness=self._fresh(), key=("A", 119), signal=datetime(2026, 5, 1, tzinfo=UTC)
+            )
+            is False
+        )
+
+    def test_offset_aware_signal_compares_in_utc(self) -> None:
+        # 2026-04-01T05:00 in -04:00 == 09:00 UTC == AFTER 2026-04-01T00:00 UTC
+        signal = datetime(2026, 4, 1, 5, 0, 0, tzinfo=timezone(timedelta(hours=-4)))
+        assert is_stub_unchanged(freshness=self._fresh(), key=("A", 119), signal=signal) is False
+
+
+class TestLoadBillSignalMap:
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert load_bill_signal_map(tmp_path / "bills.jsonl") == {}
+
+    def test_picks_max_of_update_dates(self, tmp_path: Path) -> None:
+        path = tmp_path / "bills.jsonl"
+        _write_envelope(
+            path,
+            key={"congress": 119, "bill_type": "hr", "bill_number": 1},
+            fetched_at="2026-04-01T00:00:00Z",
+            payload={
+                "updateDate": "2026-04-01",
+                "updateDateIncludingText": "2026-04-10T08:00:00Z",
+            },
+        )
+        result = load_bill_signal_map(path)
+        assert result[(119, "hr", 1)] == datetime(2026, 4, 10, 8, 0, 0, tzinfo=UTC)
+
+    def test_unparseable_payload_skipped(self, tmp_path: Path) -> None:
+        path = tmp_path / "bills.jsonl"
+        _write_envelope(
+            path,
+            key={"congress": 119, "bill_type": "hr", "bill_number": 1},
+            fetched_at="2026-04-01T00:00:00Z",
+            payload={"updateDate": None, "updateDateIncludingText": None},
+        )
+        assert load_bill_signal_map(path) == {}
+
+    def test_keeps_max_across_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / "bills.jsonl"
+        _write_envelope(
+            path,
+            key={"congress": 119, "bill_type": "hr", "bill_number": 1},
+            fetched_at="2026-04-01T00:00:00Z",
+            payload={"updateDate": "2026-04-01"},
+        )
+        _write_envelope(
+            path,
+            key={"congress": 119, "bill_type": "hr", "bill_number": 1},
+            fetched_at="2026-05-15T00:00:00Z",
+            payload={"updateDate": "2026-05-15"},
+        )
+        result = load_bill_signal_map(path)
+        assert result[(119, "hr", 1)] == datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/test_scraper_common.py
+++ b/tests/test_scraper_common.py
@@ -1,7 +1,5 @@
 """Unit tests for :mod:`concord.scraper._common` (ADR 0015 helpers)."""
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path

--- a/tests/test_scraper_members.py
+++ b/tests/test_scraper_members.py
@@ -56,14 +56,14 @@ class TestScrape:
         client = _client_serving({119: _load_fixture("current_house.json")})
 
         with client:
-            n = scrape(
+            stats = scrape(
                 client=client,
                 congresses=[119],
                 storage_path=out,
                 fetched_at=FIXED_FETCHED_AT,
             )
 
-        assert n == 1
+        assert stats.members_written == 1
         lines = out.read_text().splitlines()
         assert len(lines) == 1
         envelope = json.loads(lines[0])
@@ -81,14 +81,14 @@ class TestScrape:
         )
 
         with client:
-            n = scrape(
+            stats = scrape(
                 client=client,
                 congresses=[117, 119],
                 storage_path=out,
                 fetched_at=FIXED_FETCHED_AT,
             )
 
-        assert n == 2
+        assert stats.members_written == 2
         envelopes = [json.loads(line) for line in out.read_text().splitlines()]
         keys = [e["key"]["bioguide_id"] for e in envelopes]
         assert keys == ["J000301", "S000033"]
@@ -146,14 +146,14 @@ class TestScrape:
         client = _client_serving({117: fixture, 118: fixture, 119: fixture})
 
         with client:
-            n = scrape(
+            stats = scrape(
                 client=client,
                 congresses=[117, 118, 119],
                 storage_path=out,
                 fetched_at=FIXED_FETCHED_AT,
             )
 
-        assert n == 3
+        assert stats.members_written == 3
         envelopes = [json.loads(line) for line in out.read_text().splitlines()]
         # Same bioguide_id, distinct congress, distinct envelopes.
         assert [e["key"]["bioguide_id"] for e in envelopes] == ["S000033"] * 3
@@ -172,3 +172,130 @@ class TestScrape:
             )
 
         assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# --skip-unchanged (ADR 0015)
+# ---------------------------------------------------------------------------
+
+
+def _seed_member_snapshot(path: Path, *, bioguide: str, congress: int, fetched_at: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "fetched_at": fetched_at,
+                    "key": {"bioguide_id": bioguide, "congress": congress},
+                    "payload": {},
+                }
+            )
+        )
+        fh.write("\n")
+
+
+def _members_payload(*, bioguide: str, update_date: str | None) -> dict[str, Any]:
+    member = {
+        "bioguideId": bioguide,
+        "name": "Test, Person",
+        "directOrderName": "Person Test",
+        "invertedOrderName": "Test, Person",
+        "partyName": "Democratic",
+        "state": "NY",
+        "terms": {"item": [{"chamber": "House of Representatives", "startYear": 2019}]},
+    }
+    if update_date is not None:
+        member["updateDate"] = update_date
+    return {"members": [member], "pagination": {"count": 1}}
+
+
+class TestScrapeSkipUnchanged:
+    def test_flag_off_writes_all(self, tmp_path: Path) -> None:
+        out = tmp_path / "members.jsonl"
+        _seed_member_snapshot(
+            out, bioguide="O000172", congress=119, fetched_at="2026-05-01T00:00:00Z"
+        )
+        client = _client_serving(
+            {119: _members_payload(bioguide="O000172", update_date="2026-01-15T00:00:00Z")}
+        )
+        with client:
+            stats = scrape(
+                client=client,
+                congresses=[119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+            )
+        assert stats.members_written == 1
+        assert stats.members_skipped == 0
+
+    def test_empty_jsonl_no_skip(self, tmp_path: Path) -> None:
+        out = tmp_path / "members.jsonl"
+        client = _client_serving(
+            {119: _members_payload(bioguide="O000172", update_date="2026-01-15T00:00:00Z")}
+        )
+        with client:
+            stats = scrape(
+                client=client,
+                congresses=[119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+                skip_unchanged=True,
+            )
+        assert stats.members_written == 1
+        assert stats.members_skipped == 0
+
+    def test_signal_older_skips(self, tmp_path: Path) -> None:
+        out = tmp_path / "members.jsonl"
+        _seed_member_snapshot(
+            out, bioguide="O000172", congress=119, fetched_at="2026-05-01T00:00:00Z"
+        )
+        client = _client_serving(
+            {119: _members_payload(bioguide="O000172", update_date="2026-01-15T00:00:00Z")}
+        )
+        with client:
+            stats = scrape(
+                client=client,
+                congresses=[119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+                skip_unchanged=True,
+            )
+        assert stats.members_written == 0
+        assert stats.members_skipped == 1
+        assert len(out.read_text().splitlines()) == 1  # only seed line
+
+    def test_signal_newer_fetches(self, tmp_path: Path) -> None:
+        out = tmp_path / "members.jsonl"
+        _seed_member_snapshot(
+            out, bioguide="O000172", congress=119, fetched_at="2026-01-01T00:00:00Z"
+        )
+        client = _client_serving(
+            {119: _members_payload(bioguide="O000172", update_date="2026-04-01T00:00:00Z")}
+        )
+        with client:
+            stats = scrape(
+                client=client,
+                congresses=[119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+                skip_unchanged=True,
+            )
+        assert stats.members_written == 1
+        assert stats.members_skipped == 0
+
+    def test_missing_update_date_fetches(self, tmp_path: Path) -> None:
+        out = tmp_path / "members.jsonl"
+        _seed_member_snapshot(
+            out, bioguide="O000172", congress=119, fetched_at="2026-05-01T00:00:00Z"
+        )
+        client = _client_serving({119: _members_payload(bioguide="O000172", update_date=None)})
+        with client:
+            stats = scrape(
+                client=client,
+                congresses=[119],
+                storage_path=out,
+                fetched_at=FIXED_FETCHED_AT,
+                skip_unchanged=True,
+            )
+        assert stats.members_written == 1  # fail-safe
+        assert stats.members_skipped == 0

--- a/tests/test_scraper_votes.py
+++ b/tests/test_scraper_votes.py
@@ -391,3 +391,248 @@ class TestScrapeSenate:
         assert len(detail_lines) == 1
         # File ends in newline — no half-written partial line.
         assert (tmp_path / SENATE_VOTES_JSONL_NAME).read_text().endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# --skip-unchanged (ADR 0015)
+# ---------------------------------------------------------------------------
+
+
+def _seed_envelope(path: Path, *, key: dict[str, Any], fetched_at: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"fetched_at": fetched_at, "key": key, "payload": {}}))
+        fh.write("\n")
+
+
+def _house_list_payload(stubs: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"houseRollCallVotes": stubs, "pagination": {"count": len(stubs)}}
+
+
+class TestScrapeHouseSkipUnchanged:
+    def test_flag_off_baseline(self, tmp_path: Path) -> None:
+        client = _client(
+            _house_list_payload(
+                [
+                    {
+                        "congress": 119,
+                        "sessionNumber": 1,
+                        "rollCallNumber": 240,
+                        "updateDate": "2026-04-01",
+                    }
+                ]
+            ),
+            {240: _fixture("detail_house_119_1_240.json")},
+            {240: _fixture("members_house_119_1_240.json")},
+        )
+        with client:
+            stats = scrape_house(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                sessions=(1,),
+            )
+        assert stats.votes_written == 1
+        assert stats.votes_skipped == 0
+        assert stats.positions_skipped == 0
+
+    def test_both_files_fresh_skips_both(self, tmp_path: Path) -> None:
+        detail_key = {
+            "chamber": "house",
+            "congress": 119,
+            "session": 1,
+            "roll_number": 240,
+        }
+        _seed_envelope(
+            tmp_path / HOUSE_VOTES_JSONL_NAME,
+            key=detail_key,
+            fetched_at="2026-05-01T00:00:00Z",
+        )
+        _seed_envelope(
+            tmp_path / HOUSE_VOTE_POSITIONS_JSONL_NAME,
+            key=detail_key,
+            fetched_at="2026-05-01T00:00:00Z",
+        )
+        client = _client(
+            _house_list_payload(
+                [
+                    {
+                        "congress": 119,
+                        "sessionNumber": 1,
+                        "rollCallNumber": 240,
+                        "updateDate": "2026-04-01",
+                    }
+                ]
+            ),
+            {240: _fixture("detail_house_119_1_240.json")},
+            {240: _fixture("members_house_119_1_240.json")},
+        )
+        with client:
+            stats = scrape_house(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                sessions=(1,),
+                skip_unchanged=True,
+            )
+        assert stats.votes_written == 0
+        assert stats.positions_written == 0
+        assert stats.votes_skipped == 1
+        assert stats.positions_skipped == 1
+
+    def test_detail_fresh_positions_missing_fetches_positions_only(self, tmp_path: Path) -> None:
+        detail_key = {
+            "chamber": "house",
+            "congress": 119,
+            "session": 1,
+            "roll_number": 240,
+        }
+        _seed_envelope(
+            tmp_path / HOUSE_VOTES_JSONL_NAME,
+            key=detail_key,
+            fetched_at="2026-05-01T00:00:00Z",
+        )
+        # positions file does not exist.
+        client = _client(
+            _house_list_payload(
+                [
+                    {
+                        "congress": 119,
+                        "sessionNumber": 1,
+                        "rollCallNumber": 240,
+                        "updateDate": "2026-04-01",
+                    }
+                ]
+            ),
+            {240: _fixture("detail_house_119_1_240.json")},
+            {240: _fixture("members_house_119_1_240.json")},
+        )
+        with client:
+            stats = scrape_house(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                sessions=(1,),
+                skip_unchanged=True,
+            )
+        # Detail skipped, positions written.
+        assert stats.votes_written == 0
+        assert stats.votes_skipped == 1
+        assert stats.positions_written == 1
+        assert stats.positions_skipped == 0
+
+    def test_stub_newer_fetches(self, tmp_path: Path) -> None:
+        detail_key = {
+            "chamber": "house",
+            "congress": 119,
+            "session": 1,
+            "roll_number": 240,
+        }
+        _seed_envelope(
+            tmp_path / HOUSE_VOTES_JSONL_NAME,
+            key=detail_key,
+            fetched_at="2026-01-01T00:00:00Z",
+        )
+        _seed_envelope(
+            tmp_path / HOUSE_VOTE_POSITIONS_JSONL_NAME,
+            key=detail_key,
+            fetched_at="2026-01-01T00:00:00Z",
+        )
+        client = _client(
+            _house_list_payload(
+                [
+                    {
+                        "congress": 119,
+                        "sessionNumber": 1,
+                        "rollCallNumber": 240,
+                        "updateDate": "2026-04-01",
+                    }
+                ]
+            ),
+            {240: _fixture("detail_house_119_1_240.json")},
+            {240: _fixture("members_house_119_1_240.json")},
+        )
+        with client:
+            stats = scrape_house(
+                client=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                sessions=(1,),
+                skip_unchanged=True,
+            )
+        assert stats.votes_written == 1
+        assert stats.positions_written == 1
+
+
+class TestScrapeSenateSkipUnchanged:
+    def test_presence_only_skip(self, tmp_path: Path) -> None:
+        # Pre-seed roll 7 — only roll 3 should fetch.
+        _seed_envelope(
+            tmp_path / SENATE_VOTES_JSONL_NAME,
+            key={
+                "chamber": "senate",
+                "congress": 119,
+                "session": 1,
+                "roll_number": 7,
+            },
+            fetched_at="2026-01-01T00:00:00Z",
+        )
+        roster_xml = (SENATE_FIXTURES / "senators_cfm.xml").read_bytes()
+        detail_xml = (SENATE_FIXTURES / "detail_119_1_00007_bill.xml").read_bytes()
+        another_xml = (SENATE_FIXTURES / "detail_119_1_00003_amendment.xml").read_bytes()
+        client = _senate_client(
+            roster_xml,
+            {(119, 1): _menu_xml([3, 7])},
+            {(119, 1, 3): another_xml, (119, 1, 7): detail_xml},
+        )
+
+        with client:
+            stats = scrape_senate(
+                client_xml=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                sessions=(1,),
+                sleep=lambda _s: None,
+                skip_unchanged=True,
+            )
+
+        # Roll 7 skipped (presence); roll 3 fetched.
+        assert stats.votes_written == 1
+        assert stats.votes_skipped == 1
+
+    def test_flag_off_writes_all(self, tmp_path: Path) -> None:
+        _seed_envelope(
+            tmp_path / SENATE_VOTES_JSONL_NAME,
+            key={
+                "chamber": "senate",
+                "congress": 119,
+                "session": 1,
+                "roll_number": 7,
+            },
+            fetched_at="2026-01-01T00:00:00Z",
+        )
+        roster_xml = (SENATE_FIXTURES / "senators_cfm.xml").read_bytes()
+        detail_xml = (SENATE_FIXTURES / "detail_119_1_00007_bill.xml").read_bytes()
+        another_xml = (SENATE_FIXTURES / "detail_119_1_00003_amendment.xml").read_bytes()
+        client = _senate_client(
+            roster_xml,
+            {(119, 1): _menu_xml([3, 7])},
+            {(119, 1, 3): another_xml, (119, 1, 7): detail_xml},
+        )
+        with client:
+            stats = scrape_senate(
+                client_xml=client,
+                congresses=[119],
+                storage_dir=tmp_path,
+                fetched_at=FIXED_FETCHED_AT,
+                sessions=(1,),
+                sleep=lambda _s: None,
+            )
+        # Without the flag, both rolls fetched even though 7 was seeded.
+        assert stats.votes_written == 2
+        assert stats.votes_skipped == 0


### PR DESCRIPTION
## Summary

Closes [#74](https://github.com/johnmarcampbell/concord/issues/74). Implements the plan in [docs/plans/staleness-aware-rescrape.md](docs/plans/staleness-aware-rescrape.md).

- Opt-in `--skip-unchanged` flag on `concord scrape bills`, `concord scrape bills enrich`, `concord scrape members`, `concord scrape votes`. Default behavior is unchanged.
- When set: skip per-record detail/enrichment fetches whose upstream `updateDate` (or `max(updateDate, updateDateIncludingText)` for Bills) has not advanced past the latest snapshot's `fetched_at` for the same key. Senate votes fall back to **presence-only** skipping since the LIS menu XML carries no per-roll modify-date.
- New thin helper module `src/concord/scraper/_common.py` (`load_freshness_map`, `parse_signal_timestamp`, `is_stub_unchanged`, `load_bill_signal_map`) — explicitly allowed by ADR 0007.
- New ADR 0015 documents the contract change (ADR 0002's "always refetch" weakens under the flag), the per-entity signal table, chamber-asymmetric Vote handling, and rejected alternatives (wall-clock window, uniform bill-level enrichment).
- `Members.scrape` return type changes from `int` to a `ScrapeStats` NamedTuple (`members_written`, `members_skipped`); other `ScrapeStats`/`EnrichStats` gain `*_skipped` counters with defaulted zero so existing callers keep working.

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy src`
- [x] `uv run pytest` — 594 passed (21 new in `tests/test_scraper_common.py`, plus per-entity skip scenarios in the three existing scraper tests)
- [x] `concord scrape bills|members|votes --help` and `concord scrape bills enrich --help` all expose `--skip-unchanged`
- [ ] Manual end-to-end: a real-API double-run on a small `--limit` slice to confirm the second run reports skips and writes zero new lines (left for the reviewer / merge sanity check; requires `CONGRESS_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)