### PR TITLE
docs: plans for bill enrichment button and rate-limiting

### DIFF
--- a/docs/plans/bill-enrichment-button.md
+++ b/docs/plans/bill-enrichment-button.md
@@ -1,0 +1,298 @@
+# Bill enrichment button (web-initiated Stage 0 → 1 → 2)
+
+> Add a single "Request enrichment" button at the top of every Bill profile page that runs the tier-2 enrichment pipeline for that one bill — `scrape_enrichment` → `load_bills.load_one` → `index_bills.reindex_one` — in a fire-and-forget background task, with HTMX-polled status, off by default behind an env-var kill switch and an explicit chokepoint for the follow-up rate-limit plan.
+
+## Source
+
+Conversation context, 2026-05-27. The user described wanting a web affordance for what `concord scrape bills enrich --bill-ids <id>` does from the CLI today. The grilling session for this plan resolved seven design branches; see [Approach](#approach) for the resulting decisions. (No durable issue/RFC; this paraphrase is the only source. A GitHub issue will be filed pointing at this plan as the durable record.)
+
+## Context
+
+Concord's pipeline has three stages for Bills today:
+
+- **Stage 0 — Scrape.** [`src/concord/scraper/bills.py`](../../src/concord/scraper/bills.py) exposes `scrape_basic` (one-time tier-1 walk) and `scrape_enrichment` (per-bill tier-2 walk over five sub-endpoints: cosponsors / actions / subjects / titles / summaries — see [ADR 0009](../adr/0009-multi-endpoint-entities-split-jsonl.md)). Writes JSONL snapshots per [ADR 0006](../adr/0006-snapshot-on-fetch-for-mutable-entities.md).
+- **Stage 1 — Load.** [`src/concord/pipeline/load_bills.py`](../../src/concord/pipeline/load_bills.py) projects all six JSONL files into the `bills` row + five child tables, stamping the per-section `*_fetched_at` columns.
+- **Stage 2 — Index.** [`src/concord/pipeline/index_bills.py`](../../src/concord/pipeline/index_bills.py) rebuilds the `bills_fts` FTS5 virtual table; aggregates the bill's first short title and its subjects so `/search` matches on them.
+
+The Bill profile page ([`src/concord/web/templates/bills/profile.html`](../../src/concord/web/templates/bills/profile.html)) already renders five tier-2 sections (cosponsors, action history, subjects, titles, summaries). Each section has a dashed-box "not yet fetched — run `concord scrape bills enrich --bill-ids {bill_id}`" placeholder when its `*_fetched_at` column is NULL. This plan replaces that CLI-invocation hint with an in-page action button (when enabled) that runs the same pipeline from the web process.
+
+The web layer today is a **pure reader** of the derived SQLite store. It does not import `concord.api.Client`, does not read `CONGRESS_API_KEY`, and has no background-task scaffolding. Letting it kick off enrichment makes it (directly) a writer to the JSONL canonical store — a meaningful framing shift relative to [ADR 0007](../adr/0007-parallel-pipelines-per-entity.md). That shift is captured in **ADR 0016** (new, drafted as a step of this plan).
+
+[Phase 2b explicitly deferred this work](./phase-2b-bills-enrichment.md#out-of-scope) because no background-task framework existed in the codebase. This plan resolves the deferral by leaning on `fastapi.BackgroundTasks` rather than a real task queue — see [Approach](#approach) for the reasoning.
+
+Domain terms used here are defined in [CONTEXT.md](../../CONTEXT.md): Bill, Bill ID, Bill type, Cosponsor, Bill action, Policy area, Chamber.
+
+## Goals
+
+1. Add `POST /bills/{congress}/{bill_type}/{bill_number}/enrichment` to the FastAPI app. The handler dispatches a background task that runs `scrape_enrichment` → `load_bills.load_one` → `index_bills.reindex_one` for the one bill and returns an HTMX in-flight fragment immediately (HTTP 200, not 202 — HTMX is happier with 200).
+2. Add `GET /bills/{congress}/{bill_type}/{bill_number}/enrichment-status` returning an HTMX fragment with one of four states: **idle** (button visible), **in-flight** (polling 3s), **done** (button hidden, triggers section-content refresh), **failed** (error banner + "Try again" button).
+3. Add a "Request enrichment" button to the top of [`src/concord/web/templates/bills/profile.html`](../../src/concord/web/templates/bills/profile.html). The button renders only when both `CONGRESS_API_KEY` and `CONCORD_ENABLE_WEB_ENRICHMENT` are set in the environment of the web process.
+4. Factor a `reindex_one(*, db_path, bill_id)` helper out of [`src/concord/pipeline/index_bills.py`](../../src/concord/pipeline/index_bills.py)'s bulk `index()` so the request flow's FTS update is O(1) per bill rather than O(N).
+5. Factor a `load_one(*, storage_dir, db_path, bill_id)` helper out of [`src/concord/pipeline/load_bills.py`](../../src/concord/pipeline/load_bills.py)'s bulk `load()` so the request flow's projection is O(1) per bill rather than O(N).
+6. Add an in-process `set[str]` of in-flight `bill_id`s plus an `asyncio.Lock` on `app.state` for cross-request de-dup.
+7. Add a `bills.last_enrichment_error TEXT NULL` column to the SQLite schema. Cleared at the start of every enrichment attempt; written on any failure path.
+8. Draft **ADR 0016 — Web layer may invoke Stage 0 enrichment on demand** at [`docs/adr/0016-web-initiated-enrichment.md`](../adr/0016-web-initiated-enrichment.md). Documents the framing shift relative to ADR 0007, the choice of `BackgroundTasks` over a real queue, the in-process lock and its single-worker assumption, and that rate limiting is the subject of a follow-up.
+
+## Non-goals
+
+1. **Rate limiting.** A separate plan and a separate ADR. This plan names the chokepoint — the `POST …/enrichment` handler — and arranges the in-flight check so it runs *after* any future `@limiter.limit(...)` decorator. No placeholder decorator, no commented-out limit string.
+2. **Bills embeddings (Phase 5).** `index_bills` is FTS-only today; embeddings for bills are deferred. The new `reindex_one` mirrors that scope.
+3. **Per-section buttons / section checkboxes.** Considered and rejected in grilling. One button, all five sections.
+4. **Real task queue (Celery / RQ / arq / Dramatiq).** Adds a Redis dependency and a worker process to what is currently a single-process FastAPI demo. Rejected; see ADR 0016.
+5. **Multi-worker uvicorn correctness.** The in-process lock is correct only for `uvicorn` with `--workers 1` (the current shape of `concord serve`). Documented as a known limitation in ADR 0016.
+6. **Auth / login / per-user quotas.** The app is anonymous. The env-var kill switch is the v1 access control. Per-user quotas are not a goal until the app has users.
+7. **Automatic retries inside the background task.** The user retries by clicking. Simpler, cooperates naturally with the future per-IP limiter.
+8. **A schema version / migration story for the new column.** [ADR 0012](../adr/0012-web-bootstraps-empty-schema-on-startup.md) flagged that "no `schema_version` check yet" is acceptable while DDL is append-only. Adding one nullable column stays inside that contract.
+
+## Relevant prior decisions
+
+- [ADR 0001 — Python end-to-end for the web layer](../adr/0001-python-end-to-end-for-the-web-layer.md). The "no separate worker process" preference is the reason this plan picks `BackgroundTasks` over a real task queue.
+- [ADR 0002 — JSONL as canonical raw store](../adr/0002-jsonl-as-canonical-raw-store.md). Append-only JSONL is what makes the "user re-clicks; up to 5 duplicate envelopes; loader dedups" failure model cheap.
+- [ADR 0006 — Snapshot-on-fetch for mutable entities](../adr/0006-snapshot-on-fetch-for-mutable-entities.md). Each enrichment fetch appends one snapshot envelope per (bill, section).
+- [ADR 0007 — Parallel pipelines per entity](../adr/0007-parallel-pipelines-per-entity.md). The relevant framing: Stage 0 is the scraper. ADR 0016 (new) records the expansion to "the web layer may also run Stage 0 enrichment on demand".
+- [ADR 0009 — Multi-endpoint entities split their JSONL canonical store by sub-endpoint](../adr/0009-multi-endpoint-entities-split-jsonl.md). Defines the five `bill_<section>.jsonl` files this plan writes to.
+- [ADR 0012 — Web layer bootstraps an empty schema on startup](../adr/0012-web-bootstraps-empty-schema-on-startup.md). Schema-of-record lives in `storage/sqlite.py`. The new `bills.last_enrichment_error` column goes there.
+- [`docs/plans/phase-2b-bills-enrichment.md`](./phase-2b-bills-enrichment.md). The plan that built the enrichment scraper, loader, and the section placeholders this plan now wires a button into; explicitly deferred web-initiated enrichment.
+- **ADR 0016 — Web layer may invoke Stage 0 enrichment on demand** (new, created with this plan). See [Step 9](#step-by-step-plan).
+- [`docs/plans/enrichment-rate-limiting.md`](./enrichment-rate-limiting.md). Sibling plan that adds the `@limiter.limit(...)` decorator on the POST handler this plan creates, and **introduces `src/concord/config.py` with a pydantic-settings `Settings` class** that this plan's Step 5 consumes. The two plans must land together (or this plan's Step 5 depends on the rate-limit plan's Steps 1–4 landing first).
+
+## Relevant files and code
+
+- [`src/concord/scraper/bills.py:222`](../../src/concord/scraper/bills.py) — `scrape_enrichment(client, bill_keys, storage_dir, *, fetched_at, sections=None, limit=None, progress=None)`. Per-section try/except (lines 273–288) already absorbs individual failures; the function returns even if 0–5 sections succeeded. No changes needed in this file.
+- [`src/concord/pipeline/load_bills.py:62`](../../src/concord/pipeline/load_bills.py) — `load(*, storage_dir, db_path, limit=None)`. Full-table projection. This plan factors `load_one(...)` out of the existing per-bill loop body (see [`_ingest_tier1`](../../src/concord/pipeline/load_bills.py) and the tier-2 loop at line 106).
+- [`src/concord/pipeline/index_bills.py:31`](../../src/concord/pipeline/index_bills.py) — `index(*, db_path, limit=None)`. Full-table FTS rebuild. This plan factors `reindex_one(...)` out of the per-row body (lines 41–72).
+- [`src/concord/api.py:114`](../../src/concord/api.py) — `Client(api_key=None)`. Reads `CONGRESS_API_KEY` if `api_key` not passed; raises `ApiError` if absent.
+- [`src/concord/web/app.py:98`](../../src/concord/web/app.py) — `create_app(db_path, *, embedder=None)`. The boot-time env-var sniff and the `enrichment_in_flight` / `enrichment_lock` `app.state` attributes go in here.
+- [`src/concord/web/app.py:152`](../../src/concord/web/app.py) — `_register_routes(app, limiter)`. The two new routes are conditionally registered here (only when enrichment is enabled).
+- [`src/concord/web/app.py:426`](../../src/concord/web/app.py) — `bills_profile` route. The context dict it builds will gain `enrichment_enabled` and `enrichment_state` keys.
+- [`src/concord/web/templates/bills/profile.html`](../../src/concord/web/templates/bills/profile.html) — adds the button-or-status fragment block at the top of the `md:col-span-3` content column, above the "Latest action" section.
+- [`src/concord/web/templates/bills/`](../../src/concord/web/templates/bills/) — new partials: `_enrichment_button.html`, `_enrichment_in_flight.html`, `_enrichment_done.html`, `_enrichment_failed.html`. (One file per state keeps each tiny and HTMX-swappable in isolation.)
+- [`src/concord/storage/sqlite.py:205`](../../src/concord/storage/sqlite.py) — the `bills` table DDL. The new `last_enrichment_error TEXT NULL` column goes alongside the existing `cosponsors_fetched_at` line.
+- [`tests/test_pipeline_bills.py`](../../tests/test_pipeline_bills.py) — existing per-bill loader / indexer tests; new `load_one` / `reindex_one` cases go in the same file.
+- [`tests/test_web_bills.py`](../../tests/test_web_bills.py) — existing FastAPI route tests for the bills section; new tests for the three new routes (POST + status GET in three states) and the env-var gating go in the same file.
+
+## Approach
+
+### Top-of-page button, not per-section
+
+The five existing "not yet fetched — run …" placeholders stay as the fallback for the non-enrichment-enabled deployment. When enrichment is enabled, a single button-or-status fragment appears above the "Latest action" section and applies to all five tier-2 sections at once. Per-section buttons were considered and rejected — `scrape_enrichment` defaults to all five sections, the existing CLI command does all five together, and the cost asymmetry (summaries dominate) is something an operator can mitigate via the CLI; it isn't worth five buttons in the UI.
+
+### Fire-and-forget via `BackgroundTasks`, not a real queue
+
+The work is 5 sub-endpoint calls + one set of UPSERTs + one single-row FTS update — typically a few seconds, occasionally tens of seconds for a heavily-cosponsored bill with paginated actions. Long enough that blocking the HTTP request is the wrong shape (proxy timeouts; bad demo feel); short enough that a real task queue with Redis is overkill for a single-process FastAPI demo. `fastapi.BackgroundTasks` is the middle road: zero new dependencies, runs in-process, and `asyncio.to_thread` keeps the synchronous scraper / loader / indexer off the event loop.
+
+Crash-mid-job semantics: the in-process in-flight set evaporates on restart; the user re-clicks; `scrape_enrichment` re-runs all five sections; the JSONL gains up to 5 duplicate envelopes, all swallowed by the loader's natural-key dedup (existing behavior per [ADR 0002](../adr/0002-jsonl-as-canonical-raw-store.md)). End state is correct.
+
+### In-process lock, single-worker assumption
+
+`app.state.enrichment_in_flight: set[str]` and `app.state.enrichment_lock: asyncio.Lock`. The handler acquires the lock, checks membership, adds, releases. The background task removes from the set in a `finally:` block. Multi-worker uvicorn would need a SQLite-backed `enrichment_jobs` table; that's a future change, gated on a real deployment shape we don't have yet. ADR 0016 names the revisit trigger.
+
+### Status state machine and HTMX poll
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle: any *_fetched_at IS NULL and not in-flight and no error
+    Idle --> InFlight: POST /enrichment
+    InFlight --> InFlight: GET /enrichment-status (still in set)
+    InFlight --> Done: GET /enrichment-status (not in set, all fetched_at populated)
+    InFlight --> Failed: GET /enrichment-status (not in set, last_enrichment_error IS NOT NULL)
+    Failed --> InFlight: POST /enrichment (retry)
+    Done --> [*]: page reload renders Idle if all sections populated (no button)
+```
+
+The button POST returns the in-flight fragment with `hx-get=".../enrichment-status" hx-trigger="every 3s" hx-swap="outerHTML"`. The status GET returns the same in-flight fragment while the bill is in the set; otherwise it returns the done or failed fragment. The done fragment carries `hx-trigger="load"` on hidden `hx-get` directives that swap the five section bodies with fresh content; the failed fragment carries a "Try again" button that POSTs to `/enrichment`.
+
+"Done" state is the conjunction `bill_id not in in_flight AND all(*_fetched_at IS NOT NULL)`. "Failed" is `bill_id not in in_flight AND last_enrichment_error IS NOT NULL`. Partial success (3 of 5 sections fetched) reports as "Done" — the per-section UI already shows "not yet fetched" for the NULL columns, so a re-click naturally retries the still-NULL ones.
+
+### Pipeline calls scoped to one bill
+
+`load_bills.load(...)` and `index_bills.index(...)` are both O(N) over all bills today. Calling them on every button click would scale poorly as bills count grows past ~100K. New helpers:
+
+- `load_bills.load_one(*, storage_dir, db_path, bill_id)` — reads only the snapshots for `bill_id` from `bills.jsonl` and the five sibling files, UPSERTs the bill row, DELETEs+INSERTs the five child tables.
+- `index_bills.reindex_one(*, db_path, bill_id)` — DELETEs the matching `bills_fts` row by `rowid` (joined to the `bills` row by `bill_id`), then re-INSERTs the one row with the same SELECT shape as the bulk path.
+
+Both factor out logic from the existing bulk functions; the bulk functions are refactored to call the per-bill helper in their inner loop. Bulk behavior is unchanged.
+
+### Env-var gating
+
+Two gates:
+
+- `CONGRESS_API_KEY` present → enrichment is *possible*. Used at boot to stash `app.state.has_congress_api_key: bool`.
+- `CONCORD_ENABLE_WEB_ENRICHMENT` present and truthy ("1" / "true" / "yes", case-insensitive) → enrichment is *offered*. Used at boot to stash `app.state.enrichment_enabled: bool`.
+
+Both must be true for the button to render and the two new routes to be registered. When disabled, the routes don't exist (404, not 403) and the existing per-section CLI-hint placeholders are unchanged. This means a public-demo deployment without the kill-switch can't be coaxed into running enrichment even by hand-crafting the POST URL.
+
+### The new ADR
+
+ADR 0016 records:
+- Web process becomes a writer to the JSONL canonical store; this is an expansion of, not a violation of, ADR 0007. The CLI scraper remains the primary writer.
+- Rationale for `BackgroundTasks` over a real queue.
+- Rationale for in-process lock; revisit trigger ("when we deploy multi-worker").
+- Rate limiting is deferred to a separate plan and a separate ADR; this ADR names the chokepoint.
+- Why the button is gated on a second env var beyond `CONGRESS_API_KEY` (defense in depth; the limiter is the other layer).
+
+## Step-by-step plan
+
+1. **Add the `bills.last_enrichment_error` column.** Edit [`src/concord/storage/sqlite.py:205`](../../src/concord/storage/sqlite.py) to add `last_enrichment_error TEXT NULL` to the `bills` CREATE TABLE statement, on the line after `summaries_fetched_at TEXT,`. The DDL is already `CREATE … IF NOT EXISTS` and append-only across releases (per ADR 0012), so existing DBs need no migration step beyond running `ensure_schema` on next boot. **Verify:** `uv run pytest tests/test_storage_sqlite.py -x` passes; `sqlite3 :memory: < schema.sql` round-trip in a quick Python REPL shows the new column.
+
+2. **Add storage helpers for the error column.** In `storage/sqlite.py`, add two methods to `SqliteStorage`: `set_bill_enrichment_error(bill_id: str, error: str) -> None` (one-line UPDATE) and `clear_bill_enrichment_error(bill_id: str) -> None` (UPDATE … SET last_enrichment_error = NULL). Mirror the style of the existing per-section `*_fetched_at` setters. **Verify:** add two tests to [`tests/test_storage_sqlite.py`](../../tests/test_storage_sqlite.py) round-tripping set / read / clear.
+
+3. **Factor `load_one` out of `load_bills.load`.** In [`src/concord/pipeline/load_bills.py`](../../src/concord/pipeline/load_bills.py), add `load_one(*, storage_dir, db_path, bill_id: str) -> LoadStats` that:
+   (a) parses `bill_id` into `(congress, bill_type, bill_number)` (the format is `"<c>-<t>-<n>"` per [CONTEXT.md](../../CONTEXT.md));
+   (b) streams `bills.jsonl` and keeps only the latest snapshot whose key matches; UPSERTs that one bill if found;
+   (c) for each of the five tier-2 sections, streams `bill_<section>.jsonl`, filters to envelopes with the matching key, runs the existing `_project_<section>` helper inside one transaction.
+   Refactor the bulk `load(...)` to share the per-bill projection code with `load_one(...)` (extract a private `_project_one_bill(storage, bill_id, payloads_by_section)` helper). **Verify:** `uv run pytest tests/test_pipeline_bills.py -x` still passes; new test `test_load_one_projects_only_the_named_bill` covers the filter behavior and confirms re-running `load_one` against unchanged JSONL is a no-op (idempotent).
+
+4. **Factor `reindex_one` out of `index_bills.index`.** In [`src/concord/pipeline/index_bills.py`](../../src/concord/pipeline/index_bills.py), add `reindex_one(*, db_path, bill_id: str) -> None` that runs the existing per-row SELECT + DELETE-by-rowid + INSERT against just the one `bills` row matching `bill_id`. Refactor `index(...)`'s body so the per-row work is a call to a private `_reindex_one_with_conn(conn, bill_id)` shared with the new public function. **Verify:** `uv run pytest tests/test_pipeline_bills.py -x` still passes; new test `test_reindex_one_updates_only_one_fts_row` covers the scoping.
+
+5. **Construct `Settings` and stash enrichment state on `app.state`.** This step depends on `src/concord/config.py` existing — see [enrichment-rate-limiting.md](./enrichment-rate-limiting.md) Steps 1–2. In [`src/concord/web/app.py`](../../src/concord/web/app.py), inside `create_app(...)` after `ensure_schema(db_path)` and before the `limiter = Limiter(...)` line, add:
+   ```python
+   from concord.config import Settings
+   settings = Settings()
+   enrichment_enabled = bool(settings.congress_api_key) and settings.enable_web_enrichment
+   ```
+   Stash `settings` and `enrichment_enabled` on `app.state`. Also stash `app.state.enrichment_in_flight: set[str] = set()` and `app.state.enrichment_lock = asyncio.Lock()` (these are created unconditionally — the routes that consume them are conditionally registered). **Verify:** boot the app via `uv run concord serve` with and without each env var; assert `app.state.enrichment_enabled` matches via a test that constructs the app with monkey-patched env.
+
+6. **Add the `POST /bills/.../enrichment` route, conditionally registered.** In `_register_routes(...)`, inside `if app.state.enrichment_enabled:`, register a `@app.post("/bills/{congress}/{bill_type}/{bill_number}/enrichment", response_class=HTMLResponse)` handler that:
+   (a) validates `bill_type` against `_VALID_BILL_TYPES` and returns 404 otherwise;
+   (b) constructs `bill_id = f"{congress}-{bill_type.lower()}-{bill_number}"`;
+   (c) acquires `app.state.enrichment_lock`, checks `bill_id in app.state.enrichment_in_flight`:
+       - if present → release lock, return the in-flight fragment without enqueuing;
+       - if absent → add to set, release lock, call `background_tasks.add_task(_enrich_one_bill, app, bill_id)`, return the in-flight fragment.
+   The handler is the named chokepoint for the future rate-limit plan; the in-flight check sits *inside* the handler so a 429 from a future limiter decorator returns before any state mutation. **Verify:** add `test_post_enrichment_returns_in_flight_fragment` to [`tests/test_web_bills.py`](../../tests/test_web_bills.py) hitting the route with the env vars set in the test fixture; assert the response HTML contains `hx-get` for the status URL.
+
+7. **Add the background-task body.** In `src/concord/web/app.py` (module-level helper, not inside `_register_routes`), define `def _enrich_one_bill(app: FastAPI, bill_id: str) -> None`. Body:
+   ```python
+   from concord.api import Client
+   from concord.scraper.bills import scrape_enrichment, BILL_ENRICHMENT_SECTIONS
+   from concord.pipeline import load_bills, index_bills
+   storage = SqliteStorage(app.state.db_path, load_vec=False)
+   try:
+       storage.clear_bill_enrichment_error(bill_id)
+   finally:
+       storage.close()
+   try:
+       congress_s, bill_type, bill_number_s = bill_id.split("-")
+       key = (int(congress_s), bill_type, int(bill_number_s))
+       with Client() as client:
+           scrape_enrichment(
+               client,
+               [key],
+               app.state.storage_dir,
+               fetched_at=datetime.now(UTC),
+           )
+       load_bills.load_one(storage_dir=app.state.storage_dir, db_path=app.state.db_path, bill_id=bill_id)
+       index_bills.reindex_one(db_path=app.state.db_path, bill_id=bill_id)
+   except Exception as exc:
+       storage = SqliteStorage(app.state.db_path, load_vec=False)
+       try:
+           storage.set_bill_enrichment_error(bill_id, str(exc)[:500])
+       finally:
+           storage.close()
+   finally:
+       app.state.enrichment_in_flight.discard(bill_id)
+   ```
+   The body runs synchronously inside `BackgroundTasks`; FastAPI runs sync functions registered via `add_task` in a threadpool, so the event loop is not blocked. `app.state.storage_dir` is a new attribute set in `create_app` (Step 8). **Verify:** add an integration test that monkeypatches `concord.api.Client` to a stub and `scrape_enrichment` to a no-op-ish double that touches the JSONL, kicks off one enrichment via the route, awaits a brief async wait, and asserts the SQLite row's `*_fetched_at` columns and `last_enrichment_error` are as expected.
+
+8. **Expose `storage_dir` to the web app.** `create_app(...)` currently takes `db_path` only; the background task also needs the JSONL directory. Two options: add a `storage_dir: Path | None = None` parameter (defaults to `db_path.parent / "data"` or similar — verify against the conventional layout) **or** make it a third positional. Pick the parameter form. Wire it through [`src/concord/cli/serve.py`](../../src/concord/cli/serve.py)'s `serve_command`. **Verify:** `uv run concord serve --help` still renders; existing app tests still pass.
+
+9. **Add the `GET /bills/.../enrichment-status` route, conditionally registered.** Same registration condition as Step 6. Handler reads `app.state.enrichment_in_flight`, `*_fetched_at` columns, and `last_enrichment_error` from the bills row to pick one of three fragments to return: `bills/_enrichment_in_flight.html`, `bills/_enrichment_done.html`, or `bills/_enrichment_failed.html`. Idle is not returned from this endpoint — idle is what the profile page renders directly. **Verify:** add `test_enrichment_status_in_flight`, `test_enrichment_status_done`, `test_enrichment_status_failed` to [`tests/test_web_bills.py`](../../tests/test_web_bills.py), each setting the precondition state explicitly.
+
+10. **Add the four HTMX partials.** Create:
+    - [`src/concord/web/templates/bills/_enrichment_button.html`](../../src/concord/web/templates/bills/_enrichment_button.html) — a `<button hx-post="/bills/{c}/{t}/{n}/enrichment" hx-target="#enrichment-status" hx-swap="outerHTML">Request enrichment</button>` wrapped in `<div id="enrichment-status">`.
+    - `_enrichment_in_flight.html` — a `<div id="enrichment-status" hx-get="/bills/{c}/{t}/{n}/enrichment-status" hx-trigger="every 3s" hx-swap="outerHTML">Enriching this bill…</div>` plus a small spinner / dimmed text.
+    - `_enrichment_done.html` — a `<div id="enrichment-status" hx-get="/bills/{c}/{t}/{n}" hx-trigger="load" hx-target="body" hx-swap="outerHTML">Enrichment complete. Refreshing…</div>`. (Simpler than five per-section hidden swaps: one full page swap on completion.)
+    - `_enrichment_failed.html` — a `<div id="enrichment-status">⚠ Enrichment failed: {{ error|e }} <button hx-post=".../enrichment" hx-target="#enrichment-status" hx-swap="outerHTML">Try again</button></div>`.
+
+    **Verify:** view a Bill profile page in the browser via `uv run concord serve` with both env vars set, click the button, watch the status update via 3s poll, confirm page refresh on completion. Repeat with `CONGRESS_API_KEY` deliberately set to a known-bad value to exercise the failed path.
+
+11. **Wire the button into the Bill profile page.** Edit [`src/concord/web/templates/bills/profile.html`](../../src/concord/web/templates/bills/profile.html) to include the appropriate state partial at the top of the `md:col-span-3` block, *above* the "Latest action" section (line 47):
+    ```jinja
+    {% if enrichment_enabled %}
+      {% include "bills/" + enrichment_state + ".html" %}
+    {% endif %}
+    ```
+    The `bills_profile` route (Step 12) computes `enrichment_state` ∈ {`_enrichment_button`, `_enrichment_in_flight`, `_enrichment_failed`} and passes `enrichment_enabled` through to the template. (`_enrichment_done` is only used as a poll response, never as the initial page render.) The five per-section "run …" placeholders stay as-is — they remain the fallback for deployments where `enrichment_enabled` is False, and they're harmless when the top button is present (they only render at all when `*_fetched_at IS NULL`).
+
+12. **Extend the `bills_profile` route to compute initial state.** In [`src/concord/web/app.py`](../../src/concord/web/app.py) (around line 426), compute:
+    ```python
+    enrichment_state = None
+    if request.app.state.enrichment_enabled:
+        if bill_id in request.app.state.enrichment_in_flight:
+            enrichment_state = "_enrichment_in_flight"
+        elif bill.last_enrichment_error:
+            enrichment_state = "_enrichment_failed"
+        else:
+            any_missing = any(getattr(bill, f"{s}_fetched_at") is None for s in BILL_ENRICHMENT_SECTIONS)
+            enrichment_state = "_enrichment_button" if any_missing else None
+    ```
+    Pass `enrichment_enabled`, `enrichment_state`, and (when `_enrichment_failed`) the error message into the template context. **Verify:** add a test that requests `/bills/{c}/{t}/{n}` with the env vars set and asserts the rendered HTML contains the button when all `*_fetched_at` are NULL, and does *not* contain the button when all are populated.
+
+13. **Draft ADR 0016.** Create [`docs/adr/0016-web-initiated-enrichment.md`](../adr/0016-web-initiated-enrichment.md) using the existing ADR style (compare [ADR 0012](../adr/0012-web-bootstraps-empty-schema-on-startup.md)). Status: Accepted, 2026-05-27 (or whatever the actual landing date is). Sections: Context → Decision → Consequences (trade-offs accepted / things this buys / what stays open) → Rejected: real task queue → Rejected: SQLite-backed `enrichment_jobs` table. The "what stays open" list must explicitly include rate limiting (deferred to its own plan) and multi-worker uvicorn correctness (revisit trigger). **Verify:** `uv run ruff format --check` and `uv run ruff check` pass over the new file (it's Markdown so this is mostly a no-op, but other ADR files have a trailing-newline convention worth matching).
+
+14. **Update the ADR index.** [`docs/adr/`](../adr/) doesn't currently have an index file — confirm by `ls docs/adr/`. If one exists (e.g. `README.md`), add ADR 0016 to it; if not, this step is a no-op. The recent ADR landings (0013, 0014) provide the precedent.
+
+15. **README / CLAUDE.md cross-references.** No change to [CLAUDE.md](../../CLAUDE.md): the "Commands" section lists pipeline commands, not env vars, and the env-var contract section already documents `CONGRESS_API_KEY`. Add a single line under "API keys" in CLAUDE.md mentioning `CONCORD_ENABLE_WEB_ENRICHMENT` as an opt-in toggle for the web button, gated on `CONGRESS_API_KEY` being present. **Verify:** read the rendered CLAUDE.md change in the PR diff.
+
+16. **Manual end-to-end smoke.** With a populated `proceedings.db` containing at least one tier-1-only Bill (i.e. `cosponsors_fetched_at IS NULL`):
+    ```sh
+    export CONGRESS_API_KEY=...                       # a real key, not DEMO_KEY
+    export CONCORD_ENABLE_WEB_ENRICHMENT=1
+    uv run concord serve
+    ```
+    Visit `/bills/119/hr/1` (or any bill with NULL `*_fetched_at`). Confirm the button appears at the top. Click it. Confirm the in-flight fragment appears and polls. Confirm the page swaps to the populated profile within ~10s. Refresh — confirm the button is gone (all `*_fetched_at` are now populated). Re-run the server without `CONCORD_ENABLE_WEB_ENRICHMENT` set — confirm the button is absent and the existing per-section CLI placeholders are shown.
+
+## Demo seed data
+
+> No `backend/demo/seed.sql` exists in this repo — this is a Python project, not the JS-shape repo the template was written for. The closest equivalent is the test fixtures in [`tests/`](../../tests/), which Step 7's integration test already updates. The web-initiated enrichment feature has no persistent "demo mode" surface beyond what already exists (a bill row, with or without enrichment); no fixture changes needed beyond the test additions in Steps 2–12.
+
+## Testing strategy
+
+**Unit tests (new):**
+- `tests/test_storage_sqlite.py` — `set_bill_enrichment_error` / `clear_bill_enrichment_error` round-trip; the schema includes the new column on `ensure_schema`.
+- `tests/test_pipeline_bills.py` — `load_one` projects only the named bill and is idempotent; `reindex_one` updates only the matching FTS row; the bulk `load` and `index` paths still produce the same SQLite state after the refactor (regression).
+
+**Integration tests (new, in `tests/test_web_bills.py`):**
+- POST `/bills/{c}/{t}/{n}/enrichment` returns the in-flight fragment and registers `bill_id` in `app.state.enrichment_in_flight`.
+- Re-POST while in flight returns the same in-flight fragment and does not enqueue a second task.
+- GET `/bills/{c}/{t}/{n}/enrichment-status` returns each of the three fragments (in-flight / done / failed) when state is set up to match.
+- The bills profile page renders the button when `enrichment_enabled=True` and at least one `*_fetched_at IS NULL`; renders nothing extra when `enrichment_enabled=False`; renders failed banner when `last_enrichment_error IS NOT NULL`.
+- The POST and status routes are not registered (return 404) when `CONCORD_ENABLE_WEB_ENRICHMENT` is unset.
+- End-to-end with a stub `Client` and a real temp JSONL directory: POST enrichment, drive the background task to completion (synchronously in the test via direct call to `_enrich_one_bill`), assert the bill's five `*_fetched_at` columns are populated and `last_enrichment_error` is NULL.
+- Failure-path test: stub `Client` raises `ApiError`; assert `last_enrichment_error` is set, the status fragment is "failed", and a subsequent POST clears the error and re-attempts.
+
+**Manual checks (browser):**
+- The flow described in Step 16. Particular attention to: the dashed-box per-section placeholders disappearing in the right order (only after the page-refresh swap, not during the poll); the failed banner truncating long error messages reasonably; the status fragment stops polling once it lands on done or failed.
+
+**Regression risk:**
+- `uv run pytest` full suite must pass. The refactor of `load_bills.load` and `index_bills.index` to share code with the new per-bill helpers must not change observable bulk behavior — covered by the regression test in `tests/test_pipeline_bills.py`.
+- `uv run mypy src` must pass with strict mode on `src/concord/`. The `app.state.*` attributes are dynamic; FastAPI's `state` is typed as `State` (essentially `Any`) so this typically Just Works, but check for any explicit annotations needed.
+- `uv run ruff check` and `uv run ruff format --check` must pass. The web `app.py` already has `# noqa: C901, PLR0915` on `_register_routes` — Steps 6 and 9 will push that complexity higher; if ruff flags it, add the new routes to a small inner `def _register_enrichment_routes(app, limiter)` helper called conditionally.
+
+## Acceptance criteria
+
+- [ ] `bills.last_enrichment_error` column exists; `ensure_schema` creates it on fresh DBs.
+- [ ] `load_bills.load_one(*, storage_dir, db_path, bill_id)` exists and is unit-tested.
+- [ ] `index_bills.reindex_one(*, db_path, bill_id)` exists and is unit-tested.
+- [ ] `POST /bills/{c}/{t}/{n}/enrichment` returns the in-flight fragment, registers the bill_id in the in-flight set, and dispatches a background task that runs scrape → load_one → reindex_one.
+- [ ] `GET /bills/{c}/{t}/{n}/enrichment-status` returns one of three fragments based on `app.state.enrichment_in_flight` membership, `*_fetched_at` columns, and `last_enrichment_error`.
+- [ ] Bill profile page renders the "Request enrichment" button at the top when `enrichment_enabled=True` and at least one `*_fetched_at IS NULL`.
+- [ ] Both new routes return 404 when `CONCORD_ENABLE_WEB_ENRICHMENT` is unset.
+- [ ] Both new routes return 404 when `CONGRESS_API_KEY` is unset (even if `CONCORD_ENABLE_WEB_ENRICHMENT=1`).
+- [ ] `docs/adr/0016-web-initiated-enrichment.md` exists with Status: Accepted and explicitly names rate limiting as a deferred follow-up.
+- [ ] CLAUDE.md "API keys" section mentions `CONCORD_ENABLE_WEB_ENRICHMENT`.
+- [ ] `uv run ruff check` clean.
+- [ ] `uv run ruff format --check` clean.
+- [ ] `uv run mypy src` clean.
+- [ ] `uv run pytest` clean.
+
+## Open questions
+
+None — all design decisions resolved during grilling on 2026-05-27.
+
+## Out-of-band work
+
+- **Rate-limit plan (separate, follow-up).** Will add `@limiter.limit(...)` to the `POST …/enrichment` route, pick a rate string (recommendation in grilling notes: `"3/hour"` per-IP, conservative; revisit), and write a sibling ADR. Depends on this plan landing first to have a real chokepoint to decorate.
+- **Bills embeddings (Phase 5).** Out of scope here. When that work lands, `reindex_one` will need a sibling pass that chunks the bill text + writes embeddings; the request-flow body in Step 7 will gain a `bills_embed_one(...)` call between `load_one` and `reindex_one`.
+- **Multi-worker uvicorn.** If `concord serve` ever grows a `--workers N` flag (N > 1), the in-process `enrichment_in_flight` set stops protecting against duplicate enrichment of the same bill across workers. ADR 0016 names this; the trigger to revisit is the introduction of the flag, not this plan.
+- **Staleness-aware re-scrape ([docs/plans/staleness-aware-rescrape.md](./staleness-aware-rescrape.md)).** Once that lands and `--skip-unchanged` exists on the scraper, the button's semantics broaden gracefully: a re-click on a fully-enriched bill becomes "re-fetch and skip if upstream hasn't moved". No code change needed in *this* plan for that to compose; just a future copy tweak from "Request enrichment" to "Refresh enrichment" when all `*_fetched_at` are populated.

--- a/docs/plans/enrichment-rate-limiting.md
+++ b/docs/plans/enrichment-rate-limiting.md
@@ -1,0 +1,333 @@
+# Rate limiting for the bill-enrichment endpoint
+
+> Add per-IP rate limiting to the `POST /bills/{c}/{t}/{n}/enrichment` route designed in [bill-enrichment-button.md](./bill-enrichment-button.md), introduce a centralized pydantic-settings config module so the growing set of operator env vars has a single home, make per-IP limits actually work behind the Traefik reverse proxy of the standard Docker deployment, and replace the default JSON 429 handler with one that returns HTMX-friendly HTML when the client opts in.
+
+## Source
+
+Conversation context, 2026-05-27 — paired with [bill-enrichment-button.md](./bill-enrichment-button.md) ([concord#78](https://github.com/johnmarcampbell/concord/issues/78)) which deferred rate limiting and named the chokepoint. The grilling session for this plan walked seven branches (deployment topology, per-IP rate string, global cap, status-poll handling, 429 response shape, ADR-worthiness, multi-process future-proofing); the resolved decisions live in [Approach](#approach).
+
+## Context
+
+The enrichment plan adds `POST /bills/{c}/{t}/{n}/enrichment` which runs `scrape_enrichment` → `load_bills.load_one` → `index_bills.reindex_one` for one bill in a `BackgroundTasks` job. Each click costs **5 sub-endpoint calls to api.congress.gov, often more after pagination** — cosponsors and actions paginate at 20/page, subjects paginates too — so a heavily-cosponsored bill (e.g. ~200 cosponsors, ~50 actions) can be 20–30+ API calls per click. The `CONGRESS_API_KEY` budget is **5,000 requests/hour per registered key**, a hard ceiling rather than a money-buys-more relationship. ~500 enrichment clicks/hr (or fewer if bills are heavy) exhaust the entire budget — and the budget is shared with any other use of the same key, including the `concord scrape` CLI an operator might run overnight.
+
+The web app is anonymous (no users, no sessions). Threat model is **anonymous-internet abuse**: curious visitor (1–5 clicks total), adversarial visitor walking the `/bills` index (50 bills/page × ~15 calls = drains the quota in a few page-walks), scripted scraper from one IP, and distributed multi-IP campaigns.
+
+`slowapi` is already wired up — `Limiter(key_func=get_remote_address)` at [src/concord/web/app.py:125](src/concord/web/app.py:125), and `@limiter.limit("30/minute")` decorates `/search` at line 177. This plan does not introduce a new rate-limit library; it extends the existing one. But the existing setup has two latent problems this plan also fixes:
+
+1. **`get_remote_address` reads the socket peer**, which behind any reverse proxy is the proxy's IP. Every visitor shares one bucket and per-IP limiting silently collapses to global. The standard Concord deployment per [docs/adr/0012-web-bootstraps-empty-schema-on-startup.md](../adr/0012-web-bootstraps-empty-schema-on-startup.md) is a Docker container on a Hostinger VPS with a Traefik container on the same VPS doing the proxying — so the deployment **does** sit behind a proxy and per-IP is broken today.
+2. **`slowapi`'s default `_rate_limit_exceeded_handler` returns JSON.** The enrichment button POST has `hx-swap="outerHTML"` targeting `#enrichment-status`; a JSON 429 lands as a string in that div. Visually broken.
+
+A third item this plan addresses is **env-var sprawl**. The enrichment plan adds `CONCORD_ENABLE_WEB_ENRICHMENT` on top of `CONGRESS_API_KEY`; this plan adds `CONCORD_TRUST_PROXY_HEADERS`, `CONCORD_ENRICHMENT_RATE_LIMIT`, and `CONCORD_SEARCH_RATE_LIMIT`. Six env vars read from scattered places is one too many. A small `Settings` class via `pydantic-settings` makes the operator-facing surface self-documenting and typed.
+
+Domain terms used here are defined in [CONTEXT.md](../../CONTEXT.md): Bill, Bill ID.
+
+## Goals
+
+1. Add per-IP rate limiting to `POST /bills/{c}/{t}/{n}/enrichment` at the composite rate `1/minute;3/hour;20/day` (`slowapi`'s semicolon-separated multi-limit syntax). Default in `Settings`; overridable via env var `CONCORD_ENRICHMENT_RATE_LIMIT`.
+2. Introduce `src/concord/config.py` containing a single pydantic-settings `Settings` class with six fields covering every operator-facing knob. Read once at `create_app()` boot, stashed on `app.state.settings`.
+3. Make per-IP limiting work behind a reverse proxy: a new `CONCORD_TRUST_PROXY_HEADERS` env var (default off). When set, `create_app()` registers `uvicorn.middleware.proxy_headers.ProxyHeadersMiddleware` with `trusted_hosts="*"`. `get_remote_address` then sees the real client IP rather than the proxy.
+4. Replace `slowapi`'s default `_rate_limit_exceeded_handler` with a custom handler that branches on `HX-Request: true` — HTMX requests get an HTML fragment (`web/templates/_rate_limited.html`), other requests get the existing JSON shape. Both set `Retry-After` and log a WARN line.
+5. Migrate the existing `SEARCH_RATE_LIMIT` module constant ([src/concord/web/app.py:49](src/concord/web/app.py:49)) to `settings.search_rate_limit`, env-overridable via `CONCORD_SEARCH_RATE_LIMIT`. No behaviour change at the default value.
+6. Land [ADR 0017 — Rate-limit posture for the public web demo](../adr/0017-rate-limit-posture.md) (new). Records the seven locked decisions, the rejected alternatives (global static cap; status-poll limit), and the multi-process revisit trigger in a "what stays open" paragraph.
+7. Amend [bill-enrichment-button.md](./bill-enrichment-button.md) Step 5 to consume `Settings` instead of doing inline `os.environ.get(...)` reads. (Done at plan-write time; documented under [Out-of-band work](#out-of-band-work).)
+
+## Non-goals
+
+1. **Global static cap across all IPs.** Considered and rejected during grilling. Defense stack is per-IP + the [`concord.api.Client`](../../src/concord/api.py) upstream-429 backoff that already exists ([src/concord/api.py:526-540](src/concord/api.py:526)) + the `CONCORD_ENABLE_WEB_ENRICHMENT` kill switch + a WARN log line on every 429. If a real distributed attack ever materializes, observability + a circuit-breaker is the better answer than a static cap; defer.
+2. **Rate limiting `GET /bills/.../enrichment-status`.** The status-poll endpoint fires 20× per minute per in-flight job; it's a cheap SELECT with no external API calls; the POST limit indirectly caps how many polls are legitimately reachable. Limiting it would either fire on legitimate use (if tight) or be redundant (if generous). Don't.
+3. **Refactoring `concord.api.Client` to read `Settings().congress_api_key`.** `Client` currently reads `os.environ.get("CONGRESS_API_KEY")` lazily in its `__init__` and that's fine. Migration is a small, independent follow-up; not part of this plan.
+4. **Distributed (Redis-backed) rate limiting.** `slowapi`'s default in-memory storage is correct for single-process deployment. Multi-process correctness is the same revisit trigger as the in-process in-flight set in [ADR 0016](../adr/0016-web-initiated-enrichment.md) (not yet written; drafted by the enrichment plan). When `concord serve` ever grows a `--workers N > 1` flag, the storage backend swaps to `Limiter(storage_uri="redis://…")`. Documented in ADR 0017's "what stays open" section.
+5. **Auth / per-user rate limits.** The app is anonymous. This is purely per-IP.
+6. **A `Retry-After` value computed from `slowapi`'s internal bucket state.** `slowapi` doesn't expose seconds-until-reset on `RateLimitExceeded` via a public API. We use the *window size* of the violated limit instead — pessimistic (says "wait 60s" when actually only 23s remain) but correct in spirit and resilient to `slowapi` internals.
+
+## Relevant prior decisions
+
+- [bill-enrichment-button.md](./bill-enrichment-button.md). This plan extends that plan's `POST /bills/{c}/{t}/{n}/enrichment` route with a `@limiter.limit(...)` decorator, and amends Step 5 of that plan to consume `Settings`. Merge order: this plan's Settings module must exist before the enrichment plan's Step 5 lands. See [Out-of-band work](#out-of-band-work).
+- [ADR 0001 — Python end-to-end for the web layer](../adr/0001-python-end-to-end-for-the-web-layer.md). The reason `slowapi` (in-process Python) rather than a sidecar limiter is the right shape.
+- [ADR 0012 — Web layer bootstraps an empty schema on startup](../adr/0012-web-bootstraps-empty-schema-on-startup.md). References the upcoming Dockerfile that this plan's `CONCORD_TRUST_PROXY_HEADERS` env var documents alongside.
+- [ADR 0016 — Web layer may invoke Stage 0 enrichment on demand](../adr/0016-web-initiated-enrichment.md) (drafted by the enrichment plan; not yet on disk). ADR 0017 cross-references its "what stays open" multi-worker note.
+- **ADR 0017 — Rate-limit posture for the public web demo** (new, drafted as a step of this plan). See [Step 9](#step-by-step-plan).
+
+## Relevant files and code
+
+- [`src/concord/web/app.py:35`](../../src/concord/web/app.py) — `slowapi` import line. The custom handler will replace the imported `_rate_limit_exceeded_handler`.
+- [`src/concord/web/app.py:48-49`](../../src/concord/web/app.py) — `SEARCH_RATE_LIMIT = "30/minute"` module constant. Migrated to `settings.search_rate_limit`.
+- [`src/concord/web/app.py:98-146`](../../src/concord/web/app.py) — `create_app(db_path, *, embedder=None)`. Settings construction, proxy-header middleware registration, and custom 429 handler registration all land here.
+- [`src/concord/web/app.py:125`](../../src/concord/web/app.py) — `limiter = Limiter(key_func=get_remote_address)`. Unchanged in this plan — `get_remote_address` keeps reading `request.client.host`, but `ProxyHeadersMiddleware` (when enabled) rewrites that to the real client IP from `X-Forwarded-For` before any handler runs.
+- [`src/concord/web/app.py:136`](../../src/concord/web/app.py) — `app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)`. Replaced with the local custom handler.
+- [`src/concord/web/app.py:176-177`](../../src/concord/web/app.py) — `@limiter.limit(SEARCH_RATE_LIMIT)` on `/search`. Updated to `@limiter.limit(settings.search_rate_limit)`.
+- [`pyproject.toml`](../../pyproject.toml) — add `pydantic-settings` dependency. `pydantic` is already present (used by `concord.models`).
+- [`tests/test_web_routes.py:230-247`](../../tests/test_web_routes.py) — existing 429 test class. Pattern: `TestClient(app, raise_server_exceptions=False)` + hammer the route + assert `r.status_code == 429`. New 429 tests for the enrichment route follow the same shape.
+- [`CLAUDE.md`](../../CLAUDE.md) — "API keys" section ([CLAUDE.md:39-44](../../CLAUDE.md:39)). New env vars get one line each.
+- (Created by enrichment plan, modified here) [`src/concord/web/app.py`](../../src/concord/web/app.py) — the `@app.post(".../enrichment")` route from enrichment-plan Step 6. This plan adds `@limiter.limit(settings.enrichment_rate_limit)` between `@app.post(...)` and the handler.
+
+## Approach
+
+### Centralized config via pydantic-settings
+
+The growing operator-facing surface (`CONGRESS_API_KEY`, `OPENAI_API_KEY`, `CONCORD_ENABLE_WEB_ENRICHMENT`, `CONCORD_TRUST_PROXY_HEADERS`, `CONCORD_ENRICHMENT_RATE_LIMIT`, `CONCORD_SEARCH_RATE_LIMIT`) is consolidated into `src/concord/config.py`:
+
+```python
+"""Operator-facing configuration. Each field's name (uppercased) is the
+env var that overrides it.
+
+Construct a fresh ``Settings()`` at each consumption boundary (typically
+once at app boot inside ``create_app``). Tests monkeypatch ``os.environ``
+and then construct a new ``Settings`` to see the override — no
+module-level cache to clear.
+"""
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=None,            # we don't auto-load .env; see CLAUDE.md
+        case_sensitive=False,     # CONGRESS_API_KEY → congress_api_key
+        extra="ignore",
+    )
+
+    # API keys — no default; presence-checked at the use site.
+    congress_api_key: str | None = None        # env: CONGRESS_API_KEY
+    openai_api_key: str | None = None          # env: OPENAI_API_KEY
+
+    # Web behaviour.
+    enable_web_enrichment: bool = False        # env: CONCORD_ENABLE_WEB_ENRICHMENT
+    trust_proxy_headers: bool = False          # env: CONCORD_TRUST_PROXY_HEADERS
+
+    # Rate limits — slowapi rate strings.
+    search_rate_limit: str = "30/minute"                       # env: CONCORD_SEARCH_RATE_LIMIT
+    enrichment_rate_limit: str = "1/minute;3/hour;20/day"      # env: CONCORD_ENRICHMENT_RATE_LIMIT
+```
+
+Functions-vs-class was considered. Class wins because: (a) `Settings` is *the* answer to "what knobs does this app have?" — discoverable in one place; (b) bool/string parsing and validation are free; (c) a malformed value (`CONCORD_ENABLE_WEB_ENRICHMENT=banana`) fails loud at boot rather than silently defaulting to False; (d) `pydantic-settings` is small (~25 KB) and only depends on `pydantic`, which is already in the project.
+
+The one cost: env-var → field mapping is implicit (uppercased field name). `grep -rn "CONCORD_TRUST_PROXY_HEADERS"` won't find the field declaration. The one-line comment per field (above) makes the contract grep-able.
+
+### `Settings()` lifecycle
+
+Construct once at the top of `create_app()`, stash on `app.state.settings`. Routes read it via `request.app.state.settings`. The decorator-applied rate strings (`@limiter.limit(settings.enrichment_rate_limit)`) are captured at *route registration time* (inside `_register_routes`, called from `create_app`) — so they always reflect the boot-time value. A re-tune of `CONCORD_ENRICHMENT_RATE_LIMIT` needs a process restart, which matches operator expectations for env-var-driven config.
+
+### Proxy-header trust
+
+`uvicorn.middleware.proxy_headers.ProxyHeadersMiddleware` ships with uvicorn — no new dep. When `settings.trust_proxy_headers` is True, register it with `trusted_hosts="*"`:
+
+```python
+if settings.trust_proxy_headers:
+    from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+    app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+```
+
+The middleware rewrites `request.scope["client"]` from `X-Forwarded-For` *before* any handler (including `slowapi`'s `get_remote_address`) runs. So `get_remote_address` keeps working unchanged — it just sees the real client IP instead of the proxy.
+
+`trusted_hosts="*"` is correct for the standard deployment shape (Docker container, Traefik on the same VPS — the container only receives traffic from Traefik, so trusting `X-Forwarded-For` from any upstream is fine). The env var **is** the operator promise: "I have an actual trusted proxy in front of me." A separate `CONCORD_TRUSTED_PROXIES` env var with CIDRs was considered and rejected as over-engineering for a single-tenant demo.
+
+Defaulting the env var off (rather than on) means `concord serve` locally without a proxy keeps the spoof-proof socket-peer behavior. The Dockerfile follow-up (per [ADR 0012](../adr/0012-web-bootstraps-empty-schema-on-startup.md)) will document `CONCORD_TRUST_PROXY_HEADERS=1` as a recommended setting for the standard Traefik deployment.
+
+### Rate-string shape — why `1/minute;3/hour;20/day`
+
+The asymmetry with `/search`'s `30/minute` is intentional. `/search` costs one OpenAI embed call per request — your money, no hard external ceiling. Enrichment costs 5–30+ api.congress.gov calls — a hard 5,000/hr ceiling shared across all uses of the key. Enrichment must be tighter by ~an order of magnitude.
+
+Composite shape rationale:
+- **`1/minute`** is cheap insurance against accidental double-clicks (browser back/forward, form resubmission) and frantic retry storms. Legitimate users don't enrich more than one bill per minute.
+- **`3/hour`** maps to "engaged researcher": clicking enrichment on three specific bills in an hour while writing about a topic. More than that and the CLI (`concord scrape bills enrich --bill-ids …`) is the right tool.
+- **`20/day`** catches slow walkers (one click every ~5 minutes from one IP — beats the per-hour limit but still drains over a day). 20 × ~15 calls/click ≈ 300 calls/day per IP; even with a dozen committed adversarial IPs that's ~3,600/day, comfortably under the 120,000/day theoretical budget (5,000/hr × 24).
+
+`slowapi` accepts the semicolon-separated form natively: `@limiter.limit("1/minute;3/hour;20/day")` is equivalent to stacking three decorators.
+
+### No global cap; rely on upstream backoff
+
+A global limit (e.g. `key_func=lambda *_: "global"` at `100/hour`) would catch distributed abuse but at the cost of returning 429 to legitimate new visitors during popularity moments. The failure mode without a global cap is well-tolerated: [`concord.api.Client`](../../src/concord/api.py) already retries upstream 429s indefinitely with `Retry-After`-respecting backoff ([src/concord/api.py:526-540](src/concord/api.py:526)), so a drained quota slows down enrichment rather than corrupting it. The user sees "Enriching…" for longer; nothing breaks.
+
+The operator-visible signal that something is amiss: every web-side 429 emits a WARN log line. `grep "rate limit exceeded"` from container logs shows the rate of legitimate vs adversarial pressure.
+
+### No limit on the status-poll endpoint
+
+`GET /bills/.../enrichment-status` is cheap (one indexed SELECT, no external calls) and indirectly capped: you can only legitimately poll for bills you've POSTed, and the POST limit caps that. An attacker hammering the status endpoint achieves nothing (no expensive work triggered, no privileged info leaked). Limiting it would either be redundant or fire on legitimate use.
+
+### HTMX-aware 429 response
+
+Replace `slowapi`'s `_rate_limit_exceeded_handler` with a local one:
+
+```python
+def _rate_limit_exceeded(request: Request, exc: RateLimitExceeded) -> Response:
+    retry_after_s = _window_seconds(exc)        # see below
+    _log.warning(
+        "rate limit exceeded: ip=%s path=%s limit=%s",
+        get_remote_address(request),
+        request.url.path,
+        exc.detail,
+    )
+    headers = {"Retry-After": str(retry_after_s)}
+    if request.headers.get("HX-Request") == "true":
+        html = templates.get_template("_rate_limited.html").render(
+            {"retry_after_s": retry_after_s}
+        )
+        return HTMLResponse(html, status_code=429, headers=headers)
+    return JSONResponse(
+        {"error": "rate_limit_exceeded", "retry_after": retry_after_s},
+        status_code=429,
+        headers=headers,
+    )
+```
+
+`_window_seconds(exc)` parses `exc.detail` (a string like `"1 per 1 minute"`) and returns the window size (60 / 3600 / 86400). `slowapi`'s `RateLimitExceeded` doesn't expose seconds-until-reset on a public API; window-size is pessimistic but correct-in-spirit and resilient to `slowapi` internals.
+
+The HTML fragment is **generic — no `id` attribute, no "Try again" button**:
+
+```html
+<div class="border border-amber-300 bg-amber-50 text-amber-800 rounded p-3 text-sm">
+  ⚠ Too many requests. Try again in {{ retry_after_s }}s.
+</div>
+```
+
+This lets it swap into any HTMX target (the `#enrichment-status` div for the enrichment POST, the search results container for `/search` if it ever 429s an HTMX-paginating client). The user retries via a page reload — clunkier than auto-recovery via `hx-trigger="load delay:60s"`, but the wiring for auto-recovery would couple this fragment to the enrichment polling state machine in a fragile way. For an exceptional UX state (rate-limited), a page reload is fine.
+
+### ADR 0017 — what it records
+
+The seven locked decisions plus the rejected alternatives. The multi-process correctness note lives inside ADR 0017's "what stays open" section rather than getting its own ADR — `slowapi`'s in-memory storage is one paragraph of context, not a standalone decision.
+
+## Step-by-step plan
+
+1. **Add `pydantic-settings` dependency.** Edit [`pyproject.toml`](../../pyproject.toml) `[project.dependencies]` to add `"pydantic-settings>=2.0"`. Run `uv sync` to update the lockfile. **Verify:** `uv run python -c "from pydantic_settings import BaseSettings"` succeeds.
+
+2. **Create `src/concord/config.py`.** Add the `Settings` class shown in [Approach > Centralized config via pydantic-settings](#centralized-config-via-pydantic-settings) — six fields, one-line comment per field naming the env var, `model_config` set as shown. Export `__all__ = ["Settings"]`. **Verify:** `uv run python -c "from concord.config import Settings; s = Settings(); print(s.model_dump())"` prints all six fields with their defaults. `uv run mypy src` is clean.
+
+3. **Write unit tests for `Settings`.** Add `tests/test_config.py` with cases using `pytest-monkeypatch`:
+   - Default values match the source declarations when no env vars are set.
+   - `CONCORD_ENABLE_WEB_ENRICHMENT=1` → True; `=true` → True; `=yes` → True; `=on` → True; `=0` → False; `=banana` → raises `ValidationError` at `Settings()` construction.
+   - `CONCORD_ENRICHMENT_RATE_LIMIT=2/hour` → field reads the override.
+   - `CONGRESS_API_KEY=test-key` → `settings.congress_api_key == "test-key"`.
+   **Verify:** `uv run pytest tests/test_config.py -x` passes.
+
+4. **Wire `Settings` into `create_app()`.** Edit [`src/concord/web/app.py:114-130`](../../src/concord/web/app.py:114) (the body of `create_app`):
+   ```python
+   from concord.config import Settings
+
+   def create_app(db_path, *, embedder=None) -> FastAPI:
+       db_path = Path(db_path)
+       ensure_schema(db_path)
+       settings = Settings()
+       # ... existing embedder init ...
+       limiter = Limiter(key_func=get_remote_address)
+       app = FastAPI(...)
+       app.state.db_path = db_path
+       app.state.embedder = embedder
+       app.state.limiter = limiter
+       app.state.settings = settings
+       # ...
+   ```
+   Remove the existing `SEARCH_RATE_LIMIT = "30/minute"` module constant at line 48-49 — it now lives in `Settings`. **Verify:** `uv run pytest tests/test_web_routes.py -x` passes (the existing test fixtures don't depend on `SEARCH_RATE_LIMIT` as a module symbol — confirm before deleting; if anything imports it, leave it as `SEARCH_RATE_LIMIT = Settings().search_rate_limit` for compat).
+
+5. **Add proxy-header middleware conditionally.** In `create_app()` after the `app = FastAPI(...)` line and before `app.state.* = ...` assignments, add:
+   ```python
+   if settings.trust_proxy_headers:
+       from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware  # noqa: PLC0415 - middleware gated on env var
+       app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+   ```
+   The `# noqa: PLC0415` matches the project pattern for runtime-gated imports (see CLAUDE.md "Things that bite"). **Verify:** add `test_proxy_headers_middleware_registered_when_trust_enabled` to [`tests/test_web_routes.py`](../../tests/test_web_routes.py) — set `CONCORD_TRUST_PROXY_HEADERS=1` via monkeypatch, build the app, assert `ProxyHeadersMiddleware` is in `app.user_middleware`. Without the env var set, assert it isn't.
+
+6. **Replace the default 429 handler.** In [`src/concord/web/app.py`](../../src/concord/web/app.py):
+   - Remove the import of `_rate_limit_exceeded_handler` from `slowapi` (line 35).
+   - Add a module-level function `def _rate_limit_exceeded(request: Request, exc: RateLimitExceeded) -> Response` per [Approach > HTMX-aware 429 response](#htmx-aware-429-response). The handler renders `_rate_limited.html` (created in Step 7) via `request.app.state.templates`.
+   - Add `def _window_seconds(exc: RateLimitExceeded) -> int` that parses `exc.detail` (a string like `"1 per 1 minute"` or `"3 per 1 hour"`) and returns 60 / 3600 / 86400 / etc. The implementation can use a small `{"second": 1, "minute": 60, "hour": 3600, "day": 86400}` dict and `re.match(r"\d+ per \d+ (\w+)", exc.detail)`. Default to 60 if the parse fails.
+   - Update line 136 to register the new handler: `app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded)`.
+   **Verify:** `tests/test_web_routes.py::TestRateLimiting::test_search_endpoint_rate_limited` still passes (the existing test only checks status code, so format-of-body changes are fine).
+
+7. **Add the `_rate_limited.html` template.** Create [`src/concord/web/templates/_rate_limited.html`](../../src/concord/web/templates/_rate_limited.html) with exactly the markup shown in [Approach](#htmx-aware-429-response). No `id` attribute, no button, generic amber alert with Tailwind classes matching the existing failure-banner styling in the bills templates. **Verify:** add `test_429_html_branch_returns_amber_alert` to [`tests/test_web_routes.py`](../../tests/test_web_routes.py) — hammer `/search` past the limit with `HX-Request: true` header, assert response is HTML (not JSON), assert it contains `"Too many requests"`, assert `Retry-After` header is set to `60`.
+
+8. **Migrate `/search`'s rate string to settings.** Edit [`src/concord/web/app.py:177`](../../src/concord/web/app.py:177): change `@limiter.limit(SEARCH_RATE_LIMIT)` to `@limiter.limit(app.state.settings.search_rate_limit)`. This requires moving the decorator application inside `_register_routes` so it can access `app.state.settings`, which is already the structure since `_register_routes(app, limiter)` is called after `app.state.settings` is set. **Verify:** `tests/test_web_routes.py::TestRateLimiting::test_search_endpoint_rate_limited` still passes at the default rate; an additional test setting `CONCORD_SEARCH_RATE_LIMIT=2/minute` exercises the override path (hammer to 3 requests/min, assert third is 429).
+
+9. **Add `@limiter.limit(...)` to the enrichment POST route.** This step *modifies code created by the enrichment plan* — it depends on [bill-enrichment-button.md](./bill-enrichment-button.md) Step 6 having landed. Inside `_register_routes` (per the enrichment plan), find the `@app.post("/bills/{congress}/{bill_type}/{bill_number}/enrichment", response_class=HTMLResponse)` decorator and add a `@limiter.limit(settings.enrichment_rate_limit)` decorator *below* it (slowapi-decorator goes inside FastAPI-decorator). The in-flight check inside the handler body stays unchanged — it's already designed to sit after any limiter decorator per the enrichment plan's chokepoint contract. **Verify:** add `test_enrichment_post_rate_limited` to [`tests/test_web_bills.py`](../../tests/test_web_bills.py) — set both `CONGRESS_API_KEY` and `CONCORD_ENABLE_WEB_ENRICHMENT=1`, POST the enrichment route twice in quick succession, assert the second response is 429 with `Retry-After` set. Verify the in-flight set was *not* mutated (the bill is not in `app.state.enrichment_in_flight` after the 429).
+
+10. **Draft ADR 0017.** Create [`docs/adr/0017-rate-limit-posture.md`](../adr/0017-rate-limit-posture.md) using the existing ADR style (compare [ADR 0012](../adr/0012-web-bootstraps-empty-schema-on-startup.md)). Status: Accepted, dated at landing. Sections: Context → Decision → Consequences (trade-offs accepted / things this buys / what stays open) → Rejected: global static cap → Rejected: limit the status-poll endpoint. The "what stays open" section must include both (a) multi-process correctness (revisit when `--workers N > 1`; migration path is `Limiter(storage_uri="redis://…")`) and (b) the observability + circuit-breaker follow-up if distributed abuse becomes a real problem. **Verify:** `uv run ruff format --check` and `uv run ruff check` clean.
+
+11. **Update CLAUDE.md.** Under the "API keys" section ([CLAUDE.md:39-44](../../CLAUDE.md:39)), add three lines documenting the new env vars:
+    - `CONCORD_TRUST_PROXY_HEADERS=1` — set when running behind a reverse proxy (the standard Docker-on-VPS-with-Traefik deployment). Default off.
+    - `CONCORD_ENRICHMENT_RATE_LIMIT` — overrides the default `"1/minute;3/hour;20/day"` rate applied to the bill-enrichment button. Format: `slowapi` rate string (semicolon-separated for composite limits).
+    - `CONCORD_SEARCH_RATE_LIMIT` — overrides the default `"30/minute"` rate applied to `/search`.
+    Also add a forward reference: "All operator-facing env vars are declared in [`src/concord/config.py`](src/concord/config.py); see the `Settings` class for the full set." **Verify:** read the rendered CLAUDE.md change in the PR diff.
+
+12. **Amend [bill-enrichment-button.md](./bill-enrichment-button.md) Step 5 to consume `Settings`.** Replace the inline `os.environ.get(...)` reads:
+    ```python
+    # Before (enrichment plan as written):
+    has_congress_api_key = bool(os.environ.get("CONGRESS_API_KEY"))
+    enrich_flag = os.environ.get("CONCORD_ENABLE_WEB_ENRICHMENT", "").strip().lower()
+    enrichment_enabled = has_congress_api_key and enrich_flag in {"1", "true", "yes"}
+    ```
+    with:
+    ```python
+    # After (this plan amends):
+    settings = Settings()
+    enrichment_enabled = bool(settings.congress_api_key) and settings.enable_web_enrichment
+    ```
+    Stash `settings` (and `enrichment_enabled` for convenience) on `app.state` exactly as the enrichment plan did. Also add a line to the enrichment plan's "Relevant prior decisions" listing this plan as the source of `concord.config.Settings`. This edit is **done at plan-write time** (i.e., as part of writing this plan, not as a runtime step) so the two plan files on disk are coherent for whichever executor reads them. See [Out-of-band work](#out-of-band-work) for the merge-order note.
+
+13. **Manual end-to-end smoke.** With the enrichment plan landed and `proceedings.db` containing at least one tier-1-only bill:
+    ```sh
+    export CONGRESS_API_KEY=...                           # a real key
+    export CONCORD_ENABLE_WEB_ENRICHMENT=1
+    export CONCORD_ENRICHMENT_RATE_LIMIT="2/minute"       # tight, for easy testing
+    uv run concord serve
+    ```
+    Visit `/bills/119/hr/1`. Click "Request enrichment" — confirm in-flight fragment. Click "Request enrichment" on another bill — confirm in-flight fragment. Click on a third bill within the same minute — confirm the response is an amber 429 fragment in `#enrichment-status` with "Try again in 60s." Confirm the third bill is *not* in `app.state.enrichment_in_flight` (inspect via a debug print or a `/healthz` extension; pragmatic — just check the container logs for the WARN line). Reload the page after 60s, click again — confirm the request goes through.
+
+    Re-run with `CONCORD_TRUST_PROXY_HEADERS=1` *not* set behind Traefik — confirm all requests appear to come from one IP (Traefik's), confirming the per-IP collapse footgun is real. Then re-run with the env var set — confirm distinct client IPs are seen via the WARN log.
+
+## Demo seed data
+
+> No `backend/demo/seed.sql` exists in this repo — this is a Python project, not the JS-shape repo the template was written for. This plan adds zero persistent data (rate-limit state lives in-process in `slowapi`'s in-memory backend). No fixture changes needed beyond the test additions in Steps 3, 5, 7, 8, and 9.
+
+## Testing strategy
+
+**Unit tests (new):**
+- `tests/test_config.py` — `Settings` field defaults, env-var overrides, bool parsing (including the malformed-value ValidationError case), case-insensitive env-var names.
+
+**Integration tests (new, in `tests/test_web_routes.py`):**
+- `test_proxy_headers_middleware_registered_when_trust_enabled` — env var set → middleware present; unset → middleware absent.
+- `test_429_html_branch_returns_amber_alert` — hammer `/search` past limit with `HX-Request: true`, assert HTML response, content contains "Too many requests", `Retry-After: 60`.
+- `test_429_json_branch_for_non_htmx` — hammer `/search` past limit without `HX-Request`, assert JSON response with `error: "rate_limit_exceeded"` and `Retry-After` header.
+- `test_search_rate_limit_override` — `CONCORD_SEARCH_RATE_LIMIT=2/minute` → third request in a minute is 429.
+- `test_rate_limit_warn_log` — assert WARN log line is emitted on a 429 (`caplog` fixture).
+
+**Integration tests (new, in `tests/test_web_bills.py`):**
+- `test_enrichment_post_rate_limited` — two POSTs in a minute, third returns 429; in-flight set unchanged.
+- `test_enrichment_rate_limit_override` — `CONCORD_ENRICHMENT_RATE_LIMIT=10/hour` → looser, more requests allowed.
+
+**Regression risk:**
+- `tests/test_web_routes.py::TestRateLimiting::test_search_endpoint_rate_limited` must still pass — the rate-string source changed but the behavior at the default value didn't. Confirm before and after.
+- `uv run pytest` full suite must pass.
+- `uv run mypy src` must pass with strict mode — `pydantic-settings` has good mypy support; if any field-typing issue arises, prefer narrowing the field type over `# type: ignore`.
+- `uv run ruff check` and `uv run ruff format --check` must pass.
+
+**Manual checks:**
+- The full Step 13 walkthrough.
+
+## Acceptance criteria
+
+- [ ] `src/concord/config.py` exists with a `Settings` class containing all six fields with documented env-var comments.
+- [ ] `pydantic-settings` is a declared dependency in `pyproject.toml` and resolved in `uv.lock`.
+- [ ] `create_app()` constructs `Settings()` once and stashes it on `app.state.settings`.
+- [ ] `ProxyHeadersMiddleware` is registered iff `CONCORD_TRUST_PROXY_HEADERS` is truthy; verified by route test.
+- [ ] `slowapi`'s default 429 handler is replaced with the HTMX-aware local handler.
+- [ ] `web/templates/_rate_limited.html` exists; renders an amber alert with retry-after seconds; contains no `id` attribute and no button.
+- [ ] `Retry-After` header is set on every 429 response.
+- [ ] A WARN log line is emitted on every 429.
+- [ ] `@limiter.limit(settings.enrichment_rate_limit)` decorates the enrichment POST route.
+- [ ] `@limiter.limit(settings.search_rate_limit)` decorates the `/search` route (replacing the module-constant version).
+- [ ] `docs/adr/0017-rate-limit-posture.md` exists with Status: Accepted; references ADR 0016's multi-worker revisit trigger.
+- [ ] CLAUDE.md "API keys" section documents the three new env vars and points at `concord.config.Settings`.
+- [ ] [bill-enrichment-button.md](./bill-enrichment-button.md) Step 5 has been amended (at plan-write time) to consume `Settings`.
+- [ ] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy src`, `uv run pytest` all clean.
+
+## Open questions
+
+None — all design decisions resolved during grilling on 2026-05-27.
+
+## Out-of-band work
+
+- **Merge-order coordination with [bill-enrichment-button.md](./bill-enrichment-button.md).** The enrichment plan's Step 5 (as amended by this plan's Step 12) imports `from concord.config import Settings`. Therefore this plan's Steps 1–4 must land *before* the enrichment plan's implementation begins, OR the two plans are executed as one bundled arc by the same agent. The simplest path: bundle. Bundle PR scope: `pydantic-settings` dep + `concord.config` + the enrichment feature + this plan's rate-limit decorator and 429 handler. That's roughly 25 numbered steps across the two plans; large but coherent. A reviewer can read the two plan files first, then the diff.
+- **`concord.api.Client` could consume `Settings().congress_api_key`** instead of reading `os.environ.get("CONGRESS_API_KEY")` directly ([src/concord/api.py:121](../../src/concord/api.py:121)). Small follow-up, not part of this plan. Trade-off: introduces a dep from `concord.api` (currently lean) on `concord.config` (and transitively `pydantic-settings`).
+- **The CLI modules (`src/concord/cli/`) also read `CONGRESS_API_KEY` and `OPENAI_API_KEY` directly.** Same follow-up opportunity as above. Migrating them is a one-line edit per command function and aligns the codebase on a single config-read pattern. Not required for this plan to land.
+- **Distributed rate limiting / multi-worker correctness.** ADR 0017's "what stays open" section names this. Revisit trigger: introduction of `concord serve --workers N > 1`. Migration: `Limiter(storage_uri="redis://…")` with a corresponding Redis container in the deployment stack. Out of scope here.
+- **Observability + circuit-breaker for distributed-abuse response.** If logs show sustained quota burn from many IPs collectively, the right response is a small counter that auto-disables enrichment for N minutes (effectively flipping the kill switch programmatically), not a static global cap. Defer until the threat materializes; ADR 0017 names this.
+- **The Dockerfile follow-up referenced in [ADR 0012](../adr/0012-web-bootstraps-empty-schema-on-startup.md)** should document `CONCORD_TRUST_PROXY_HEADERS=1` as a recommended env-var setting alongside the standard Traefik deployment. That's a Dockerfile PR concern, not this plan's.


### PR DESCRIPTION
## Summary

Adds two new implementation plans for the bill enrichment work, sized to be executed together as one bundled arc:

- [`docs/plans/bill-enrichment-button.md`](docs/plans/bill-enrichment-button.md) — web-initiated tier-2 enrichment for one Bill via an HTMX-polled `BackgroundTasks` job. Resolves the deferral in [`docs/plans/phase-2b-bills-enrichment.md`](docs/plans/phase-2b-bills-enrichment.md). Tracks #78. Will land **ADR 0016** — *Web layer may invoke Stage 0 enrichment on demand*.
- [`docs/plans/enrichment-rate-limiting.md`](docs/plans/enrichment-rate-limiting.md) — sibling plan: per-IP `slowapi` rate limit (`1/minute;3/hour;20/day`) on the POST chokepoint; centralized `pydantic-settings` config; `ProxyHeadersMiddleware` for the standard Traefik-on-VPS deployment; HTMX-aware 429 handler. Tracks #79. Will land **ADR 0017** — *Rate-limit posture for the public web demo*.

Both plans came out of two `/implementation-plan` grilling sessions and pass the self-containment audit. No code is changed in this PR — these are durable, hand-off-ready planning documents.

## Test plan

- [ ] Plans read top-to-bottom for someone with no prior context (the self-containment test the planning skill enforces).
- [ ] File paths, line numbers, and function signatures referenced in the plans match the current `master` (verified at write time against `b40a543`; rebased to `323521d` before push).
- [ ] No conflicts with the recently-landed ADR 0015 (#73, #77) — confirmed no overlapping references.
- [ ] Cross-references between the two plans are coherent: the enrichment plan's Step 5 consumes `concord.config.Settings` from the rate-limit plan's Step 2; the dependency is documented in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)