### PR TITLE
refactor: remove all `getattr` from src/ by tightening types

### DIFF
--- a/src/concord/cli/_common.py
+++ b/src/concord/cli/_common.py
@@ -45,7 +45,7 @@ class Progress:
     def __init__(self, enabled: bool, *, stream: IO[str] | None = None) -> None:
         self._stream = stream if stream is not None else sys.stderr
         self._enabled = enabled
-        self._inplace = enabled and getattr(self._stream, "isatty", lambda: False)()
+        self._inplace = enabled and self._stream.isatty()
         self._open = False
 
     def update(self, msg: str) -> None:

--- a/src/concord/embedding.py
+++ b/src/concord/embedding.py
@@ -33,6 +33,8 @@ import time
 from collections.abc import Callable
 from typing import Any, Protocol
 
+import openai
+
 #: Embedding dimension for ``text-embedding-3-small``.
 EMBEDDING_DIM = 1536
 
@@ -142,45 +144,18 @@ class Embedder:
 
     def _create_with_retry(self, batch: list[str]) -> Any:
         """Call ``embeddings.create`` once, retrying indefinitely on 429."""
-        # Lazy import: openai is a runtime dep but we don't want test stubs
-        # to need it on the import path. The Exception type comparison
-        # below falls back to class-name matching when openai isn't loaded.
-        try:
-            import openai  # noqa: PLC0415 — guarded so test stubs don't need openai installed
-
-            rate_limit_exc: type[BaseException] = openai.RateLimitError
-        except ImportError:  # pragma: no cover - openai is a hard dep in prod
-            rate_limit_exc = type("_NeverMatches", (BaseException,), {})
-
-        attempt = 0
         while True:
             try:
                 return self._client.embeddings.create(model=self._model, input=batch)
-            except rate_limit_exc as exc:
-                wait = _retry_after_seconds(exc) + RATE_LIMIT_BUFFER
-                wait = min(wait, MAX_RATE_LIMIT_WAIT)
+            except openai.RateLimitError as exc:
+                wait = min(_retry_after_seconds(exc) + RATE_LIMIT_BUFFER, MAX_RATE_LIMIT_WAIT)
                 _log.info(
                     "openai rate-limited (batch of %d); waiting %.2fs before retry",
                     len(batch),
                     wait,
                 )
                 self._sleep(wait)
-                attempt += 1
-                continue
             except Exception as exc:
-                # Defensive fallback if openai wasn't importable above:
-                # match RateLimitError by class name.
-                if exc.__class__.__name__ == "RateLimitError":
-                    wait = _retry_after_seconds(exc) + RATE_LIMIT_BUFFER
-                    wait = min(wait, MAX_RATE_LIMIT_WAIT)
-                    _log.info(
-                        "openai rate-limited (batch of %d); waiting %.2fs before retry",
-                        len(batch),
-                        wait,
-                    )
-                    self._sleep(wait)
-                    attempt += 1
-                    continue
                 raise EmbeddingError(
                     f"OpenAI embeddings.create failed for batch of {len(batch)} inputs"
                 ) from exc
@@ -189,7 +164,7 @@ class Embedder:
 # -- helpers ---------------------------------------------------------------
 
 
-def _retry_after_seconds(exc: BaseException) -> float:
+def _retry_after_seconds(exc: openai.RateLimitError) -> float:
     """Best-effort extraction of "wait this many seconds" from a 429.
 
     Order of preference:
@@ -198,24 +173,21 @@ def _retry_after_seconds(exc: BaseException) -> float:
     3. Regex over the error message for ``try again in Xms|Xs``
     4. Default: 1.0 second
     """
-    response = getattr(exc, "response", None)
-    headers = getattr(response, "headers", None)
-    if headers is not None:
-        ms = headers.get("retry-after-ms") or headers.get("Retry-After-Ms")
-        if ms is not None:
-            try:
-                return float(ms) / 1000.0
-            except (TypeError, ValueError):
-                pass
-        secs = headers.get("retry-after") or headers.get("Retry-After")
-        if secs is not None:
-            try:
-                return float(secs)
-            except (TypeError, ValueError):
-                pass
+    headers = exc.response.headers
+    ms = headers.get("retry-after-ms")
+    if ms is not None:
+        try:
+            return float(ms) / 1000.0
+        except (TypeError, ValueError):
+            pass
+    secs = headers.get("retry-after")
+    if secs is not None:
+        try:
+            return float(secs)
+        except (TypeError, ValueError):
+            pass
 
-    message = str(exc)
-    match = _RETRY_AFTER_MESSAGE_RE.search(message)
+    match = _RETRY_AFTER_MESSAGE_RE.search(str(exc))
     if match:
         value = float(match.group(1))
         unit = match.group(2).lower()

--- a/src/concord/scraper/bills.py
+++ b/src/concord/scraper/bills.py
@@ -279,12 +279,12 @@ class EnrichStats(NamedTuple):
     sections_skipped: int = 0
 
 
