### PR TITLE
chore: drop `from __future__ import annotations` and guard against reintroduction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
+      - name: Forbid `from __future__ import annotations`
+        run: |
+          if grep -rn --include='*.py' '^from __future__ import annotations' src tests; then
+            echo "::error::Remove 'from __future__ import annotations' — banned by CONTRIBUTING.md"
+            exit 1
+          fi
+
       - name: Lint (ruff)
         run: uv run ruff check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,10 @@ repos:
       - id: ruff-format
       - id: ruff
         args: [--fix]
+  - repo: local
+    hooks:
+      - id: no-future-annotations
+        name: Forbid `from __future__ import annotations`
+        language: pygrep
+        entry: '^from __future__ import annotations'
+        types: [python]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 If a proposed change conflicts with an ADR, the right move is to discuss whether to write a new ADR (or amend the existing one) — not to silently diverge. ADRs are appended, not edited away.
 
+## Never write `from __future__ import annotations`
+
+This project is Python 3.12+ and bans that import — see [CONTRIBUTING.md](CONTRIBUTING.md). A pre-commit hook and CI step block it; don't add it back.
+
 ## Branch naming
 
 The harness spawns Claude sessions on randomly-named branches like `claude/funny-kirch-3bad54`. **Rename to something descriptive before doing real work** (`git branch -m claude/<short-task-name>`). This is a project convention, not a hard tooling requirement.

