### PR TITLE
fix(web): render Congress numbers with a correct ordinal suffix (#98)

### DIFF
--- a/src/concord/_common.py
+++ b/src/concord/_common.py
@@ -1,0 +1,33 @@
+"""Cross-cutting helpers shared across the package.
+
+Thin home for small utilities that don't belong to any one entity or
+layer and would otherwise force a layering inversion. Keeping them here
+lets a core module (e.g. :mod:`concord.brief`) and the web layer
+(:mod:`concord.web.app`) share one implementation without the web
+package importing core or vice versa.
+"""
+
+#: Last digit → ordinal suffix for the common case. Any digit not in this
+#: map (0 and 4-9) falls through to ``"th"``.
+_ORDINAL_SUFFIXES = {1: "st", 2: "nd", 3: "rd"}
+
+#: Inclusive range (on ``n % 100``) of numbers that take ``"th"`` despite
+#: their last digit — eleventh, twelfth, thirteenth and their multiples of
+#: 100 (111th, 212th, …).
+_TEENS_LO = 11
+_TEENS_HI = 13
+
+
+def ordinal(n: int) -> str:
+    """Return ``n`` with its English ordinal suffix, e.g. ``121`` -> ``"121st"``.
+
+    The suffix follows the standard rule: numbers whose last two digits
+    are 11-13 always take ``th`` (eleventh through thirteenth); otherwise
+    the last digit picks ``st`` (1), ``nd`` (2), ``rd`` (3), or ``th``.
+    Used to render Congress numbers (``119th``, ``121st``, ``123rd``)
+    consistently in templates and the Bill Brief fact pack. Defined for
+    positive integers, which is all Congress numbers ever are.
+    """
+    if _TEENS_LO <= (n % 100) <= _TEENS_HI:
+        return f"{n}th"
+    return f"{n}{_ORDINAL_SUFFIXES.get(n % 10, 'th')}"

--- a/src/concord/brief.py
+++ b/src/concord/brief.py
@@ -26,6 +26,8 @@ from typing import Any, Protocol
 
 from pydantic import BaseModel
 
+from concord._common import ordinal
+
 #: Default chat model for brief generation. Centralized here like
 #: :data:`concord.embedding.DEFAULT_MODEL` so a swap is one edit (ADR 0004).
 DEFAULT_BRIEF_MODEL = "gpt-4o-mini"
@@ -314,7 +316,7 @@ def _facts_to_context(facts: BriefFacts) -> str:
     else:
         party = "n/a"
     lines = [
-        f"Bill: {facts.identifier} ({facts.congress}th Congress, {facts.origin_chamber})",
+        f"Bill: {facts.identifier} ({ordinal(facts.congress)} Congress, {facts.origin_chamber})",
         f"Title: {facts.title}",
         f"Sponsor: {facts.sponsor_display_name or 'unknown'}",
         f"Policy area: {facts.policy_area or 'n/a'}",

--- a/src/concord/web/app.py
+++ b/src/concord/web/app.py
@@ -39,6 +39,7 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
+from concord._common import ordinal
 from concord.brief import Briefer
 from concord.embedding import Embedder
 from concord.scraper.bills import BILL_ENRICHMENT_SECTIONS
@@ -208,6 +209,7 @@ def create_app(
 
     templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
     templates.env.filters["humanize_age"] = humanize_age
+    templates.env.filters["ordinal"] = ordinal
     app.state.templates = templates
 
     if _STATIC_DIR.exists():

--- a/src/concord/web/templates/_vote_row.html
+++ b/src/concord/web/templates/_vote_row.html
@@ -10,7 +10,7 @@
     >
       {% if v.chamber == "house" %}H{% else %}S{% endif %} {{ v.roll_number }}
     </a>
-    <span class="text-xs text-stone-400">· {{ v.congress }}th · {{ v.start_date[:10] }}</span>
+    <span class="text-xs text-stone-400">· {{ v.congress|ordinal }} · {{ v.start_date[:10] }}</span>
     {% if v.is_party_unity %}
       <span class="text-xs text-amber-700 bg-amber-50 px-1 rounded">party-unity</span>
     {% endif %}

--- a/src/concord/web/templates/bills/_bill_card_header.html
+++ b/src/concord/web/templates/bills/_bill_card_header.html
@@ -10,5 +10,5 @@
     href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
     class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
   >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
-  <span class="text-xs text-stone-400">· {{ b.congress }}th Congress</span>
+  <span class="text-xs text-stone-400">· {{ b.congress|ordinal }} Congress</span>
 </div>

--- a/src/concord/web/templates/bills/profile.html
+++ b/src/concord/web/templates/bills/profile.html
@@ -78,7 +78,7 @@
     </div>
     <div>
       <div class="uppercase text-xs tracking-wide text-stone-400">Congress</div>
-      <div>{{ bill.congress }}th</div>
+      <div>{{ bill.congress|ordinal }}</div>
     </div>
     {% if bill.introduced_date %}
       <div>
@@ -100,7 +100,7 @@
   <div class="md:col-span-3 space-y-8">
     <header>
       <div class="font-mono text-sm text-stone-500 mb-1">
-        {{ bill.bill_type|upper }} {{ bill.bill_number }} · {{ bill.congress }}th Congress
+        {{ bill.bill_type|upper }} {{ bill.bill_number }} · {{ bill.congress|ordinal }} Congress
       </div>
       <h1 class="text-2xl font-serif font-semibold leading-snug">{{ bill.title }}</h1>
     </header>

--- a/src/concord/web/templates/members/profile.html
+++ b/src/concord/web/templates/members/profile.html
@@ -107,7 +107,7 @@
                   href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
                   class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
                 >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
-                <span class="text-xs text-stone-400">· {{ b.congress }}th</span>
+                <span class="text-xs text-stone-400">· {{ b.congress|ordinal }}</span>
               </div>
               <a
                 href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
@@ -139,7 +139,7 @@
                   href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
                   class="font-mono text-sm font-medium text-stone-900 hover:text-stone-700"
                 >{{ b.bill_type|upper }} {{ b.bill_number }}</a>
-                <span class="text-xs text-stone-400">· {{ b.congress }}th</span>
+                <span class="text-xs text-stone-400">· {{ b.congress|ordinal }}</span>
               </div>
               <a
                 href="/bills/{{ b.congress }}/{{ b.bill_type }}/{{ b.bill_number }}"
@@ -200,7 +200,7 @@
               <p class="text-stone-700">
                 <span class="text-xs uppercase tracking-wide text-stone-500">{{ chamber_label }}:</span>
                 Voted on {{ current.party_unity_votes_cast }} party-unity vote{{ "" if current.party_unity_votes_cast == 1 else "s" }}
-                in the {{ current.congress }}th Congress —
+                in the {{ current.congress|ordinal }} Congress —
                 <span class="text-stone-500">not enough for a stable score yet.</span>
               </p>
             {% else %}
@@ -212,7 +212,7 @@
                 <span class="font-semibold">{{ pct }}%</span>
                 of party-unity votes
                 ({{ current.party_line_votes }}/{{ current.party_unity_votes_cast }}
-                in the {{ current.congress }}th Congress).
+                in the {{ current.congress|ordinal }} Congress).
               </p>
             {% endif %}
           {% endfor %}
@@ -224,11 +224,11 @@
               {% set chamber_short = "S" if r.chamber == "senate" else "H" %}
               {% if r.party_unity_votes_cast >= party_unity_min_votes %}
                 {% set rp = (r.party_line_votes * 100 // r.party_unity_votes_cast) %}
-                <span>{{ r.congress }}th ({{ chamber_short }}): {{ rp }}%
+                <span>{{ r.congress|ordinal }} ({{ chamber_short }}): {{ rp }}%
                   <span class="text-stone-400">({{ r.party_line_votes }}/{{ r.party_unity_votes_cast }})</span>
                 </span>
               {% else %}
-                <span class="text-stone-400">{{ r.congress }}th ({{ chamber_short }}): {{ r.party_unity_votes_cast }} votes</span>
+                <span class="text-stone-400">{{ r.congress|ordinal }} ({{ chamber_short }}): {{ r.party_unity_votes_cast }} votes</span>
               {% endif %}
             {% endfor %}
           </div>

--- a/src/concord/web/templates/proceeding.html
+++ b/src/concord/web/templates/proceeding.html
@@ -9,7 +9,7 @@
     </div>
     <div>
       <div class="uppercase text-xs tracking-wide text-stone-400">Congress</div>
-      <div>{{ p.congress }} (session {{ p.session }})</div>
+      <div>{{ p.congress|ordinal }} (session {{ p.session }})</div>
     </div>
     <div>
       <div class="uppercase text-xs tracking-wide text-stone-400">Volume / Issue</div>

--- a/src/concord/web/templates/votes/profile.html
+++ b/src/concord/web/templates/votes/profile.html
@@ -11,7 +11,7 @@
       </div>
       <div>
         <div class="uppercase text-xs tracking-wide text-stone-400">Congress</div>
-        <div>{{ vote.congress }}th · session {{ vote.session }}</div>
+        <div>{{ vote.congress|ordinal }} · session {{ vote.session }}</div>
       </div>
       <div>
         <div class="uppercase text-xs tracking-wide text-stone-400">Date</div>
@@ -38,7 +38,7 @@
     <div class="md:col-span-3 space-y-8">
       <header>
         <div class="font-mono text-sm text-stone-500 mb-1">
-          {{ "House" if vote.chamber == "house" else "Senate" }} roll {{ vote.roll_number }} · {{ vote.congress }}th
+          {{ "House" if vote.chamber == "house" else "Senate" }} roll {{ vote.roll_number }} · {{ vote.congress|ordinal }}
         </div>
         <h1 class="text-2xl font-serif font-semibold leading-snug">{{ vote.vote_question }}</h1>
       </header>

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,53 @@
+"""Unit tests for cross-cutting helpers in :mod:`concord._common`."""
+
+import pytest
+
+from concord._common import ordinal
+
+
+class TestOrdinal:
+    """English ordinal suffixes, with the 11-13 special case."""
+
+    @pytest.mark.parametrize(
+        ("n", "expected"),
+        [
+            # Single-digit base cases: 1/2/3 get st/nd/rd, the rest th.
+            (0, "0th"),
+            (1, "1st"),
+            (2, "2nd"),
+            (3, "3rd"),
+            (4, "4th"),
+            (5, "5th"),
+            (9, "9th"),
+            (10, "10th"),
+            # The 11-13 special case: these take th despite ending in 1/2/3.
+            (11, "11th"),
+            (12, "12th"),
+            (13, "13th"),
+            (14, "14th"),
+            # Past the teens, the last digit rules again: 21st/22nd/23rd.
+            (20, "20th"),
+            (21, "21st"),
+            (22, "22nd"),
+            (23, "23rd"),
+            (24, "24th"),
+            # The current corpus and the first future breaks (issue #98).
+            (119, "119th"),
+            (121, "121st"),
+            (122, "122nd"),
+            (123, "123rd"),
+            # The 11-13 rule keys off the last *two* digits, so 111-113
+            # are th even though they end in 1/2/3.
+            (100, "100th"),
+            (101, "101st"),
+            (102, "102nd"),
+            (103, "103rd"),
+            (111, "111th"),
+            (112, "112th"),
+            (113, "113th"),
+            (211, "211th"),
+            (221, "221st"),
+        ],
+    )
+    def test_ordinal(self, n: int, expected: str) -> None:
+        assert ordinal(n) == expected


### PR DESCRIPTION
Fixes #98.

## Problem

Every place the UI (and one LLM-prompt string) rendered a Congress number appended a literal `th`: `{{ congress }}th`. Correct for the 119th Congress, but wrong for any Congress whose number ends in **1**, **2**, or **3** (except 11–13): `121th` (should be 121**st**), `122` → 122**nd**, `123` → 123**rd**, and historical `1th`/`2th`/`3th`/`21th`/… So it's latent for the current corpus but immediately wrong for any earlier Congress loaded via member term history, votes, or bills.

## Fix

One shared `ordinal()` helper, used everywhere:

- **New** [`src/concord/_common.py`](src/concord/_common.py) — `ordinal(n: int) -> str` with the standard rule (`n % 100` in 11–13 → `th`; else by `n % 10`). It lives in **core**, not `web/_deps.py`, because `brief.py` consumes it too — and core importing from `concord.web` would pull FastAPI into core and invert the web→core layering.
- **Jinja filter** registered in [`web/app.py`](src/concord/web/app.py) beside `humanize_age`.
- **Fact pack** in [`brief.py`](src/concord/brief.py) now uses `ordinal(facts.congress)`.
- **12 template sites** converted `{{ x.congress }}th` → `{{ x.congress|ordinal }}` across `_vote_row.html`, `votes/profile.html`, `bills/profile.html`, `bills/_bill_card_header.html`, and `members/profile.html`.

> The issue's line-number table was stale (the #102 refactor had moved the bill-card markup into `_bill_card_header.html`); every current site was located by grep.

## Tests

[`tests/test_common.py`](tests/test_common.py) — parametrized coverage of the 11–13 special case, the 1/2/3 vs 21/22/23 boundaries, the 111–113 "teens of a hundred" case, and the concrete examples (119th unchanged; 121st/122nd/123rd).

## Verification

- `ruff check`, `ruff format --check`, `mypy --strict src` — all pass
- Full suite: **700 passed**
- Render check: `119→119th`, `121→121st`, `122→122nd`, `123→123rd`, `111→111th`

🤖 Generated with [Claude Code](https://claude.com/claude-code)