### PR TITLE
test: make tokenization offline so the suite runs in sandboxes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,71 @@
 Tests load recorded API JSON and article HTML from ``tests/fixtures/`` so the
 suite never touches the network. The ``load_fixture`` helper returns the raw
 text of a fixture file; ``load_json_fixture`` parses it as JSON.
+
+The suite also never touches the network for *tokenization*. The real
+``tiktoken.get_encoding("cl100k_base")`` downloads a BPE vocab on first use,
+which fails in a sandboxed/offline environment. ``_offline_tiktoken`` (autouse,
+session-scoped) swaps in :class:`_OfflineEncoding`, a lossless stand-in, so any
+test that builds a ``Chunker`` runs offline.
 """
 
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
+import tiktoken
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class _OfflineEncoding:
+    """Lossless ~4-chars-per-token stand-in for a real tiktoken encoding.
+
+    The ``Chunker`` only needs two things from an encoding: a token *count*
+    that drives chunk boundaries, and ``encode``/``decode`` that round-trip so
+    decoded spans can be located in the source text (see ``chunking.py``).
+
+    This tokenizer splits text into fixed 4-character spans — tiktoken's rough
+    average for English — so token counts land in the same ballpark as
+    ``cl100k_base`` and boundary-preference tests stay meaningful. Every token
+    is a verbatim slice of the input, so ``decode(encode(t)) == t`` exactly and
+    any contiguous run of tokens decodes to a contiguous substring, which is
+    all the Chunker's ``str.find``/``rfind`` round-tripping relies on.
+    """
+
+    _WIDTH = 4
+
+    def __init__(self) -> None:
+        self._to_id: dict[str, int] = {}
+        self._to_str: dict[int, str] = {}
+
+    def encode(self, text: str) -> list[int]:
+        ids: list[int] = []
+        for i in range(0, len(text), self._WIDTH):
+            span = text[i : i + self._WIDTH]
+            tid = self._to_id.get(span)
+            if tid is None:
+                tid = len(self._to_id)
+                self._to_id[span] = tid
+                self._to_str[tid] = span
+            ids.append(tid)
+        return ids
+
+    def decode(self, ids: list[int]) -> str:
+        return "".join(self._to_str[i] for i in ids)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _offline_tiktoken():
+    """Replace ``tiktoken.get_encoding`` with an offline, network-free stub.
+
+    A fresh :class:`_OfflineEncoding` per call mirrors the real API (each
+    ``Chunker`` gets its own encoder) without ever downloading a vocab.
+    """
+    with patch.object(tiktoken, "get_encoding", lambda _name: _OfflineEncoding()):
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

Running tests in a sandboxed/offline environment fails: `tiktoken.get_encoding("cl100k_base")` (called in `Chunker.__init__`) downloads a BPE vocab from the internet on first use. Every test that builds a `Chunker` — `test_chunking.py`, `test_indexing.py`, and the index CLI/web paths — trips on it.

## Inventory

While here, I audited the whole suite for other network reach. **`tiktoken` was the only offender.** Everything else is already mocked:

- HTTP clients go through `httpx.Client(transport=httpx.MockTransport(...))` with recorded fixtures.
- OpenAI/embeddings use stub clients (`_StubOpenAI`, `_FakeClient`, `Embedder(fake)`).
- No `requests`/`urllib`/`socket`, no un-mocked `httpx.Client()`, no real `OpenAI()`. The `https://…` strings in tests are fixture URLs fed to mock handlers, never fetched.

## Fix

A session-scoped autouse fixture in `tests/conftest.py` swaps `tiktoken.get_encoding` for a lossless `_OfflineEncoding`:

- Tokenizes text into fixed 4-character spans — tiktoken's rough English average — so token counts stay in the `cl100k_base` ballpark and boundary-preference / token-budget tests remain meaningful.
- Every token is a verbatim slice of the input, so `decode(encode(t)) == t` exactly and decoded spans are findable in the source — all the `Chunker`'s `str.find`/`rfind` round-tripping relies on.

### Tradeoff

Tests no longer exercise *real* `cl100k_base` token counts — chunk boundaries are validated against the approximation, not production tokenization. The alternative (vendoring the vocab + `TIKTOKEN_CACHE_DIR`) keeps the real encoder but adds a ~1.7 MB binary fixture; this approach keeps the suite dependency-light.

## Verification

Airtight offline proof — full suite run with **all outbound sockets hard-blocked** and an **empty `TIKTOKEN_CACHE_DIR`**, so any real download would error:

- **670 passed** with sockets blocked + empty cache
- **670 passed** normally
- `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)