-_ENRICHMENT_FETCHERS: dict[str, str] = {
-    "cosponsors": "get_bill_cosponsors",
-    "actions": "get_bill_actions",
-    "subjects": "get_bill_subjects",
-    "titles": "get_bill_titles",
-    "summaries": "get_bill_summaries",
+_ENRICHMENT_FETCHERS: dict[str, Callable[[Client, int, str, int], dict[str, Any]]] = {
+    "cosponsors": Client.get_bill_cosponsors,
+    "actions": Client.get_bill_actions,
+    "subjects": Client.get_bill_subjects,
+    "titles": Client.get_bill_titles,
+    "summaries": Client.get_bill_summaries,
 }
 
 
@@ -322,9 +322,9 @@ def _enrich_one_bill(
         ):
             skipped += 1
             continue
-        method = getattr(client, _ENRICHMENT_FETCHERS[section])
+        fetcher = _ENRICHMENT_FETCHERS[section]
         try:
-            payload = method(congress, bt, bill_number)
+            payload = fetcher(client, congress, bt, bill_number)
         except Exception as exc:
             _log.warning(
                 "enrichment fetch failed for %s/%s/%s/%s: %s",

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -3,6 +3,8 @@
 from collections.abc import Callable
 from typing import Any
 
+import httpx
+import openai
 import pytest
 
 from concord.embedding import (
@@ -139,31 +141,16 @@ def _make_rate_limit_error(
     *,
     retry_after_ms: str | None = None,
     retry_after: str | None = None,
-) -> Exception:
-    """Build an exception that looks enough like ``openai.RateLimitError``.
-
-    We don't import ``openai`` in tests; the Embedder falls back to matching
-    by class name when openai isn't loaded. The exception carries a
-    ``.response.headers`` attribute, mirroring the SDK's real shape.
-    """
-
-    class _Headers(dict[str, str]):
-        pass
-
-    class _Response:
-        def __init__(self) -> None:
-            self.headers = _Headers()
-            if retry_after_ms is not None:
-                self.headers["retry-after-ms"] = retry_after_ms
-            if retry_after is not None:
-                self.headers["retry-after"] = retry_after
-
-    class RateLimitError(Exception):
-        def __init__(self, msg: str) -> None:
-            super().__init__(msg)
-            self.response = _Response()
-
-    return RateLimitError(message)
+) -> openai.RateLimitError:
+    """Build a real ``openai.RateLimitError`` for retry tests."""
+    headers: dict[str, str] = {}
+    if retry_after_ms is not None:
+        headers["retry-after-ms"] = retry_after_ms
+    if retry_after is not None:
+        headers["retry-after"] = retry_after
+    request = httpx.Request("POST", "https://api.openai.com/v1/embeddings")
+    response = httpx.Response(429, headers=headers, request=request)
+    return openai.RateLimitError(message, response=response, body=None)
 
 
 class _RateLimitedThenOk:


### PR DESCRIPTION
## Summary

Three `getattr` call sites in `src/` were each a symptom of a function accepting a type broader than what its caller actually passes. Tightening the signatures lets the type system enforce what we already know is true, and the `getattr`s disappear.

### 1. `cli/_common.py` — pure superstition
```diff
- self._inplace = enabled and getattr(self._stream, "isatty", lambda: False)()
+ self._inplace = enabled and self._stream.isatty()
```
`IO[str]` already guarantees `isatty()`. No type narrowing needed.

### 2. `scraper/bills.py` — string-keyed method dispatch
`_ENRICHMENT_FETCHERS` was a `dict[str, str]` mapping section name to `Client` method *name*, then `getattr(client, name)` at the call site. mypy had zero visibility into the dispatch — a rename would only surface at runtime.

Now it's `dict[str, Callable[[Client, int, str, int], dict[str, Any]]]` holding unbound `Client.get_bill_*` methods. Renaming any of them breaks at type-check time.

### 3. `embedding.py` — the biggest payoff
`_retry_after_seconds(exc: BaseException)` used `getattr` to feel for `response.headers`. That signature existed because `_create_with_retry` lazy-imported `openai`, built a `_NeverMatches` placeholder type on `ImportError`, and had a second `except Exception` branch that matched `RateLimitError` by class name as a fallback.

All of this was working around a fictional world where `openai` might not be importable. It's a hard dep (`openai>=2.38.0`). After hoisting the import:

- `_retry_after_seconds(exc: openai.RateLimitError)` — narrowed signature, direct `exc.response.headers.get(...)` access.
- `_create_with_retry` collapses to one `except openai.RateLimitError` + the existing wrap-as-`EmbeddingError` branch.
- Deleted: `_NeverMatches` placeholder, `# pragma: no cover` ImportError branch, duplicate class-name-match fallback, unused `attempt` counter.
- Tests now construct a real `openai.RateLimitError` wrapping an `httpx.Response` instead of a hand-rolled lookalike.

Net: `src/` now has **zero** `getattr`. Three signatures say what they actually mean.

## Test plan

- [x] `grep -rn getattr src/` returns nothing
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run mypy src` passes
- [x] `uv run pytest` — 637/637 passing (including the rate-limit retry tests against the real `openai.RateLimitError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)