### PR TITLE
fix(scraper): escalate and persist congress.gov throttle backoff

### DIFF
--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -34,7 +34,7 @@ from . import __version__
 from .models import Article, Issue
 
 API_BASE = "https://api.congress.gov/v3"
-USER_AGENT = f"concord/{__version__} (+https://github.com/johnmarcampbell/concord)"
+USER_AGENT = f"concord/{__version__}"
 ENV_API_KEY = "CONGRESS_API_KEY"
 
 #: Per-page size when walking the ``/articles`` endpoint. The API maxes out

--- a/src/concord/scraper/proceedings.py
+++ b/src/concord/scraper/proceedings.py
@@ -13,10 +13,10 @@ from datetime import date
 import httpx
 import typer
 
-from concord.api import ApiError, Client
+from concord.api import USER_AGENT, ApiError, Client
 from concord.pipeline.load_proceedings import ProgressEvent, PullResult, pull
 from concord.storage.base import Storage
-from concord.text import fetch_text
+from concord.text import AdaptiveThrottle, fetch_text
 
 #: Per-request timeout (seconds) for fetching article text from congress.gov.
 #: The default httpx timeout (5s) is too aggressive for occasional slow
@@ -51,7 +51,15 @@ def scrape(
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
 
-    http_client = httpx.Client(timeout=TEXT_FETCH_TIMEOUT)
+    # Identify ourselves honestly: the default httpx UA ("python-httpx/…") is a
+    # known trigger for the Cloudflare bot management in front of congress.gov,
+    # which surfaces as the 403s that the AdaptiveThrottle then has to absorb.
+    # Matching the UA the api/senate clients already send cuts those at source.
+    http_client = httpx.Client(timeout=TEXT_FETCH_TIMEOUT, headers={"User-Agent": USER_AGENT})
+
+    # One throttle for the whole pull: congress.gov rate-limits per client across
+    # every URL, so backoff state must persist across fetches, not reset per URL.
+    throttle = AdaptiveThrottle()
 
     try:
         with api_client:
@@ -59,7 +67,7 @@ def scrape(
                 start,
                 end,
                 client=api_client,
-                fetch=lambda url: fetch_text(url, http_client),
+                fetch=lambda url: fetch_text(url, http_client, throttle=throttle),
                 storage=storage,
                 limit=limit,
                 progress=progress,

--- a/src/concord/senate_xml.py
+++ b/src/concord/senate_xml.py
@@ -34,7 +34,7 @@ from . import __version__
 
 _log = logging.getLogger("concord.senate_xml")
 
-USER_AGENT = f"concord/{__version__} (+https://github.com/johnmarcampbell/concord)"
+USER_AGENT = f"concord/{__version__}"
 
 #: Base URL for senate.gov roll-call LIS feeds.
 SENATE_LIS_BASE = "https://www.senate.gov/legislative/LIS"

--- a/src/concord/text.py
+++ b/src/concord/text.py
@@ -13,17 +13,29 @@ Retry policy
 ------------
 
 The ``www.congress.gov`` HTML tier is a separate service from
-``api.congress.gov`` and has its own (undocumented) rate limit — bulk pulls
-of many articles can trip 429s or 403s. Retries mirror :mod:`concord.api`:
+``api.congress.gov``: it sits behind Cloudflare and has its own (undocumented)
+rate limit. A bulk pull of many articles trips two distinct Cloudflare signals,
+and the limit is enforced **per client across every URL**, not per request —
+so the backoff state lives on a single :class:`AdaptiveThrottle` shared by all
+fetches in a run, not inside one URL's retry loop (see ADR 0002's "JSONL is
+canonical, re-runs are cheap" — being throttled is a wait, never a data loss):
 
-* HTTP 403: congress.gov uses 403 as a rate-limit signal in addition to 429.
-  Treated identically to 429: retry **indefinitely** with exponential backoff.
-* HTTP 429: retry **indefinitely**, honoring ``Retry-After`` and otherwise
-  backing off exponentially capped at :data:`MAX_BACKOFF`.
-* HTTP 5xx and transport errors (DNS, timeout, connection reset): retry up
-  to :data:`MAX_5XX_RETRIES` times before surfacing a :class:`TextFetchError`.
+* HTTP 429 (Cloudflare rate-limit rule): typically carries a ``Retry-After``;
+  we honor it. Retry **indefinitely**.
+* HTTP 403 (Cloudflare bot/WAF block): a block page with **no** ``Retry-After``,
+  so there is no server hint to honor. Treated as the same throttle signal as
+  429 and retried **indefinitely**, but the wait comes from our own adaptive
+  backoff. This is the case a flat retry handles badly, which is why the
+  throttle escalates and persists across URLs rather than resetting per fetch.
+* HTTP 5xx and transport errors (DNS, timeout, connection reset): genuine
+  faults — retry up to :data:`MAX_5XX_RETRIES` times with exponential backoff
+  before surfacing a :class:`TextFetchError`. These are tracked per fetch and
+  are kept separate from throttling, which never counts against that budget.
 
-Retry decisions are logged via :mod:`logging` (logger ``concord.text``).
+Both throttle signals escalate one :class:`AdaptiveThrottle` level per hit and
+relax one level per :data:`_DECAY_AFTER_SUCCESSES` clean fetches, so a steady
+drip of "one 403 per URL" ratchets the backoff up instead of oscillating at the
+floor. Retry decisions are logged via :mod:`logging` (logger ``concord.text``).
 """
 
 import logging
@@ -97,19 +109,100 @@ class _PreExtractor(HTMLParser):
         return "".join(self._chunks).strip()
 
 
+#: Consecutive clean fetches required to relax the throttle one level. Decay is
+#: deliberately slower than the one-level-per-throttle climb so a steady drip of
+#: "one 403 per URL" still ratchets the backoff up rather than oscillating at the
+#: 1s floor (a single success would otherwise cancel a single 403).
+_DECAY_AFTER_SUCCESSES = 3
+
+#: Cap on the throttle level. At this level the exponential backoff has already
+#: saturated :data:`MAX_BACKOFF`; capping bounds how long recovery takes after a
+#: sustained block (``_MAX_THROTTLE_LEVEL * _DECAY_AFTER_SUCCESSES`` clean
+#: fetches to fully relax).
+_MAX_THROTTLE_LEVEL = 7
+
+
+class AdaptiveThrottle:
+    """Client-level adaptive backoff shared across every article fetch in a run.
+
+    congress.gov enforces its limit per client, not per request, so a single
+    instance is threaded through all :func:`fetch_text` calls: the level climbs
+    one step per 403/429 and relaxes one step per :data:`_DECAY_AFTER_SUCCESSES`
+    clean fetches. :meth:`pace` proactively slows the *next* request once the
+    level is raised (so a recovered fetch doesn't immediately re-trip the
+    limit); :meth:`penalize` performs the post-throttle retry wait, honoring a
+    server ``Retry-After`` when present and otherwise backing off exponentially.
+
+    Throttle waits never count against the 5xx fault budget — being blocked is a
+    wait condition, not a fault. ``sleep`` is injectable so tests don't pay real
+    wall time.
+    """
+
+    def __init__(self, *, sleep: Callable[[float], None] = time.sleep) -> None:
+        self._sleep = sleep
+        self._level = 0
+        self._ok_streak = 0
+
+    @property
+    def level(self) -> int:
+        """Current throttle level (0 when healthy). Exposed for tests/logging."""
+        return self._level
+
+    def pace(self) -> None:
+        """Wait the current throttle delay before a request (no-op when healthy)."""
+        if self._level > 0:
+            self._sleep(self._delay())
+
+    def penalize(self, retry_after: float | None) -> float:
+        """Record a throttle response, sleep the retry wait, return the delay used.
+
+        Honors ``retry_after`` when the server supplied one (Cloudflare 429s do);
+        otherwise falls back to the exponential schedule for the newly raised
+        level (Cloudflare 403s don't).
+        """
+        self._level = min(self._level + 1, _MAX_THROTTLE_LEVEL)
+        self._ok_streak = 0
+        delay = retry_after if retry_after is not None else self._delay()
+        self._sleep(delay)
+        return delay
+
+    def recover(self) -> None:
+        """Note a clean fetch; relax one level after enough consecutive successes."""
+        if self._level == 0:
+            return
+        self._ok_streak += 1
+        if self._ok_streak >= _DECAY_AFTER_SUCCESSES:
+            self._level -= 1
+            self._ok_streak = 0
+
+    def _delay(self) -> float:
+        """Exponential backoff for the current level, capped at :data:`MAX_BACKOFF`.
+
+        Level 1 → 1s, 2 → 2s, 3 → 4s, … saturating at the cap.
+        """
+        return min(_BACKOFF_BASE ** (self._level - 1), MAX_BACKOFF)
+
+
 def fetch_text(
     url: str,
     client: httpx.Client,
     *,
+    throttle: AdaptiveThrottle | None = None,
     sleep: Callable[[float], None] = time.sleep,
 ) -> str:
     """Fetch an article URL and return its plain text.
 
     The caller owns the :class:`httpx.Client` (so connection pooling, custom
     transports, and timeout policy are external concerns). Redirects are
-    followed automatically. Transient failures (429, 5xx, transport errors)
-    are retried per the module-level policy; ``sleep`` is injectable so tests
-    don't pay real wall time.
+    followed automatically. Transient failures (429, 403, 5xx, transport
+    errors) are retried per the module-level policy.
+
+    ``throttle`` is the shared :class:`AdaptiveThrottle` carrying rate-limit
+    state across every fetch in a run; pass one instance for a whole pull so
+    throttling congress.gov slows *subsequent* URLs too. When omitted, a fresh
+    per-call throttle is used (fine for one-off fetches and tests). ``sleep`` is
+    injectable so tests don't pay real wall time; it also seeds the default
+    throttle's clock.
 
     Raises :class:`TextFetchError` on:
 
@@ -117,7 +210,7 @@ def fetch_text(
     - transport-level failures after retries are exhausted (``status_code`` is ``None``)
     - HTML that contains no ``<pre>`` block (``status_code`` is ``None``)
     """
-    response = _get_with_retry(url, client, sleep)
+    response = _get_with_retry(url, client, throttle or AdaptiveThrottle(sleep=sleep), sleep)
 
     extractor = _PreExtractor()
     extractor.feed(response.text)
@@ -130,8 +223,13 @@ def fetch_text(
 def _get_with_retry(
     url: str,
     client: httpx.Client,
+    throttle: AdaptiveThrottle,
     sleep: Callable[[float], None],
 ) -> httpx.Response:
+    # Proactively wait out any backoff carried over from earlier URLs before the
+    # first attempt — congress.gov rate-limits per client, so hammering the next
+    # URL immediately after a throttle just re-trips the limit.
+    throttle.pace()
     transient_attempts = 0
     while True:
         try:
@@ -150,23 +248,20 @@ def _get_with_retry(
 
         status = response.status_code
 
-        if status == HTTP_FORBIDDEN:
-            # congress.gov returns 403 instead of 429 when rate-limiting bulk
-            # fetches. Treat it the same as 429: back off and retry indefinitely
-            # rather than surfacing a permanent failure. Retries do not count
-            # against transient_attempts — being throttled is a wait condition,
-            # not a fault.
-            delay = _retry_after_seconds(response) or _backoff_seconds(transient_attempts)
-            _log.warning("403 from %s (rate-limited?); backing off %.1fs before retry", url, delay)
-            sleep(delay)
-            continue
-
-        if status == HTTP_TOO_MANY_REQUESTS:
-            delay = _retry_after_seconds(response) or _backoff_seconds(transient_attempts)
-            _log.warning("429 from %s; backing off %.1fs before retry", url, delay)
-            sleep(delay)
-            # 429 retries do not increment transient_attempts — rate-limited
-            # is a wait condition, not a fault.
+        if status in (HTTP_FORBIDDEN, HTTP_TOO_MANY_REQUESTS):
+            # Both are Cloudflare throttle signals on this tier (403 = bot/WAF
+            # block, no Retry-After; 429 = rate-limit rule, usually with one).
+            # Escalate the shared throttle and retry indefinitely. Throttle waits
+            # do not increment transient_attempts — being blocked is a wait
+            # condition, not a fault, and must not burn the 5xx budget.
+            delay = throttle.penalize(_retry_after_seconds(response))
+            _log.warning(
+                "%d from %s (rate-limited?); backing off %.1fs before retry (level %d)",
+                status,
+                url,
+                delay,
+                throttle.level,
+            )
             continue
 
         if HTTP_SERVER_ERROR_MIN <= status < HTTP_SERVER_ERROR_MAX:
@@ -195,6 +290,7 @@ def _get_with_retry(
                 status_code=status,
             )
 
+        throttle.recover()
         return response
 
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import httpx
 import pytest
 
-from concord.text import MAX_BACKOFF, TextFetchError, fetch_text
+from concord.text import (
+    MAX_BACKOFF,
+    AdaptiveThrottle,
+    TextFetchError,
+    fetch_text,
+)
 
 
 def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
@@ -156,8 +161,9 @@ class TestFetchTextRateLimit:
         with _client(lambda r: next(responses)) as client:
             text = fetch_text(SAMPLE_URL, client, sleep=slept.append)
         assert text == "after backoff"
-        # Two 429s -> two sleeps before the success.
-        assert len(slept) == 2
+        # Two 429s -> two sleeps, and the backoff *escalates* (1s, then 2s)
+        # rather than sitting at a flat 1s — the bug this fix exists for.
+        assert slept == [1.0, 2.0]
 
     def test_429_honors_retry_after_header(self) -> None:
         responses = iter(
@@ -204,7 +210,9 @@ class TestFetchTextRateLimit:
         with _client(lambda r: next(responses)) as client:
             text = fetch_text(SAMPLE_URL, client, sleep=slept.append)
         assert text == "after 403 backoff"
-        assert len(slept) == 2
+        # 403s escalate identically to 429s (1s, then 2s) — congress.gov's 403
+        # carries no Retry-After, so our own escalating backoff is all we have.
+        assert slept == [1.0, 2.0]
 
     def test_403_honors_retry_after_header(self) -> None:
         responses = iter(
@@ -225,6 +233,80 @@ class TestFetchTextRateLimit:
         with _client(lambda r: next(responses)) as client:
             text = fetch_text(SAMPLE_URL, client, sleep=lambda _s: None)
         assert text == "finally"
+
+
+class TestAdaptiveThrottle:
+    """The client-level backoff that persists across URLs in a run."""
+
+    def test_escalates_and_recovers(self) -> None:
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append)
+
+        # Healthy: pacing is a no-op.
+        throttle.pace()
+        assert slept == []
+        assert throttle.level == 0
+
+        # Each throttle hit escalates the backoff and the level.
+        assert throttle.penalize(None) == 1.0
+        assert throttle.penalize(None) == 2.0
+        assert throttle.penalize(None) == 4.0
+        assert throttle.level == 3
+
+        # A Retry-After header overrides the schedule but still escalates level.
+        assert throttle.penalize(30.0) == 30.0
+        assert throttle.level == 4
+        assert slept == [1.0, 2.0, 4.0, 30.0]
+
+        # Clean fetches relax one level only after _DECAY_AFTER_SUCCESSES of them,
+        # so a single success can't cancel a throttle.
+        throttle.recover()
+        throttle.recover()
+        assert throttle.level == 4
+        throttle.recover()
+        assert throttle.level == 3
+
+    def test_level_and_delay_are_capped(self) -> None:
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append)
+        for _ in range(20):
+            throttle.penalize(None)
+        # Level saturates and the per-wait delay never exceeds MAX_BACKOFF.
+        assert throttle.level == 7
+        assert throttle.penalize(None) == MAX_BACKOFF
+        assert max(slept) == MAX_BACKOFF
+
+    def test_backoff_persists_across_urls(self) -> None:
+        # A shared throttle threaded through two fetches: the first URL's 403s
+        # leave the level raised, so the second URL is *paced* before its very
+        # first request — even though that request would have succeeded.
+        responses = iter(
+            [
+                httpx.Response(403),
+                httpx.Response(403),
+                _ok("<pre>first</pre>"),
+                _ok("<pre>second</pre>"),
+            ]
+        )
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append)
+        with _client(lambda r: next(responses)) as client:
+            first = fetch_text(SAMPLE_URL, client, throttle=throttle)
+            second = fetch_text(SAMPLE_URL, client, throttle=throttle)
+        assert (first, second) == ("first", "second")
+        # URL 1: penalize 1s, 2s (climbs to level 2). URL 2: pace 2s up front.
+        assert slept == [1.0, 2.0, 2.0]
+        assert throttle.level == 2
+
+    def test_per_call_throttle_does_not_leak_state(self) -> None:
+        # Omitting `throttle` gives each call a fresh one — no cross-call pacing.
+        responses = iter([httpx.Response(403), _ok("<pre>a</pre>"), _ok("<pre>b</pre>")])
+        slept: list[float] = []
+        with _client(lambda r: next(responses)) as client:
+            fetch_text(SAMPLE_URL, client, sleep=slept.append)
+            fetch_text(SAMPLE_URL, client, sleep=slept.append)
+        # Only the first call's single 403 slept; the second starts fresh (no pace).
+        assert slept == [1.0]
 
 
 # -- redirect handling --------------------------------------------------------


### PR DESCRIPTION
## Why

A Proceedings scrape was getting a wall of `403 … backing off 1.0s before retry` from `www.congress.gov`. Investigation surfaced two bugs in the article-text retry path plus a contributing factor.

congress.gov's HTML tier sits behind **Cloudflare** and rate-limits **per client across every URL**:
- **429** (rate-limit rule) ships a `Retry-After` — we honored it (the lone `60.0s` line in the logs).
- **403** (bot/WAF block) has **no** `Retry-After` — and that path was broken.

## The bugs

1. **The "exponential" backoff never escalated.** `_backoff_seconds` is driven by `transient_attempts`, but that counter is deliberately never incremented for throttle responses (so they don't burn the 5xx fault budget). Pinned at `0`, every throttle wait was `2.0**0 = 1.0s`, flat, forever. The docstring's "exponential backoff capped at 60s" only ever applied to interleaved 5xx errors. It hid because the test asserted only `len(slept)`, never the values.
2. **Backoff state was per-URL.** It lived inside one `_get_with_retry` call, so every new URL reset to `1.0s` — but the limit is per *client*, so a per-URL backoff can't slow the aggregate request rate.

## The fix (`text.py` tier only)

- **`AdaptiveThrottle`** — one instance shared across every fetch in a run. Climbs one level per 403/429 (`1→2→4→…→60s`), relaxes one level per `_DECAY_AFTER_SUCCESSES` (3) clean fetches — slower than the climb, so a steady "one 403 per URL" drip ratchets *up* instead of oscillating at the floor — and `pace()`s the next request once raised so a recovered fetch doesn't immediately re-trip the limit. Honors `Retry-After` when present, falls back to the schedule when absent. Throttle waits still don't count against the 5xx budget.
- **Honest, minimal User-Agent** — the text client was the only one of the three HTTP clients defaulting to `python-httpx/…` (a Cloudflare bot-management trigger); it now sends the shared UA, trimmed to a bare `concord/<version>` (no repo URL / handle).

## Deliberately out of scope

`api.py`'s flat 429 backoff is unchanged: api.congress.gov has a generous documented limit and always sends `Retry-After`, and [test_api.py](tests/test_api.py) documents the flat behavior as intentional.

## Tests

`test_text.py` strengthened to assert backoff **values** (the exact spot the bug lived), plus new `TestAdaptiveThrottle` coverage: escalation, level/delay caps, `Retry-After` override, cross-URL persistence, and per-call isolation when no shared throttle is passed.

All four CI checks pass locally: `ruff format --check`, `ruff check`, `mypy src`, `pytest` (644 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)