--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -21,8 +21,6 @@ Every retry decision is logged to ``stderr`` via :mod:`logging` (logger
 heartbeat.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import time
@@ -133,7 +131,7 @@ class Client:
     def close(self) -> None:
         self._client.close()
 
-    def __enter__(self) -> Client:
+    def __enter__(self) -> "Client":
         return self
 
     def __exit__(

--- a/src/concord/models.py
+++ b/src/concord/models.py
@@ -18,8 +18,6 @@ Members (Phase 1):
 - :class:`MemberSnapshot` — ADR 0006 envelope wrapping a raw API payload.
 """
 
-from __future__ import annotations
-
 import re
 from datetime import date, datetime
 from typing import Any, Literal
@@ -110,7 +108,7 @@ class Article(BaseModel):
         return data
 
     @model_validator(mode="after")
-    def _check_granule_id_matches_urls(self) -> Article:
+    def _check_granule_id_matches_urls(self) -> "Article":
         from_text = parse_granule_id(str(self.text_url))
         if from_text != self.granule_id:
             raise ValueError(
@@ -158,7 +156,7 @@ class Proceeding(BaseModel):
     @classmethod
     def build(
         cls, *, issue: Issue, article: Article, text: str, fetched_at: datetime
-    ) -> Proceeding:
+    ) -> "Proceeding":
         """Combine an issue, an article, and fetched text into a Proceeding."""
         return cls(
             **issue.model_dump(),

--- a/src/concord/pipeline/index_bills.py
+++ b/src/concord/pipeline/index_bills.py
@@ -14,8 +14,6 @@ Bill search is FTS5-only in Phase 2a/2b; embeddings come in Phase 5 when
 the ``chunks`` table generalizes to ``source_type='bill'`` per ADR 0008.
 """
 
-from __future__ import annotations
-
 import sqlite3
 from pathlib import Path
 from typing import NamedTuple

--- a/src/concord/pipeline/index_members.py
+++ b/src/concord/pipeline/index_members.py
@@ -10,8 +10,6 @@ embedding pass for Member names (BM25 + porter stemming is the right
 tool for short proper-noun lookups).
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 from typing import NamedTuple
 

--- a/src/concord/pipeline/index_votes.py
+++ b/src/concord/pipeline/index_votes.py
@@ -18,8 +18,6 @@ latest snapshot of the underlying tables. See [ADR 0011] for the
 methodology.
 """
 
-from __future__ import annotations
-
 import sqlite3
 from pathlib import Path
 from typing import NamedTuple

--- a/src/concord/pipeline/load_bills.py
+++ b/src/concord/pipeline/load_bills.py
@@ -16,8 +16,6 @@ over a JSONL that gained new snapshots converges the SQL projection to
 the latest-snapshot view.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 from collections.abc import Callable

--- a/src/concord/pipeline/load_members.py
+++ b/src/concord/pipeline/load_members.py
@@ -26,8 +26,6 @@ Re-running over a JSONL that gained new snapshots converges the SQL
 state to the latest-snapshot projection.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 from datetime import datetime

--- a/src/concord/pipeline/load_votes.py
+++ b/src/concord/pipeline/load_votes.py
@@ -24,8 +24,6 @@ skipped; the parent vote row still loads. Re-running over unchanged
 JSONL is a no-op for both chambers.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import re

--- a/src/concord/scraper/bills.py
+++ b/src/concord/scraper/bills.py
@@ -13,8 +13,6 @@ identity record per Bill plus the five tier-2 enrichment streams:
    per ADR 0009.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 from collections.abc import Callable, Iterable

--- a/src/concord/scraper/members.py
+++ b/src/concord/scraper/members.py
@@ -8,8 +8,6 @@ several Congresses will appear in each Congress's listing and produce
 one snapshot per appearance.
 """
 
-from __future__ import annotations
-
 import json
 from collections.abc import Callable, Iterable
 from datetime import datetime

--- a/src/concord/scraper/proceedings.py
+++ b/src/concord/scraper/proceedings.py
@@ -7,8 +7,6 @@ the CLI now delegates to :func:`scrape` so the per-entity scraper
 modules from ADR 0007 have a consistent shape.
 """
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from datetime import date
 

--- a/src/concord/scraper/votes.py
+++ b/src/concord/scraper/votes.py
@@ -14,8 +14,6 @@ Phase 3b adds ``scrape_senate`` alongside ``scrape_house`` here; both
 write into the same canonical ``votes`` table via the loader.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import time

--- a/src/concord/senate_xml.py
+++ b/src/concord/senate_xml.py
@@ -24,8 +24,6 @@ timezone offset; :func:`_parse_senate_date` localizes them via
 offset.
 """
 
-from __future__ import annotations
-
 import logging
 import time
 import xml.etree.ElementTree as ET
@@ -136,7 +134,7 @@ class SenateClient:
     def close(self) -> None:
         self._client.close()
 
-    def __enter__(self) -> SenateClient:
+    def __enter__(self) -> "SenateClient":
         return self
 
     def __exit__(

--- a/src/concord/text.py
+++ b/src/concord/text.py
@@ -26,8 +26,6 @@ of many articles can trip 429s or 403s. Retries mirror :mod:`concord.api`:
 Retry decisions are logged via :mod:`logging` (logger ``concord.text``).
 """
 
-from __future__ import annotations
-
 import logging
 import time
 from collections.abc import Callable

--- a/tests/_snapshots.py
+++ b/tests/_snapshots.py
@@ -5,8 +5,6 @@ Phase 1, Bills/Votes/etc. from later phases) uses :func:`wrap_snapshot`
 to keep the envelope shape consistent.
 """
 
-from __future__ import annotations
-
 from datetime import datetime
 from typing import Any
 

--- a/tests/test_index_votes.py
+++ b/tests/test_index_votes.py
@@ -1,7 +1,5 @@
 """Tests for the Votes Stage 2 indexer — party-unity computation."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 from concord.models import Vote, VotePosition

--- a/tests/test_models_bills.py
+++ b/tests/test_models_bills.py
@@ -1,7 +1,5 @@
 """Tests for Bill and BillSnapshot models (Phase 2a)."""
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime
 from pathlib import Path

--- a/tests/test_models_members.py
+++ b/tests/test_models_members.py
@@ -12,8 +12,6 @@ payload regardless of which Congress you queried, so a Term row's
 context — see :class:`TestParseMemberTerm`.
 """
 
-from __future__ import annotations
-
 from datetime import UTC, datetime
 from typing import Any
 

--- a/tests/test_models_votes.py
+++ b/tests/test_models_votes.py
@@ -1,7 +1,5 @@
 """Tests for the Vote pydantic models and parse helpers."""
 
-from __future__ import annotations
-
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/test_pipeline_bills.py
+++ b/tests/test_pipeline_bills.py
@@ -1,7 +1,5 @@
 """Tests for the Bills Stage 1 (load) and Stage 2 (index) pipelines."""
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path

--- a/tests/test_pipeline_members.py
+++ b/tests/test_pipeline_members.py
@@ -8,8 +8,6 @@ identical across Congresses (the central scrape-time bug this test
 module exists to lock in).
 """
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path

--- a/tests/test_pipeline_votes.py
+++ b/tests/test_pipeline_votes.py
@@ -1,7 +1,5 @@
 """Tests for the Votes Stage 1 loader (Phase 3a)."""
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime
 from pathlib import Path

--- a/tests/test_scraper_bills.py
+++ b/tests/test_scraper_bills.py
@@ -1,7 +1,5 @@
 """Integration tests for the Bills Stage 0 scraper."""
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime
 from pathlib import Path

--- a/tests/test_scraper_members.py
+++ b/tests/test_scraper_members.py
@@ -5,8 +5,6 @@ captured ``tests/fixtures/api/members/*.json`` fixtures via
 ``httpx.MockTransport``.
 """
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime
 from pathlib import Path

--- a/tests/test_scraper_votes.py
+++ b/tests/test_scraper_votes.py
@@ -1,7 +1,5 @@
 """Integration tests for the Votes Stage 0 scraper (Phase 3a)."""
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime
 from pathlib import Path

--- a/tests/test_senate_xml.py
+++ b/tests/test_senate_xml.py
@@ -5,8 +5,6 @@ process. XML responses are real captures from the live feeds, stored
 under ``tests/fixtures/senate/``.
 """
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from pathlib import Path
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,7 +1,5 @@
 """Smoke tests proving the project skeleton is wired up correctly."""
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime
 from pathlib import Path

--- a/tests/test_storage_bills_sqlite.py
+++ b/tests/test_storage_bills_sqlite.py
@@ -1,7 +1,5 @@
 """Tests for the Bills SQLite storage layer (Phase 2a)."""
 
-from __future__ import annotations
-
 import sqlite3
 from pathlib import Path
 

--- a/tests/test_storage_members_sqlite.py
+++ b/tests/test_storage_members_sqlite.py
@@ -5,8 +5,6 @@ into the new schema, plus the UPSERT-on-bioguide + DELETE-then-INSERT
 contract that keeps the SQL state consistent with the latest snapshot.
 """
 
-from __future__ import annotations
-
 import sqlite3
 from pathlib import Path
 

--- a/tests/test_storage_votes_sqlite.py
+++ b/tests/test_storage_votes_sqlite.py
@@ -1,7 +1,5 @@
 """Tests for the Votes SQLite schema + storage methods (Phase 3a)."""
 
-from __future__ import annotations
-
 import sqlite3
 from pathlib import Path
 

--- a/tests/test_web_bills.py
+++ b/tests/test_web_bills.py
@@ -1,7 +1,5 @@
 """Integration tests for the Bills web routes (Phase 2a)."""
 
-from __future__ import annotations
-
 import json
 import sqlite3
 from datetime import UTC, datetime
@@ -750,7 +748,7 @@ class TestEnrichmentStatusRoute:
 class _StubClient:
     """Stand-in for ``concord.api.Client`` — no network calls made in tests."""
 
-    def __enter__(self) -> _StubClient:
+    def __enter__(self) -> "_StubClient":
         return self
 
     def __exit__(self, *_a: object) -> None:

--- a/tests/test_web_members.py
+++ b/tests/test_web_members.py
@@ -5,8 +5,6 @@ Covers ``/members`` (browse list with chamber/party filters), the
 that surfaces Members alongside Proceedings.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import pytest

--- a/tests/test_web_votes.py
+++ b/tests/test_web_votes.py
@@ -1,7 +1,5 @@
 """Integration tests for the Votes web routes (Phase 3a)."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import pytest

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,7 @@ wheels = [
 
 [[package]]
 name = "congress-concord"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Strip every `from __future__ import annotations` (33 files across `src/` and `tests/`). CONTRIBUTING.md already banned it, but agents kept reintroducing it.
- Convert the five genuine self-referential return types (`Client.__enter__`, `SenateClient.__enter__`, `_StubClient.__enter__`, `Article._check_granule_id_matches_urls`, `Proceeding.build`) to quoted forward refs.
- Add a one-line ban to [CLAUDE.md](CLAUDE.md) pointing at CONTRIBUTING.md.
- Wire two guards so the line can't sneak back in:
  - **pre-commit**: local `pygrep` hook (`no-future-annotations`) in [.pre-commit-config.yaml](.pre-commit-config.yaml).
  - **CI**: grep step in [.github/workflows/ci.yml](.github/workflows/ci.yml) that fails the build on any match in `src tests`.

## Test plan

- [x] `uv run ruff format --check` passes
- [x] `uv run ruff check` passes
- [x] `uv run mypy src` passes
- [x] `uv run pytest` — 637/637 passing
- [x] Verified hook blocks a commit when the forbidden line is reintroduced (both `ruff --fix` and the new pygrep hook fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)