### PR TITLE
feat(web): add Capitol columns favicon

### DIFF
--- a/src/concord/web/static/favicon.svg
+++ b/src/concord/web/static/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="5" fill="#faf9f7"/>
+  <!-- Pediment (solid, matches the body weight) -->
+  <polygon points="16,3.5 27.5,11 4.5,11" fill="#1a1a2e"/>
+  <!-- Architrave -->
+  <rect x="4.5" y="11" width="23" height="2.4" rx="0.4" fill="#1a1a2e"/>
+  <!-- Three columns -->
+  <rect x="7.3" y="13.9" width="3.4" height="10.9" fill="#1a1a2e"/>
+  <rect x="14.3" y="13.9" width="3.4" height="10.9" fill="#1a1a2e"/>
+  <rect x="21.3" y="13.9" width="3.4" height="10.9" fill="#1a1a2e"/>
+  <!-- Stepped base -->
+  <rect x="4.5" y="24.8" width="23" height="2.2" rx="0.4" fill="#1a1a2e"/>
+  <rect x="3" y="27" width="26" height="2.4" rx="0.6" fill="#1a1a2e"/>
+</svg>

--- a/src/concord/web/templates/base.html
+++ b/src/concord/web/templates/base.html
@@ -6,6 +6,7 @@
   <title>{% block title %}Concord — Congressional Record Search{% endblock %}</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body class="bg-stone-50 text-stone-900 antialiased">


### PR DESCRIPTION
## What

Adds a favicon: a classical temple silhouette (pediment + three columns + stepped base) in navy on a slightly off-white tile.

- New `src/concord/web/static/favicon.svg`
- Wired into `base.html` via `<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">`

## Packaging

No packaging changes were needed:
- **Hatchling** — `packages = ["src/concord"]` already bundles non-Python assets under `src/concord/`, so the SVG ships in the wheel.
- **Dockerfile** — `COPY src/ src/` already copies the whole tree into the image.

## Notes

The icon is a single inline SVG (no raster fallbacks). Three columns read as a temple/legislature rather than the "doorway" look two columns gave. The off-white tile keeps the column gaps and rounded corners legible at 16px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)