### PR TITLE
refactor(web): dedupe bill-card markup and progressive-disclosure blocks

### DIFF
--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -111,6 +111,21 @@ def _read_enrichment_flag(raw: str | None) -> bool:
     return raw.strip().lower() in _ENRICHMENT_FLAG_TRUTHY
 
 
+def _resolve_top_bills(db: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Resolve CURATED_TOP_BILLS against the local store, in curated order.
+
+    Degrades gracefully: any curated bill missing from the store is skipped.
+    Shared by the landing page (``/``) and the bills index (``/bills``).
+    """
+    keys = [(c.congress, c.bill_type, c.bill_number) for c in CURATED_TOP_BILLS]
+    resolved = search_mod.get_curated_bills(db, keys)
+    return [
+        {"bill": hit, "label": entry.label, "blurb": entry.blurb}
+        for entry in CURATED_TOP_BILLS
+        if (hit := resolved.get((entry.congress, entry.bill_type, entry.bill_number))) is not None
+    ]
+
+
 def create_app(
     db_path: Path | str,
     *,
@@ -234,23 +249,14 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR
     ) -> Response:
         # Bills are the headline entity, so the landing page leads with them
         # (curated Top Bills + recently-active bills) rather than an empty
-        # search prompt. The curated set degrades gracefully: any bill not in
-        # the local store is skipped.
-        keys = [(c.congress, c.bill_type, c.bill_number) for c in CURATED_TOP_BILLS]
-        resolved = search_mod.get_curated_bills(db, keys)
-        top_bills: list[dict[str, Any]] = []
-        for entry in CURATED_TOP_BILLS:
-            hit = resolved.get((entry.congress, entry.bill_type, entry.bill_number))
-            if hit is None:
-                continue
-            top_bills.append({"bill": hit, "label": entry.label, "blurb": entry.blurb})
+        # search prompt.
         recent_bills, bills_total = search_mod.list_bills(db, limit=6, offset=0)
         return templates.TemplateResponse(  # type: ignore[no-any-return]
             request,
             "index.html",
             {
                 "query": "",
-                "top_bills": top_bills[:6],
+                "top_bills": _resolve_top_bills(db),
                 "recent_bills": recent_bills,
                 "bills_total": bills_total,
             },
@@ -501,22 +507,7 @@ def _register_routes(app: FastAPI, limiter: Limiter) -> None:  # noqa: C901, PLR
             and congress is None
             and not sponsor
         )
-        top_bills: list[dict[str, Any]] = []
-        if is_landing:
-            keys = [(c.congress, c.bill_type, c.bill_number) for c in CURATED_TOP_BILLS]
-            resolved = search_mod.get_curated_bills(db, keys)
-            for entry in CURATED_TOP_BILLS:
-                key = (entry.congress, entry.bill_type, entry.bill_number)
-                hit = resolved.get(key)
-                if hit is None:
-                    continue
-                top_bills.append(
-                    {
-                        "bill": hit,
-                        "label": entry.label,
-                        "blurb": entry.blurb,
-                    }
-                )
+        top_bills = _resolve_top_bills(db) if is_landing else []
         context = {
             "bills": hits,
             "total": total,

--- a/src/concord/web/templates/_results.html
+++ b/src/concord/web/templates/_results.html
@@ -91,31 +91,7 @@
       {% if bill_hits %}
         <ul class="space-y-2">
           {% for b in bill_hits %}
-            <li class="border border-stone-200 rounded p-3 bg-white">
-              <div class="flex items-baseline gap-2 mb-1">
-                <span class="text-xs uppercase tracking-wide px-2 py-0.5 rounded
-                  {% if b.origin_chamber == 'House' %}bg-blue-50 text-blue-800{% else %}bg-amber-50 text-amber-800{% endif %}">
-                  {{ b.origin_chamber }}
-                </span>
-                <a
-                  href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
-                  class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
-                >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
-                <span class="text-xs text-stone-400">· {{ b.congress }}th</span>
-              </div>
-              <a
-                href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
-                class="block text-stone-800 hover:text-stone-600"
-              >{{ b.title|truncate(120) }}</a>
-              <div class="text-xs text-stone-500 mt-1 flex flex-wrap gap-x-3">
-                {% if b.sponsor_display_name %}
-                  <span>Sponsor: {{ b.sponsor_display_name }}</span>
-                {% endif %}
-                {% if b.latest_action_date %}
-                  <span>Latest action: {{ b.latest_action_date }}</span>
-                {% endif %}
-              </div>
-            </li>
+            {% include "bills/_bill_card.html" %}
           {% endfor %}
         </ul>
       {% else %}

--- a/src/concord/web/templates/bills/_bill_card.html
+++ b/src/concord/web/templates/bills/_bill_card.html
@@ -3,17 +3,7 @@
    sponsor_bioguide_id, sponsor_display_name, latest_action_date). Shared by
    the landing page, the ``/bills`` index, and federated search results. #}
 <li class="border border-stone-200 rounded p-3 bg-white hover:border-stone-300">
-  <div class="flex items-baseline gap-2 mb-1">
-    <span class="text-xs uppercase tracking-wide px-2 py-0.5 rounded
-      {% if b.origin_chamber == 'House' %}bg-blue-50 text-blue-800{% else %}bg-amber-50 text-amber-800{% endif %}">
-      {{ b.origin_chamber }}
-    </span>
-    <a
-      href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
-      class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
-    >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
-    <span class="text-xs text-stone-400">· {{ b.congress }}th Congress</span>
-  </div>
+  {% include "bills/_bill_card_header.html" %}
   <a
     href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
     class="block text-stone-800 hover:text-stone-600"

--- a/src/concord/web/templates/bills/_bill_card_header.html
+++ b/src/concord/web/templates/bills/_bill_card_header.html
@@ -1,0 +1,14 @@
+{# Card header: chamber badge + bill-number link + Congress. Caller provides
+   ``b`` (origin_chamber, congress, bill_type, bill_number). Shared by the
+   standard bill card and the curated Top-bills card on the landing page. #}
+<div class="flex items-baseline gap-2 mb-1">
+  <span class="text-xs uppercase tracking-wide px-2 py-0.5 rounded
+    {% if b.origin_chamber == 'House' %}bg-blue-50 text-blue-800{% else %}bg-amber-50 text-amber-800{% endif %}">
+    {{ b.origin_chamber }}
+  </span>
+  <a
+    href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+    class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
+  >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
+  <span class="text-xs text-stone-400">· {{ b.congress }}th Congress</span>
+</div>

--- a/src/concord/web/templates/bills/_top_bill_card.html
+++ b/src/concord/web/templates/bills/_top_bill_card.html
@@ -1,0 +1,12 @@
+{# Curated Top-bills card: editorial label + blurb over the shared card
+   header. Caller provides ``item`` (.bill, .label, .blurb). Used by the
+   landing page and the /bills index. #}
+{% set b = item.bill %}
+<li class="border border-stone-200 rounded p-3 bg-amber-50/40 hover:border-stone-300">
+  {% include "bills/_bill_card_header.html" %}
+  <a
+    href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
+    class="block font-serif text-stone-900 hover:text-stone-700"
+  >{{ item.label }}</a>
+  <p class="text-sm text-stone-600 mt-1">{{ item.blurb }}</p>
+</li>

--- a/src/concord/web/templates/bills/list.html
+++ b/src/concord/web/templates/bills/list.html
@@ -12,25 +12,7 @@
       <h2 class="text-xs uppercase tracking-wide text-stone-500 mb-3">Top bills</h2>
       <ul class="grid gap-3 sm:grid-cols-2">
         {% for item in top_bills %}
-          {% set b = item.bill %}
-          <li class="border border-stone-200 rounded p-3 bg-amber-50/40">
-            <div class="flex items-baseline gap-2 mb-1">
-              <span class="text-xs uppercase tracking-wide px-2 py-0.5 rounded
-                {% if b.origin_chamber == 'House' %}bg-blue-50 text-blue-800{% else %}bg-amber-50 text-amber-800{% endif %}">
-                {{ b.origin_chamber }}
-              </span>
-              <a
-                href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
-                class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
-              >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
-              <span class="text-xs text-stone-400">· {{ b.congress }}th Congress</span>
-            </div>
-            <a
-              href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
-              class="block font-serif text-stone-900 hover:text-stone-700"
-            >{{ item.label }}</a>
-            <p class="text-sm text-stone-600 mt-1">{{ item.blurb }}</p>
-          </li>
+          {% include "bills/_top_bill_card.html" %}
         {% endfor %}
       </ul>
     </section>

--- a/src/concord/web/templates/bills/profile.html
+++ b/src/concord/web/templates/bills/profile.html
@@ -2,9 +2,9 @@
 {% block title %}{{ bill.bill_type|upper }} {{ bill.bill_number }} — Concord{% endblock %}
 {% block content %}
 {# Long sections (cosponsors, votes, actions, subjects, titles) start as a
-   preview of the first N items and expand on click — see the per-section
-   PREVIEW counts below. Item markup is factored into macros so the preview
-   and the expanded remainder render identically. #}
+   preview of the first N items and expand the remainder on click. The
+   preview/expand structure is shared via show_more_list (below); each call
+   supplies the per-item markup as its {% call(item) %} body. #}
 {%- macro cosponsor_li(c) -%}
   <li class="text-sm">
     {% if c.sponsorship_withdrawn_date %}
@@ -42,6 +42,22 @@
 {%- endmacro -%}
 {%- macro show_more(label) -%}
   <summary class="cursor-pointer text-sm text-stone-600 hover:text-stone-900 select-none">{{ label }}</summary>
+{%- endmacro -%}
+{# Render ``items`` as a preview of the first ``preview`` entries, with the
+   remainder behind a <details>. ``caller(item)`` renders one entry, so the
+   preview and the expanded remainder render identically. #}
+{%- macro show_more_list(items, preview, noun, wrapper_class="space-y-1", tag="ul") -%}
+  <{{ tag }} class="{{ wrapper_class }}">
+    {% for item in items[:preview] %}{{ caller(item) }}{% endfor %}
+  </{{ tag }}>
+  {% if items|length > preview %}
+    <details class="mt-2">
+      {{ show_more("Show all %d %s"|format(items|length, noun)) }}
+      <{{ tag }} class="{{ wrapper_class }} mt-1">
+        {% for item in items[preview:] %}{{ caller(item) }}{% endfor %}
+      </{{ tag }}>
+    </details>
+  {% endif %}
 {%- endmacro -%}
 {# Compute the most recent fetched_at across tier-1 + tier-2 sections. #}
 {%- set tier2_stamps = [bill.cosponsors_fetched_at, bill.actions_fetched_at,
@@ -168,23 +184,12 @@
     </section>
 
     {# -- Cosponsors ---------------------------------------------------- #}
-    {% set PREVIEW = 8 %}
     <section>
       <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Cosponsors</h2>
       {% if bill.cosponsors_fetched_at is none %}
         {{ empty_state("Cosponsors not yet fetched.") }}
       {% elif cosponsors %}
-        <ul class="space-y-1">
-          {% for c in cosponsors[:PREVIEW] %}{{ cosponsor_li(c) }}{% endfor %}
-        </ul>
-        {% if cosponsors|length > PREVIEW %}
-          <details class="mt-2">
-            {{ show_more("Show all %d cosponsors"|format(cosponsors|length)) }}
-            <ul class="space-y-1 mt-1">
-              {% for c in cosponsors[PREVIEW:] %}{{ cosponsor_li(c) }}{% endfor %}
-            </ul>
-          </details>
-        {% endif %}
+        {% call(c) show_more_list(cosponsors, 8, "cosponsors") %}{{ cosponsor_li(c) }}{% endcall %}
         <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.cosponsors_fetched_at|humanize_age }}.</p>
       {% else %}
         <p class="text-stone-500 text-sm">No cosponsors recorded.</p>
@@ -193,44 +198,22 @@
     </section>
 
     {# -- Vote history -------------------------------------------------- #}
-    {% set PREVIEW = 5 %}
     <section>
       <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Vote history</h2>
       {% if vote_history %}
-        <ul class="space-y-2">
-          {% for v in vote_history[:PREVIEW] %}{% include "_vote_row.html" %}{% endfor %}
-        </ul>
-        {% if vote_history|length > PREVIEW %}
-          <details class="mt-2">
-            {{ show_more("Show all %d votes"|format(vote_history|length)) }}
-            <ul class="space-y-2 mt-2">
-              {% for v in vote_history[PREVIEW:] %}{% include "_vote_row.html" %}{% endfor %}
-            </ul>
-          </details>
-        {% endif %}
+        {% call(v) show_more_list(vote_history, 5, "votes", "space-y-2") %}{% include "_vote_row.html" %}{% endcall %}
       {% else %}
         <p class="text-stone-500 text-sm">No votes recorded for this bill yet.</p>
       {% endif %}
     </section>
 
     {# -- Action history ----------------------------------------------- #}
-    {% set PREVIEW = 8 %}
     <section>
       <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Action history</h2>
       {% if bill.actions_fetched_at is none %}
         {{ empty_state("Action history not yet fetched.") }}
       {% elif actions %}
-        <ul>
-          {% for action in actions[:PREVIEW] %}{% include "bills/_action_row.html" %}{% endfor %}
-        </ul>
-        {% if actions|length > PREVIEW %}
-          <details class="mt-2">
-            {{ show_more("Show all %d actions"|format(actions|length)) }}
-            <ul class="mt-1">
-              {% for action in actions[PREVIEW:] %}{% include "bills/_action_row.html" %}{% endfor %}
-            </ul>
-          </details>
-        {% endif %}
+        {% call(action) show_more_list(actions, 8, "actions", "") %}{% include "bills/_action_row.html" %}{% endcall %}
         <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.actions_fetched_at|humanize_age }}.</p>
       {% else %}
         <p class="text-stone-500 text-sm">No actions recorded.</p>
@@ -239,27 +222,14 @@
     </section>
 
     {# -- Subjects ----------------------------------------------------- #}
-    {% set PREVIEW = 18 %}
     <section>
       <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Subjects</h2>
       {% if bill.subjects_fetched_at is none %}
         {{ empty_state("Subjects not yet fetched.") }}
       {% elif subjects %}
-        <div class="flex flex-wrap gap-1">
-          {% for s in subjects[:PREVIEW] %}
-            <span class="inline-block px-2 py-0.5 rounded bg-stone-100 text-stone-700 text-xs">{{ s }}</span>
-          {% endfor %}
-        </div>
-        {% if subjects|length > PREVIEW %}
-          <details class="mt-2">
-            {{ show_more("Show all %d subjects"|format(subjects|length)) }}
-            <div class="flex flex-wrap gap-1 mt-1">
-              {% for s in subjects[PREVIEW:] %}
-                <span class="inline-block px-2 py-0.5 rounded bg-stone-100 text-stone-700 text-xs">{{ s }}</span>
-              {% endfor %}
-            </div>
-          </details>
-        {% endif %}
+        {% call(s) show_more_list(subjects, 18, "subjects", "flex flex-wrap gap-1", "div") -%}
+          <span class="inline-block px-2 py-0.5 rounded bg-stone-100 text-stone-700 text-xs">{{ s }}</span>
+        {%- endcall %}
         <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.subjects_fetched_at|humanize_age }}.</p>
       {% else %}
         <p class="text-stone-500 text-sm">No subjects assigned.</p>
@@ -268,23 +238,12 @@
     </section>
 
     {# -- Titles ------------------------------------------------------- #}
-    {% set PREVIEW = 4 %}
     <section>
       <h2 class="text-sm uppercase tracking-wide text-stone-500 mb-2">Titles</h2>
       {% if bill.titles_fetched_at is none %}
         {{ empty_state("Titles not yet fetched.") }}
       {% elif titles %}
-        <ul class="space-y-2">
-          {% for t in titles[:PREVIEW] %}{{ title_li(t) }}{% endfor %}
-        </ul>
-        {% if titles|length > PREVIEW %}
-          <details class="mt-2">
-            {{ show_more("Show all %d titles"|format(titles|length)) }}
-            <ul class="space-y-2 mt-1">
-              {% for t in titles[PREVIEW:] %}{{ title_li(t) }}{% endfor %}
-            </ul>
-          </details>
-        {% endif %}
+        {% call(t) show_more_list(titles, 4, "titles", "space-y-2") %}{{ title_li(t) }}{% endcall %}
         <p class="mt-2 text-xs text-stone-400">Fetched {{ bill.titles_fetched_at|humanize_age }}.</p>
       {% else %}
         <p class="text-stone-500 text-sm">No titles recorded.</p>

--- a/src/concord/web/templates/index.html
+++ b/src/concord/web/templates/index.html
@@ -13,25 +13,7 @@
       </div>
       <ul class="grid gap-3 sm:grid-cols-2">
         {% for item in top_bills %}
-          {% set b = item.bill %}
-          <li class="border border-stone-200 rounded p-3 bg-amber-50/40 hover:border-stone-300">
-            <div class="flex items-baseline gap-2 mb-1">
-              <span class="text-xs uppercase tracking-wide px-2 py-0.5 rounded
-                {% if b.origin_chamber == 'House' %}bg-blue-50 text-blue-800{% else %}bg-amber-50 text-amber-800{% endif %}">
-                {{ b.origin_chamber }}
-              </span>
-              <a
-                href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
-                class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
-              >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
-              <span class="text-xs text-stone-400">· {{ b.congress }}th Congress</span>
-            </div>
-            <a
-              href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
-              class="block font-serif text-stone-900 hover:text-stone-700"
-            >{{ item.label }}</a>
-            <p class="text-sm text-stone-600 mt-1">{{ item.blurb }}</p>
-          </li>
+          {% include "bills/_top_bill_card.html" %}
         {% endfor %}
       </ul>
     </section>


### PR DESCRIPTION
## Why

Follow-up to the code-quality review of #101. The bills-first UI work landed correctly but left several copies of the same markup behind. This is a behavior-preserving structural cleanup — it deletes duplication without changing the design language.

## What

**Bill card → one canonical partial.** The chamber-badge + bill-number + Congress header was copy-pasted across **four** templates. Extracted `bills/_bill_card_header.html` as the single source and routed `_bill_card.html` through it. The curated **Top-bills** card was duplicated verbatim between `index.html` and `bills/list.html` — extracted `bills/_top_bill_card.html`, included from both.

**Federated search Bills converged onto the canonical card.** `_results.html`'s Bill section was a denser fork of the same `BillHit` data. It now renders via `_bill_card.html`.

**Progressive disclosure → one macro.** The "preview first N, then `<details>` the remainder" block in `profile.html` was hand-written **five** times (cosponsors, votes, actions, subjects, titles). Replaced with a single `show_more_list` macro whose `{% call(item) %}` body supplies the per-item markup; the per-section `PREVIEW` counts are now arguments. ~40 lines gone.

**`app.py`: deduped curated-bill resolution.** The `CURATED_TOP_BILLS` resolution loop was duplicated between the `index` route and the bills index. Extracted `_resolve_top_bills(db)`.

## Note / one intentional behavior change

Federated-search **Bills** results were a *denser* fork. Converging them to the canonical card means search results now link the sponsor to `/members` (was plain text), show `policy_area` when present, and read "· Nth Congress" (was "· Nth"). The data is identical — `BillHit` already carries all these fields — so this is a consistency gain, not a data change. No test asserted the old compact form.

## Testing

- `670 passed`.
- `ruff check`, `ruff format --check`, `mypy src` all clean.

## Not in scope

`web/app.py` is ~1k lines and `_register_routes` carries `C901`/`PLR` waivers; splitting it into per-entity `APIRouter` modules is the real fix and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)