### PR TITLE
feat(web): collapse identical adjacent terms in Member profile

### DIFF
--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -399,6 +399,7 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR
             ),
             None,
         )
+        term_groups = search_mod.collapse_term_history(terms)
         sponsored = search_mod.sponsored_bills_for_member(db, bioguide_id, limit=25)
         sponsored_total = search_mod.count_sponsored_bills_for_member(db, bioguide_id)
         cosponsored = search_mod.cosponsored_bills_for_member(db, bioguide_id, limit=25)
@@ -416,6 +417,7 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR
             {
                 "member": member,
                 "terms": terms,
+                "term_groups": term_groups,
                 "current_term": current_term,
                 "sponsored_bills": sponsored,
                 "sponsored_bills_total": sponsored_total,

--- a/src/concord/web/search.py
+++ b/src/concord/web/search.py
@@ -364,6 +364,64 @@ def terms_for_member(db: sqlite3.Connection, bioguide_id: str) -> list[dict[str,
     return [dict(r) for r in rows]
 
 
+def collapse_term_history(
+    terms: list[dict[str, Any]],
+    today: date | None = None,
+) -> list[dict[str, Any]]:
+    """Collapse adjacent Terms that match on chamber/state/district/party.
+
+    Input is the raw term list from :func:`terms_for_member` (sorted by
+    congress DESC). Adjacent rows that share chamber, state, district,
+    and party become a single group spanning a Congress range and the
+    corresponding year range. The displayed end year is capped at the
+    current calendar year so a Term ending Jan 3 of the next Congress
+    doesn't read as already-served-through-that-year.
+    """
+    if not terms:
+        return []
+    today = today or date.today()
+    current_year = today.year
+
+    def _year(s: str | None) -> int | None:
+        return int(s[:4]) if s else None
+
+    def _key(t: dict[str, Any]) -> tuple[str, str, int | None, str | None]:
+        return (t["chamber"], t["state"], t.get("district"), t.get("party"))
+
+    groups: list[dict[str, Any]] = []
+    for t in terms:
+        ys = _year(t["start_date"])
+        ye = _year(t["end_date"])
+        if groups and _key(t) == groups[-1]["_key"]:
+            g = groups[-1]
+            g["congress_min"] = min(g["congress_min"], t["congress"])
+            g["congress_max"] = max(g["congress_max"], t["congress"])
+            if ys is not None:
+                g["year_min"] = ys if g["year_min"] is None else min(g["year_min"], ys)
+            if ye is not None:
+                g["year_max"] = ye if g["year_max"] is None else max(g["year_max"], ye)
+        else:
+            groups.append(
+                {
+                    "_key": _key(t),
+                    "chamber": t["chamber"],
+                    "state": t["state"],
+                    "district": t.get("district"),
+                    "party": t.get("party"),
+                    "congress_min": t["congress"],
+                    "congress_max": t["congress"],
+                    "year_min": ys,
+                    "year_max": ye,
+                }
+            )
+
+    for g in groups:
+        if g["year_max"] is not None and g["year_max"] > current_year:
+            g["year_max"] = current_year
+        del g["_key"]
+    return groups
+
+
 # -- Bills (Phase 2a) -------------------------------------------------------
 
 

--- a/src/concord/web/templates/members/profile.html
+++ b/src/concord/web/templates/members/profile.html
@@ -58,7 +58,7 @@
 
     <section>
       <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Term history</h2>
-      {% if terms %}
+      {% if term_groups %}
         <table class="w-full text-sm">
           <thead class="text-left text-xs uppercase tracking-wide text-stone-500">
             <tr>
@@ -71,16 +71,21 @@
             </tr>
           </thead>
           <tbody>
-            {% for t in terms %}
+            {% for g in term_groups %}
               <tr class="border-t border-stone-100">
-                <td class="py-1 pr-3">{{ t.congress }}</td>
-                <td class="py-1 pr-3">{{ t.chamber|capitalize }}</td>
-                <td class="py-1 pr-3">{{ t.state }}</td>
-                <td class="py-1 pr-3">{% if t.district %}{{ "%02d"|format(t.district) }}{% else %}—{% endif %}</td>
-                <td class="py-1 pr-3">{{ t.party or "—" }}</td>
+                <td class="py-1 pr-3">
+                  {%- if g.congress_min == g.congress_max -%}
+                    {{ g.congress_min }}
+                  {%- else -%}
+                    {{ g.congress_min }}&ndash;{{ g.congress_max }}
+                  {%- endif -%}
+                </td>
+                <td class="py-1 pr-3">{{ g.chamber|capitalize }}</td>
+                <td class="py-1 pr-3">{{ g.state }}</td>
+                <td class="py-1 pr-3">{% if g.district %}{{ "%02d"|format(g.district) }}{% else %}—{% endif %}</td>
+                <td class="py-1 pr-3">{{ g.party or "—" }}</td>
                 <td class="py-1 pr-3 text-stone-500">
-                  {{ t.start_date[:4] if t.start_date else "?" }} –
-                  {{ t.end_date[:4] if t.end_date else "present" }}
+                  {{ g.year_min or "?" }} &ndash; {{ g.year_max or "present" }}
                 </td>
               </tr>
             {% endfor %}

--- a/tests/test_web_members.py
+++ b/tests/test_web_members.py
@@ -5,6 +5,7 @@ Covers ``/members`` (browse list with chamber/party filters), the
 that surfaces Members alongside Proceedings.
 """
 
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,7 @@ from concord.models import Member, Term
 from concord.pipeline.index_members import index as index_members
 from concord.storage.sqlite import SqliteStorage
 from concord.web.app import create_app
+from concord.web.search import collapse_term_history
 
 
 class _StubData:
@@ -170,6 +172,105 @@ class TestMemberProfile:
     def test_unknown_bioguide_404(self, client: TestClient) -> None:
         resp = client.get("/members/X999999")
         assert resp.status_code == 404
+
+
+class TestCollapseTermHistory:
+    """Unit tests for the term-history collapse + year-cap helper."""
+
+    def test_empty(self) -> None:
+        assert collapse_term_history([]) == []
+
+    def test_collapses_consecutive_identical_terms(self) -> None:
+        terms = [
+            {
+                "congress": 119,
+                "chamber": "senate",
+                "state": "AK",
+                "district": None,
+                "party": "Republican",
+                "start_date": "2025-01-03",
+                "end_date": "2027-01-03",
+            },
+            {
+                "congress": 118,
+                "chamber": "senate",
+                "state": "AK",
+                "district": None,
+                "party": "Republican",
+                "start_date": "2023-01-03",
+                "end_date": "2025-01-03",
+            },
+            {
+                "congress": 117,
+                "chamber": "senate",
+                "state": "AK",
+                "district": None,
+                "party": "Republican",
+                "start_date": "2021-01-03",
+                "end_date": "2023-01-03",
+            },
+        ]
+        groups = collapse_term_history(terms, today=date(2026, 5, 28))
+        assert len(groups) == 1
+        g = groups[0]
+        assert g["congress_min"] == 117
+        assert g["congress_max"] == 119
+        assert g["year_min"] == 2021
+        # Capped at the current year (2026), not the term's 2027 end_date.
+        assert g["year_max"] == 2026
+
+    def test_splits_when_chamber_changes(self) -> None:
+        terms = [
+            {
+                "congress": 119,
+                "chamber": "senate",
+                "state": "NY",
+                "district": None,
+                "party": "Democratic",
+                "start_date": "2025-01-03",
+                "end_date": "2027-01-03",
+            },
+            {
+                "congress": 118,
+                "chamber": "house",
+                "state": "NY",
+                "district": 14,
+                "party": "Democratic",
+                "start_date": "2023-01-03",
+                "end_date": "2025-01-03",
+            },
+        ]
+        groups = collapse_term_history(terms, today=date(2026, 5, 28))
+        assert len(groups) == 2
+        assert groups[0]["chamber"] == "senate"
+        assert groups[1]["chamber"] == "house"
+        assert groups[1]["district"] == 14
+
+    def test_splits_when_party_changes(self) -> None:
+        terms = [
+            {
+                "congress": 109,
+                "chamber": "senate",
+                "state": "VT",
+                "district": None,
+                "party": "Independent",
+                "start_date": "2005-01-03",
+                "end_date": "2007-01-03",
+            },
+            {
+                "congress": 108,
+                "chamber": "senate",
+                "state": "VT",
+                "district": None,
+                "party": "Republican",
+                "start_date": "2003-01-03",
+                "end_date": "2005-01-03",
+            },
+        ]
+        groups = collapse_term_history(terms, today=date(2026, 5, 28))
+        assert len(groups) == 2
+        assert groups[0]["party"] == "Independent"
+        assert groups[1]["party"] == "Republican"
 
 
 class TestFederatedSearch:


### PR DESCRIPTION
## Summary
- Collapse adjacent Terms in the Member profile's Term History when they share `(chamber, state, district, party)`, showing a Congress range (e.g. `110–119`) and combined year range on one line.
- Cap the displayed end year at the current calendar year, so a current Term ending Jan 3 of the next Congress doesn't read as "active through next year" (e.g. Murkowski's 119th Congress term now shows `2025 – 2026` in May 2026, not `2025 – 2027`).
- New row starts whenever chamber, state, district, or party changes — preserves the historical signal the table is there to provide.

## Test plan
- [x] `uv run pytest tests/test_web_members.py` — 15 passed (4 new unit tests covering empty input, collapse + year cap, chamber split, party split).
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy src` clean.
- [ ] Hit `/members/M001153` locally and confirm Murkowski's 110–119 Senate/AK/Republican history renders as a single row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)