### PR TITLE
feat(observability): Scrape Run ledger + api.congress.gov slice (PR 1 of 2)

### DIFF
--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -32,6 +32,7 @@ import httpx
 
 from . import __version__
 from .models import Article, Issue
+from .observability import Attempt, Recorder, active_recorder
 
 API_BASE = "https://api.congress.gov/v3"
 USER_AGENT = f"concord/{__version__}"
@@ -508,6 +509,15 @@ class Client:
         if params:
             merged.update(params)
 
+        # Observability (ADR 0021): the recorder, if any, gets a success count
+        # per request and a Run Event for any request with ≥1 non-success
+        # attempt. ``attempts`` accumulates every non-success try (transport
+        # failure, 429, 5xx, terminal 4xx) so a resolved-on-retry request can
+        # report what it weathered. None outside an active scrape — recording
+        # is then a no-op. Retry *behavior* below is unchanged.
+        rec = active_recorder()
+        attempts: list[Attempt] = []
+
         transient_attempts = 0
         while True:
             try:
@@ -515,7 +525,16 @@ class Client:
             except httpx.HTTPError as exc:
                 # Transport-level failure (DNS, timeout, connection reset).
                 # Treat as a retryable transient.
+                attempts.append(
+                    Attempt(
+                        n=len(attempts) + 1,
+                        status=None,
+                        transport_class=type(exc).__name__,
+                        message=str(exc),
+                    )
+                )
                 if transient_attempts >= MAX_5XX_RETRIES:
+                    _record_failure(rec, path, attempts)
                     raise ApiError(
                         f"transport error calling {path} "
                         f"(gave up after {MAX_5XX_RETRIES} attempts): {exc}"
@@ -529,6 +548,17 @@ class Client:
             status = response.status_code
 
             if status == HTTP_TOO_MANY_REQUESTS:
+                # 429s are recorded as errors (ADR 0021) even though we retry
+                # them indefinitely — a rate-limit-aware client hitting one is
+                # our own request-budget signal worth surfacing.
+                attempts.append(
+                    Attempt(
+                        n=len(attempts) + 1,
+                        status=status,
+                        transport_class=None,
+                        message=response.reason_phrase,
+                    )
+                )
                 delay = _retry_after_seconds(response) or _backoff_seconds(transient_attempts)
                 _log.warning("429 from %s; backing off %.1fs before retry", path, delay)
                 self._sleep(delay)
@@ -537,7 +567,16 @@ class Client:
                 continue
 
             if HTTP_SERVER_ERROR_MIN <= status < HTTP_SERVER_ERROR_MAX:
+                attempts.append(
+                    Attempt(
+                        n=len(attempts) + 1,
+                        status=status,
+                        transport_class=None,
+                        message=response.reason_phrase,
+                    )
+                )
                 if transient_attempts >= MAX_5XX_RETRIES:
+                    _record_failure(rec, path, attempts)
                     raise ApiError(
                         f"{status} {response.reason_phrase} from {path} "
                         f"(gave up after {MAX_5XX_RETRIES} attempts)",
@@ -558,6 +597,15 @@ class Client:
 
             if not response.is_success:
                 # Non-retryable client error (4xx other than 429): surface immediately.
+                attempts.append(
+                    Attempt(
+                        n=len(attempts) + 1,
+                        status=status,
+                        transport_class=None,
+                        message=response.reason_phrase,
+                    )
+                )
+                _record_failure(rec, path, attempts)
                 raise ApiError(
                     f"{status} {response.reason_phrase} from {path}",
                     status_code=status,
@@ -565,8 +613,40 @@ class Client:
 
             data: Any = response.json()
             if not isinstance(data, dict):
+                attempts.append(
+                    Attempt(
+                        n=len(attempts) + 1,
+                        status=status,
+                        transport_class=None,
+                        message=f"expected JSON object, got {type(data).__name__}",
+                    )
+                )
+                _record_failure(rec, path, attempts)
                 raise ApiError(f"expected JSON object from {path}, got {type(data).__name__}")
+            _record_success(rec, path, attempts)
             return data
+
+
+# -- observability helpers --------------------------------------------------
+#
+# Kept module-level (rather than inline ``if rec is not None`` blocks) so the
+# recording stays a single statement per call site in :meth:`Client._get` —
+# the retry loop is already at the project's complexity ceiling.
+
+
+def _record_success(rec: Recorder | None, path: str, attempts: list[Attempt]) -> None:
+    """Record a successful api request, plus a resolved Run Event if it retried."""
+    if rec is None:
+        return
+    rec.note_success("api", path)
+    if attempts:
+        rec.note_request_outcome("api", path, attempts, resolved=True)
+
+
+def _record_failure(rec: Recorder | None, path: str, attempts: list[Attempt]) -> None:
+    """Record a terminal api failure as a failed Run Event (no-op without a recorder)."""
+    if rec is not None:
+        rec.note_request_outcome("api", path, attempts, resolved=False)
 
 
 # -- retry helpers ----------------------------------------------------------

--- a/src/concord/api.py
+++ b/src/concord/api.py
@@ -31,8 +31,8 @@ from typing import Any
 import httpx
 
 from . import __version__
-from .models import Article, Issue
-from .observability import Attempt, Recorder, active_recorder
+from .models import Article, Attempt, Issue
+from .observability import Recorder, active_recorder
 
 API_BASE = "https://api.congress.gov/v3"
 USER_AGENT = f"concord/{__version__}"
@@ -525,14 +525,7 @@ class Client:
             except httpx.HTTPError as exc:
                 # Transport-level failure (DNS, timeout, connection reset).
                 # Treat as a retryable transient.
-                attempts.append(
-                    Attempt(
-                        n=len(attempts) + 1,
-                        status=None,
-                        transport_class=type(exc).__name__,
-                        message=str(exc),
-                    )
-                )
+                _note_attempt(attempts, transport_class=type(exc).__name__, message=str(exc))
                 if transient_attempts >= MAX_5XX_RETRIES:
                     _record_failure(rec, path, attempts)
                     raise ApiError(
@@ -551,14 +544,7 @@ class Client:
                 # 429s are recorded as errors (ADR 0021) even though we retry
                 # them indefinitely — a rate-limit-aware client hitting one is
                 # our own request-budget signal worth surfacing.
-                attempts.append(
-                    Attempt(
-                        n=len(attempts) + 1,
-                        status=status,
-                        transport_class=None,
-                        message=response.reason_phrase,
-                    )
-                )
+                _note_attempt(attempts, status=status, message=response.reason_phrase)
                 delay = _retry_after_seconds(response) or _backoff_seconds(transient_attempts)
                 _log.warning("429 from %s; backing off %.1fs before retry", path, delay)
                 self._sleep(delay)
@@ -567,14 +553,7 @@ class Client:
                 continue
 
             if HTTP_SERVER_ERROR_MIN <= status < HTTP_SERVER_ERROR_MAX:
-                attempts.append(
-                    Attempt(
-                        n=len(attempts) + 1,
-                        status=status,
-                        transport_class=None,
-                        message=response.reason_phrase,
-                    )
-                )
+                _note_attempt(attempts, status=status, message=response.reason_phrase)
                 if transient_attempts >= MAX_5XX_RETRIES:
                     _record_failure(rec, path, attempts)
                     raise ApiError(
@@ -597,14 +576,7 @@ class Client:
 
             if not response.is_success:
                 # Non-retryable client error (4xx other than 429): surface immediately.
-                attempts.append(
-                    Attempt(
-                        n=len(attempts) + 1,
-                        status=status,
-                        transport_class=None,
-                        message=response.reason_phrase,
-                    )
-                )
+                _note_attempt(attempts, status=status, message=response.reason_phrase)
                 _record_failure(rec, path, attempts)
                 raise ApiError(
                     f"{status} {response.reason_phrase} from {path}",
@@ -613,13 +585,10 @@ class Client:
 
             data: Any = response.json()
             if not isinstance(data, dict):
-                attempts.append(
-                    Attempt(
-                        n=len(attempts) + 1,
-                        status=status,
-                        transport_class=None,
-                        message=f"expected JSON object, got {type(data).__name__}",
-                    )
+                _note_attempt(
+                    attempts,
+                    status=status,
+                    message=f"expected JSON object, got {type(data).__name__}",
                 )
                 _record_failure(rec, path, attempts)
                 raise ApiError(f"expected JSON object from {path}, got {type(data).__name__}")
@@ -629,9 +598,31 @@ class Client:
 
 # -- observability helpers --------------------------------------------------
 #
-# Kept module-level (rather than inline ``if rec is not None`` blocks) so the
+# Kept module-level (rather than inline blocks / a nested closure) so the
 # recording stays a single statement per call site in :meth:`Client._get` —
 # the retry loop is already at the project's complexity ceiling.
+
+
+def _note_attempt(
+    attempts: list[Attempt],
+    *,
+    status: int | None = None,
+    transport_class: str | None = None,
+    message: str,
+) -> None:
+    """Append one non-success :class:`Attempt`; ``n`` derives from list position.
+
+    Centralizing the construction keeps the five retry-loop branches one line
+    each and means no call site can mis-number an attempt.
+    """
+    attempts.append(
+        Attempt(
+            n=len(attempts) + 1,
+            status=status,
+            transport_class=transport_class,
+            message=message,
+        )
+    )
 
 
 def _record_success(rec: Recorder | None, path: str, attempts: list[Attempt]) -> None:

--- a/src/concord/cli/__init__.py
+++ b/src/concord/cli/__init__.py
@@ -29,6 +29,8 @@ scriptable.
 
 import typer
 
+from concord.observability import configure_logging
+
 # Side-effectful: each module decorates its commands onto the stage apps.
 from . import bills, members, proceedings, votes  # noqa: F401
 from ._apps import index_app, load_app, run_app, scrape_app
@@ -69,6 +71,10 @@ def _root() -> None:
     The empty callback exists so Typer treats this as a multi-command app
     rather than collapsing the lone command into the root.
     """
+    # Central run_id-stamped logging, installed once at the CLI seam (not at
+    # import time, per ADR 0014). Idempotent across repeated in-process
+    # invocations (tests).
+    configure_logging()
 
 
 # serve lives directly on the root app, not under a stage sub-app.

--- a/src/concord/cli/bills.py
+++ b/src/concord/cli/bills.py
@@ -143,17 +143,23 @@ def _run_scrape_bills(
     command: str,
     skip_unchanged: bool = False,
 ) -> int:
+    # Construct (and validate) the client BEFORE the scrape seam. A pure config
+    # error — e.g. a missing API key — must not mint a Scrape Run or bootstrap
+    # the ledger DB: ADR 0021 says the recorder is "born exactly where the
+    # network is", and client construction is config, not network. This also
+    # keeps `scrape bills` consistent with `run bills`, which guards the key
+    # upfront.
+    try:
+        api_client = Client()
+    except ApiError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
     # The Bills Stage-0 path is the proven vertical slice for the Scrape Run
     # ledger (ADR 0021): the recorder is born here, at the scrape seam, and
     # the api.py chokepoint records into it via contextvar. Stage 0 still
     # writes entity data only to JSONL — the DB write is telemetry.
     with scrape_run(entity="bills", command=command, db_path=db_path):
-        try:
-            api_client = Client()
-        except ApiError as exc:
-            typer.echo(f"error: {exc}", err=True)
-            raise typer.Exit(code=2) from exc
-
         progress = Progress(enabled=show_progress)
         tracker = RateTracker()
 

--- a/src/concord/cli/bills.py
+++ b/src/concord/cli/bills.py
@@ -9,6 +9,7 @@ from typing import Annotated
 import typer
 
 from concord.api import ENV_API_KEY, ApiError, Client
+from concord.observability import scrape_run
 from concord.pipeline.index_bills import index as index_bills
 from concord.pipeline.load_bills import load as load_bills
 from concord.scraper import bills as bills_scraper
@@ -138,43 +139,50 @@ def _run_scrape_bills(
     storage_dir: Path,
     limit: int | None,
     show_progress: bool,
+    db_path: Path,
+    command: str,
     skip_unchanged: bool = False,
 ) -> int:
-    try:
-        api_client = Client()
-    except ApiError as exc:
-        typer.echo(f"error: {exc}", err=True)
-        raise typer.Exit(code=2) from exc
+    # The Bills Stage-0 path is the proven vertical slice for the Scrape Run
+    # ledger (ADR 0021): the recorder is born here, at the scrape seam, and
+    # the api.py chokepoint records into it via contextvar. Stage 0 still
+    # writes entity data only to JSONL — the DB write is telemetry.
+    with scrape_run(entity="bills", command=command, db_path=db_path):
+        try:
+            api_client = Client()
+        except ApiError as exc:
+            typer.echo(f"error: {exc}", err=True)
+            raise typer.Exit(code=2) from exc
 
-    progress = Progress(enabled=show_progress)
-    tracker = RateTracker()
+        progress = Progress(enabled=show_progress)
+        tracker = RateTracker()
 
-    def _on_progress(event: bills_scraper.ScrapeProgressEvent) -> None:
-        if not progress.interactive and not event.is_pair_done:
-            return
-        tracker.update_total(event.category_total)
-        label = f"  congress {event.congress:>3}  {event.bill_type:<7}  "
-        if event.is_pair_done:
-            progress.update(label + tracker.finish(event.bills_written))
+        def _on_progress(event: bills_scraper.ScrapeProgressEvent) -> None:
+            if not progress.interactive and not event.is_pair_done:
+                return
+            tracker.update_total(event.category_total)
+            label = f"  congress {event.congress:>3}  {event.bill_type:<7}  "
+            if event.is_pair_done:
+                progress.update(label + tracker.finish(event.bills_written))
+                progress.commit()
+                tracker.reset()
+            else:
+                progress.update(label + tracker.tick(event.bills_written))
+
+        try:
+            with api_client:
+                stats = bills_scraper.scrape_basic(
+                    client=api_client,
+                    congresses=congresses,
+                    storage_dir=storage_dir,
+                    fetched_at=datetime.now(UTC),
+                    bill_types=bill_types,
+                    limit=limit,
+                    progress=_on_progress if show_progress else None,
+                    skip_unchanged=skip_unchanged,
+                )
+        finally:
             progress.commit()
-            tracker.reset()
-        else:
-            progress.update(label + tracker.tick(event.bills_written))
-
-    try:
-        with api_client:
-            stats = bills_scraper.scrape_basic(
-                client=api_client,
-                congresses=congresses,
-                storage_dir=storage_dir,
-                fetched_at=datetime.now(UTC),
-                bill_types=bill_types,
-                limit=limit,
-                progress=_on_progress if show_progress else None,
-                skip_unchanged=skip_unchanged,
-            )
-    finally:
-        progress.commit()
 
     suffix = f" ({stats.bills_skipped} skipped)" if stats.bills_skipped else ""
     typer.echo(
@@ -317,6 +325,16 @@ def scrape_bills_command(
             help="Directory holding bills.jsonl (and Phase 2b's sibling files).",
         ),
     ] = DEFAULT_BILLS_STORAGE_DIR,
+    db_path: Annotated[
+        Path,
+        typer.Option(
+            "--db",
+            help=(
+                "SQLite DB for the Scrape Run ledger (ADR 0021). Stage 0 still "
+                "writes entity data only to JSONL; this DB receives telemetry only."
+            ),
+        ),
+    ] = DEFAULT_DB,
     limit: Annotated[
         int | None,
         typer.Option(
@@ -362,6 +380,8 @@ def scrape_bills_command(
         storage_dir=storage_dir,
         limit=limit,
         show_progress=show_progress,
+        db_path=db_path,
+        command="scrape bills",
         skip_unchanged=skip_unchanged,
     )
 
@@ -572,6 +592,8 @@ def run_bills_command(
         storage_dir=storage_dir,
         limit=limit,
         show_progress=show_progress,
+        db_path=db_path,
+        command="run bills",
     )
 
     typer.echo("→ Stage 1: load", err=True)

--- a/src/concord/cli/serve.py
+++ b/src/concord/cli/serve.py
@@ -6,6 +6,7 @@ from typing import Annotated
 import typer
 
 from concord.cli._common import DEFAULT_DB, _require_openai_key
+from concord.observability import configure_logging
 
 
 def serve_command(
@@ -45,6 +46,9 @@ def serve_command(
     A missing DB file is created with an empty schema on startup (ADR 0012);
     `serve` is the only top-level command that bootstraps rather than fails.
     """
+    # Run_id-stamped logging for the long-running server, installed before
+    # the app boots (ADR 0021). Idempotent with the CLI callback's install.
+    configure_logging()
     _require_openai_key()
 
     # Lazy imports so `concord --help` doesn't pay the FastAPI/uvicorn cost.

--- a/src/concord/models/__init__.py
+++ b/src/concord/models/__init__.py
@@ -40,6 +40,7 @@ from concord.models.bills import (
 )
 from concord.models.members import Member, Term, normalize_state
 from concord.models.proceedings import Article, Issue, Proceeding, parse_granule_id
+from concord.models.runs import Attempt, RunEvent, RunRecord
 from concord.models.votes import (
     HouseVoteMembers,
     SenateVoteDetail,
@@ -55,6 +56,7 @@ from concord.models.votes import (
 
 __all__ = [
     "Article",
+    "Attempt",
     "BillAction",
     "BillCosponsor",
     "BillDetail",
@@ -66,6 +68,8 @@ __all__ = [
     "Issue",
     "Member",
     "Proceeding",
+    "RunEvent",
+    "RunRecord",
     "SenateVoteDetail",
     "SenateVotePosition",
     "SessionNumber",

--- a/src/concord/models/runs.py
+++ b/src/concord/models/runs.py
@@ -1,0 +1,83 @@
+"""Domain models for the Scrape Run ledger (ADR 0021).
+
+A **Scrape Run** records one Stage-0 execution for one entity: per-endpoint
+counts of successful requests and a **Run Event** for every request that hit
+an error. Unlike the upstream entities in this package, these are
+Concord-*originated* records — there is no ``from_congress_api`` factory; they
+are produced by the :class:`~concord.observability.Recorder` and persisted by
+the SQLite ledger.
+
+These types are the single canonical shape of "one Scrape Run": the
+:mod:`concord.storage.sqlite` ledger projects a :class:`RunRecord` into the
+``runs`` row + ``run_events`` rows, and the ``runs.jsonl`` cold backup
+serializes *the same object*. Both representations are built from one value,
+so they cannot drift (the failure this prevents: a hand-maintained dict whose
+key — e.g. ``message`` vs ``msg`` — silently diverges from the producer).
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Attempt(BaseModel):
+    """One non-success try within a logical request's retry loop.
+
+    Exactly one of ``status`` / ``transport_class`` is set: ``status`` for an
+    HTTP response (including 429s and 5xx), ``transport_class`` for a
+    transport-level failure (the exception class name, e.g. ``ConnectError``).
+    ``n`` is the 1-based position within the request's attempt sequence.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    n: int
+    status: int | None
+    transport_class: str | None
+    message: str
+
+
+class RunEvent(BaseModel):
+    """The detail record of one error-encountering logical request.
+
+    Emitted iff a request had ≥1 non-success attempt (a first-try success is
+    aggregated as a count instead). ``final_status`` is ``"resolved"`` when a
+    later retry succeeded, ``"failed"`` when the request gave up / raised. The
+    ``attempts`` list is capped with ``overflow_count`` carrying the remainder
+    so a heavily rate-limited request can't store an unbounded array.
+    ``endpoint_bucket`` and the other field names match the ``run_events``
+    columns one-for-one.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    endpoint_bucket: str
+    attempts: list[Attempt]
+    overflow_count: int
+    final_status: str
+    ts: str
+
+
+class RunRecord(BaseModel):
+    """One persisted Scrape Run: the ``runs`` row plus its ``run_events``.
+
+    Field names match the ``runs`` columns one-for-one, except ``events``,
+    which the ledger fans out into the child ``run_events`` table (and which
+    the JSONL backup nests inline). ``status`` is ``ok`` / ``partial`` /
+    ``error``; ``throttle_counts`` is reserved (always ``None`` today).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    run_id: str
+    entity: str
+    command: str
+    started_at: str
+    ended_at: str | None
+    status: str
+    success_counts: dict[str, int]
+    throttle_counts: dict[str, int] | None
+    unmatched_sample: list[str]
+    error_event_count: int
+    events: list[RunEvent]
+
+
+__all__ = ["Attempt", "RunEvent", "RunRecord"]

--- a/src/concord/observability.py
+++ b/src/concord/observability.py
@@ -1,0 +1,438 @@
+"""Scrape-run observability — the ledger and its run_id-stamped logging.
+
+This module is the home of Concord's **Scrape Run** ledger (ADR 0021). It
+records, per Stage-0 execution for one entity, the count of successful
+network requests bucketed by endpoint and a detailed **Run Event** for
+every request that hit an error — including whether the error resolved on
+retry. See ``CONTEXT.md`` ("Observability") for the term definitions.
+
+The recorder rides ambient :mod:`contextvars` rather than injected
+parameters. The :func:`scrape_run` context manager mints a run_id, sets
+both contextvars at pull start, and resets + flushes in a ``finally``. Each
+HTTP client's network chokepoint does a two-line
+``rec = active_recorder(); if rec is not None: …`` — so the clients are a
+no-op when no scrape is active (tests, the web layer). This is a deliberate
+departure from Concord's otherwise-explicit injection style: run_id
+correlation for logging *cannot* be threaded as a parameter into a bare
+``_log.warning(...)`` deep in a retry loop — it fundamentally needs a
+contextvar — and the recorder rides the same mechanism (ADR 0021).
+
+The module is a thin shared helper, **not** a base class (ADR 0007). It is
+import-safe: nothing here touches SQLite or the filesystem at import time
+(:func:`scrape_run` lazy-imports the storage layer), so :mod:`concord.api`
+can import :func:`active_recorder` on its hot path with no heavy cost and no
+import cycle.
+"""
+
+import dataclasses
+import hashlib
+import itertools
+import json
+import logging
+import os
+import re
+import sys
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_log = logging.getLogger("concord.observability")
+
+#: Cap on stored attempts per Run Event. A heavily rate-limited request can
+#: retry hundreds of times; we keep the first N and count the rest so the
+#: ``attempts`` JSON array can't grow unbounded.
+_MAX_ATTEMPTS_PER_EVENT = 20
+
+#: Cap on the number of distinct unmatched concrete paths a single run
+#: samples (and warns about), so a systematically-misrouted scrape can't
+#: flood the log or the ``unmatched_sample`` column.
+_MAX_UNMATCHED_SAMPLE = 20
+
+
+# ---------------------------------------------------------------------------
+# Context variables + readers
+# ---------------------------------------------------------------------------
+
+_run_id: ContextVar[str | None] = ContextVar("concord_run_id", default=None)
+_recorder: "ContextVar[Recorder | None]" = ContextVar("concord_recorder", default=None)
+
+
+def current_run_id() -> str | None:
+    """Return the active Scrape Run's id, or ``None`` outside a run."""
+    return _run_id.get()
+
+
+def active_recorder() -> "Recorder | None":
+    """Return the active :class:`Recorder`, or ``None`` outside a run.
+
+    The HTTP clients call this on every request; a ``None`` return means no
+    scrape is active and the client should record nothing.
+    """
+    return _recorder.get()
+
+
+# ---------------------------------------------------------------------------
+# Endpoint route table + normalizer
+# ---------------------------------------------------------------------------
+
+# Ordered (regex, template) routes per source. First match wins; the
+# template is fed to ``re.Match.expand`` so a backreference like ``\1`` can
+# splice a captured path segment into the bucket. A concrete path that
+# matches nothing falls to ``f"{source}:unmatched"`` (see :meth:`normalize`).
+#
+# Concrete per-resource URLs (``/bill/119/hr/1234``) are never the key —
+# that would defeat aggregation (ADR 0021). Order matters: the more specific
+# routes must precede their prefixes (``…/articles`` before the list,
+# ``bill/{sub}`` before ``bill/detail`` before ``bill/list``).
+#
+# PR 1 (this slice) populates only ``"api"``; PR 2 adds ``"text"`` and
+# ``"senate"`` keys here and instruments their clients — the public shape
+# of this table is part of the contract those edits build on.
+_ROUTES: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
+    "api": (
+        (
+            re.compile(r"^/?daily-congressional-record/\d+/\d+/articles/?$"),
+            "api:daily-record/articles",
+        ),
+        (re.compile(r"^/?daily-congressional-record/?$"), "api:daily-record/list"),
+        (re.compile(r"^/?member/congress/\d+/?$"), "api:member/list"),
+        (re.compile(r"^/?bill/\d+/[a-z]+/\d+/([a-z]+)/?$"), r"api:bill/\1"),
+        (re.compile(r"^/?bill/\d+/[a-z]+/\d+/?$"), "api:bill/detail"),
+        (re.compile(r"^/?bill/\d+/[a-z]+/?$"), "api:bill/list"),
+        (re.compile(r"^/?house-vote/\d+/\d+/\d+/members/?$"), "api:house-vote/members"),
+        (re.compile(r"^/?house-vote/\d+/\d+/\d+/?$"), "api:house-vote/detail"),
+        (re.compile(r"^/?house-vote/\d+/\d+/?$"), "api:house-vote/list"),
+    ),
+}
+
+
+def normalize(source: str, path: str) -> str:
+    """Map a concrete request ``path`` to its stable Endpoint bucket.
+
+    Returns the first matching route's expanded template for ``source``, or
+    ``f"{source}:unmatched"`` when nothing matches (or the source is
+    unknown). This function is pure — the loud sampling + ``WARNING`` for the
+    unmatched case lives in :meth:`Recorder._bucket`.
+    """
+    for regex, template in _ROUTES.get(source, ()):
+        match = regex.match(path)
+        if match is not None:
+            return match.expand(template)
+    return f"{source}:unmatched"
+
+
+# ---------------------------------------------------------------------------
+# Recorder + its value objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Attempt:
+    """One non-success try within a logical request's retry loop.
+
+    Exactly one of ``status`` / ``transport_class`` is set: ``status`` for an
+    HTTP response (including 429s and 5xx), ``transport_class`` for a
+    transport-level failure (the exception class name, e.g. ``ConnectError``).
+    """
+
+    n: int
+    status: int | None
+    transport_class: str | None
+    message: str
+
+
+@dataclass
+class RunEvent:
+    """The detail record of one error-encountering logical request.
+
+    Emitted iff a request had ≥1 non-success attempt (a first-try success is
+    aggregated as a count instead). ``final_status`` is ``"resolved"`` when a
+    later retry succeeded, ``"failed"`` when the request gave up / raised.
+    """
+
+    bucket: str
+    attempts: list[Attempt]
+    overflow_count: int
+    final_status: str
+    ts: str
+
+
+@dataclass
+class Recorder:
+    """Accumulates one Scrape Run's success counts and Run Events.
+
+    A plain object (no inheritance, per ADR 0007). Lives behind the
+    :data:`_recorder` contextvar; the HTTP clients call :meth:`note_success`
+    and :meth:`note_request_outcome` on it, and :func:`scrape_run` flushes its
+    contents on exit.
+    """
+
+    entity: str
+    command: str
+    started_at: datetime
+    successes: dict[str, int] = field(default_factory=dict)
+    events: list[RunEvent] = field(default_factory=list)
+    unmatched: set[str] = field(default_factory=set)
+
+    def note_success(self, source: str, path: str) -> None:
+        """Record one successful request against its Endpoint bucket."""
+        bucket = self._bucket(source, path)
+        self.successes[bucket] = self.successes.get(bucket, 0) + 1
+
+    def note_request_outcome(
+        self,
+        source: str,
+        path: str,
+        attempts: Sequence[Attempt],
+        *,
+        resolved: bool,
+    ) -> None:
+        """Record a Run Event for a request that had ≥1 non-success attempt.
+
+        ``attempts`` is the full ordered list of failed attempts; it is capped
+        at :data:`_MAX_ATTEMPTS_PER_EVENT` (keeping the earliest) with the
+        remainder counted in ``overflow_count``.
+        """
+        bucket = self._bucket(source, path)
+        capped = list(attempts[:_MAX_ATTEMPTS_PER_EVENT])
+        overflow = max(0, len(attempts) - _MAX_ATTEMPTS_PER_EVENT)
+        self.events.append(
+            RunEvent(
+                bucket=bucket,
+                attempts=capped,
+                overflow_count=overflow,
+                final_status="resolved" if resolved else "failed",
+                ts=datetime.now(UTC).isoformat(),
+            )
+        )
+
+    def _bucket(self, source: str, path: str) -> str:
+        """Normalize ``path`` to a bucket, loudly sampling unmatched paths."""
+        bucket = normalize(source, path)
+        if (
+            bucket == f"{source}:unmatched"
+            and path not in self.unmatched
+            and len(self.unmatched) < _MAX_UNMATCHED_SAMPLE
+        ):
+            self.unmatched.add(path)
+            _log.warning(
+                "unmatched %s endpoint path %r; bucketed as %s "
+                "(add a route to observability._ROUTES)",
+                source,
+                path,
+                bucket,
+            )
+        return bucket
+
+
+# ---------------------------------------------------------------------------
+# Central run_id-stamped logging
+# ---------------------------------------------------------------------------
+
+#: Marker attribute set on our handler so :func:`configure_logging` is
+#: idempotent — repeated CLI invocations in one process (tests) must not
+#: stack handlers.
+_HANDLER_FLAG = "_concord_run_id_handler"
+
+_LOG_FORMAT = "%(asctime)s %(levelname)s [%(run_id)s] %(name)s: %(message)s"
+
+
+class RunIdFormatter(logging.Formatter):
+    """A :class:`logging.Formatter` that stamps each record with the run_id.
+
+    Reads the :data:`_run_id` contextvar in :meth:`format`, so every existing
+    ``concord.*`` log line — including the api.py retry heartbeats — gains a
+    run_id with no call-site changes. ``-`` outside a run (ADR 0021).
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        record.run_id = current_run_id() or "-"
+        return super().format(record)
+
+
+def configure_logging(*, level: int = logging.INFO) -> None:
+    """Install the run_id-stamped stderr handler on the ``concord`` logger.
+
+    Idempotent: a second call is a no-op (the handler carries a marker
+    attribute we check for). Called from the CLI callback and ``serve``
+    startup only — never at import time, per ADR 0014 (the CLI is the
+    contract; library imports must stay side-effect-free).
+
+    Attaches to the ``concord`` logger (not the root) so the run_id format is
+    scoped to our lines and third-party loggers keep their own. Propagation is
+    left enabled: the root has no handler in normal CLI runs (so no duplicate),
+    and leaving it on means ``pytest``'s ``caplog`` — which captures at the
+    root — still sees ``concord.*`` records.
+    """
+    logger = logging.getLogger("concord")
+    for handler in logger.handlers:
+        if getattr(handler, _HANDLER_FLAG, False):
+            return
+    handler = logging.StreamHandler(sys.stderr)
+    setattr(handler, _HANDLER_FLAG, True)
+    handler.setFormatter(RunIdFormatter(_LOG_FORMAT))
+    logger.addHandler(handler)
+    logger.setLevel(level)
+
+
+# ---------------------------------------------------------------------------
+# Run-id minting + the scrape_run lifecycle
+# ---------------------------------------------------------------------------
+
+#: Process-local counter folded into the run_id token so two runs minted in
+#: the same wall-clock second (same entity, same pid) can't collide on the
+#: ``runs.run_id`` primary key. Deterministic per process (no randomness),
+#: which keeps test run_ids stable. See ADR 0021's open question.
+_run_counter = itertools.count()
+
+
+def _mint_run_id(started_at: datetime, entity: str) -> str:
+    """Mint a sortable, collision-resistant run_id.
+
+    Format ``"{started_at:%Y%m%dT%H%M%S}-{token}"`` — the timestamp prefix
+    sorts chronologically; the token is a short Blake2b digest of
+    ``(started_at, entity, pid, counter)``, avoiding ``random``/``uuid4`` so
+    runs are reproducible from their inputs.
+    """
+    seq = next(_run_counter)
+    raw = f"{started_at.isoformat()}|{entity}|{os.getpid()}|{seq}"
+    token = hashlib.blake2b(raw.encode("utf-8"), digest_size=4).hexdigest()
+    return f"{started_at:%Y%m%dT%H%M%S}-{token}"
+
+
+@contextmanager
+def scrape_run(
+    *,
+    entity: str,
+    command: str,
+    db_path: Path,
+    data_dir: Path | None = None,
+) -> Iterator[Recorder]:
+    """Own one Scrape Run's lifecycle: mint, record, flush.
+
+    On enter: stamp ``started_at`` (UTC), mint a run_id, bootstrap the ledger
+    schema (``ensure_schema``, ADR 0012 precedent), construct a
+    :class:`Recorder`, set both contextvars, and yield the recorder.
+
+    On exit (``finally``): reset both contextvars, then flush — INSERT one
+    ``runs`` row + N ``run_events`` rows (DB-authoritative), then append one
+    JSON line to ``<data_dir or db_path.parent>/runs.jsonl`` (cold backup).
+    The flush is best-effort: a persistence error is logged, never raised, so
+    it can't mask an in-flight exception from the scrape body.
+
+    ``db_path`` is required (no default) so this module stays a leaf and free
+    of any ``concord.cli`` import; the CLI call sites resolve the default.
+    """
+    # Lazy import keeps this module a leaf: api.py imports active_recorder on
+    # its hot path, and we don't want that to drag in the SQLite layer.
+    from concord.storage.sqlite import ensure_schema  # noqa: PLC0415 - keeps module a leaf
+
+    started_at = datetime.now(UTC)
+    run_id = _mint_run_id(started_at, entity)
+    ensure_schema(db_path)
+    recorder = Recorder(entity=entity, command=command, started_at=started_at)
+
+    token_id = _run_id.set(run_id)
+    token_rec = _recorder.set(recorder)
+    body_failed = False
+    try:
+        yield recorder
+    except BaseException:
+        body_failed = True
+        raise
+    finally:
+        _recorder.reset(token_rec)
+        _run_id.reset(token_id)
+        ended_at = datetime.now(UTC)
+        if body_failed:
+            status = "error"
+        elif any(event.final_status == "failed" for event in recorder.events):
+            status = "partial"
+        else:
+            status = "ok"
+        try:
+            _flush(
+                recorder,
+                run_id=run_id,
+                ended_at=ended_at,
+                status=status,
+                db_path=db_path,
+                data_dir=data_dir,
+            )
+        except Exception:
+            _log.exception("failed to persist scrape run %s", run_id)
+
+
+def _flush(
+    recorder: Recorder,
+    *,
+    run_id: str,
+    ended_at: datetime,
+    status: str,
+    db_path: Path,
+    data_dir: Path | None,
+) -> None:
+    """Write the run row + events to SQLite, then append the JSONL backup."""
+    from concord.storage.sqlite import SqliteStorage  # noqa: PLC0415 - keeps module a leaf
+
+    success_counts = dict(recorder.successes)
+    unmatched_sample = sorted(recorder.unmatched)
+    events_payload: list[dict[str, Any]] = [
+        {
+            "endpoint_bucket": event.bucket,
+            "attempts": [dataclasses.asdict(attempt) for attempt in event.attempts],
+            "overflow_count": event.overflow_count,
+            "final_status": event.final_status,
+            "ts": event.ts,
+        }
+        for event in recorder.events
+    ]
+    started_at_iso = recorder.started_at.isoformat()
+    ended_at_iso = ended_at.isoformat()
+
+    # DB authoritative.
+    storage = SqliteStorage(db_path, load_vec=False)
+    try:
+        with storage.transaction():
+            storage.insert_run(
+                run_id=run_id,
+                entity=recorder.entity,
+                command=recorder.command,
+                started_at=started_at_iso,
+                ended_at=ended_at_iso,
+                status=status,
+                success_counts=success_counts,
+                throttle_counts=None,
+                unmatched_sample=unmatched_sample,
+                error_event_count=len(recorder.events),
+            )
+            storage.insert_run_events(run_id, events_payload)
+    finally:
+        storage.close()
+
+    # Cold backup — never read in normal operation, disaster-recovery only
+    # (ADR 0021); a full row + events on one line.
+    backup_dir = data_dir if data_dir is not None else db_path.parent
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(
+        {
+            "run_id": run_id,
+            "entity": recorder.entity,
+            "command": recorder.command,
+            "started_at": started_at_iso,
+            "ended_at": ended_at_iso,
+            "status": status,
+            "success_counts": success_counts,
+            "throttle_counts": None,
+            "unmatched_sample": unmatched_sample,
+            "error_event_count": len(recorder.events),
+            "events": events_payload,
+        },
+        sort_keys=True,
+    )
+    with (backup_dir / "runs.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")

--- a/src/concord/observability.py
+++ b/src/concord/observability.py
@@ -24,7 +24,6 @@ can import :func:`active_recorder` on its hot path with no heavy cost and no
 import cycle.
 """
 
-import dataclasses
 import hashlib
 import itertools
 import json
@@ -38,7 +37,8 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+
+from concord.models import Attempt, RunEvent, RunRecord
 
 _log = logging.getLogger("concord.observability")
 
@@ -79,10 +79,16 @@ def active_recorder() -> "Recorder | None":
 # Endpoint route table + normalizer
 # ---------------------------------------------------------------------------
 
+#: Suffix of the bucket a path falls to when no route matches. The full
+#: sentinel is ``f"{source}{_UNMATCHED_SUFFIX}"``; :func:`normalize` returns a
+#: ``matched`` flag alongside the bucket so callers never have to reconstruct
+#: this string to detect the unmatched case.
+_UNMATCHED_SUFFIX = ":unmatched"
+
 # Ordered (regex, template) routes per source. First match wins; the
 # template is fed to ``re.Match.expand`` so a backreference like ``\1`` can
 # splice a captured path segment into the bucket. A concrete path that
-# matches nothing falls to ``f"{source}:unmatched"`` (see :meth:`normalize`).
+# matches nothing falls to ``f"{source}{_UNMATCHED_SUFFIX}"``.
 #
 # Concrete per-resource URLs (``/bill/119/hr/1234``) are never the key —
 # that would defeat aggregation (ADR 0021). Order matters: the more specific
@@ -110,55 +116,27 @@ _ROUTES: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
 }
 
 
-def normalize(source: str, path: str) -> str:
-    """Map a concrete request ``path`` to its stable Endpoint bucket.
+def normalize(source: str, path: str) -> tuple[str, bool]:
+    """Map a concrete request ``path`` to ``(bucket, matched)``.
 
-    Returns the first matching route's expanded template for ``source``, or
-    ``f"{source}:unmatched"`` when nothing matches (or the source is
-    unknown). This function is pure — the loud sampling + ``WARNING`` for the
+    ``matched`` is ``True`` when a route fired (``bucket`` is its expanded
+    template) and ``False`` when nothing matched (``bucket`` is the
+    ``f"{source}{_UNMATCHED_SUFFIX}"`` sentinel). Returning the flag means
+    callers key off a real value instead of re-deriving and comparing the
+    sentinel string — change the format here and the unmatched-detection
+    can't silently stop firing. Pure: the loud sampling + ``WARNING`` for the
     unmatched case lives in :meth:`Recorder._bucket`.
     """
     for regex, template in _ROUTES.get(source, ()):
         match = regex.match(path)
         if match is not None:
-            return match.expand(template)
-    return f"{source}:unmatched"
+            return match.expand(template), True
+    return f"{source}{_UNMATCHED_SUFFIX}", False
 
 
 # ---------------------------------------------------------------------------
-# Recorder + its value objects
+# Recorder
 # ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class Attempt:
-    """One non-success try within a logical request's retry loop.
-
-    Exactly one of ``status`` / ``transport_class`` is set: ``status`` for an
-    HTTP response (including 429s and 5xx), ``transport_class`` for a
-    transport-level failure (the exception class name, e.g. ``ConnectError``).
-    """
-
-    n: int
-    status: int | None
-    transport_class: str | None
-    message: str
-
-
-@dataclass
-class RunEvent:
-    """The detail record of one error-encountering logical request.
-
-    Emitted iff a request had ≥1 non-success attempt (a first-try success is
-    aggregated as a count instead). ``final_status`` is ``"resolved"`` when a
-    later retry succeeded, ``"failed"`` when the request gave up / raised.
-    """
-
-    bucket: str
-    attempts: list[Attempt]
-    overflow_count: int
-    final_status: str
-    ts: str
 
 
 @dataclass
@@ -167,8 +145,10 @@ class Recorder:
 
     A plain object (no inheritance, per ADR 0007). Lives behind the
     :data:`_recorder` contextvar; the HTTP clients call :meth:`note_success`
-    and :meth:`note_request_outcome` on it, and :func:`scrape_run` flushes its
-    contents on exit.
+    and :meth:`note_request_outcome` on it. At flush, :func:`scrape_run` turns
+    its accumulated state into a single :class:`RunRecord` via
+    :meth:`to_run_record` — the live runtime state stays here, the
+    serializable record lives in :mod:`concord.models`.
     """
 
     entity: str
@@ -202,7 +182,7 @@ class Recorder:
         overflow = max(0, len(attempts) - _MAX_ATTEMPTS_PER_EVENT)
         self.events.append(
             RunEvent(
-                bucket=bucket,
+                endpoint_bucket=bucket,
                 attempts=capped,
                 overflow_count=overflow,
                 final_status="resolved" if resolved else "failed",
@@ -210,11 +190,31 @@ class Recorder:
             )
         )
 
+    def to_run_record(self, *, run_id: str, ended_at: datetime, status: str) -> RunRecord:
+        """Freeze the accumulated state into a single canonical :class:`RunRecord`.
+
+        This one object is the source for both the SQLite ledger row + events
+        and the ``runs.jsonl`` backup, so the two representations cannot drift.
+        """
+        return RunRecord(
+            run_id=run_id,
+            entity=self.entity,
+            command=self.command,
+            started_at=self.started_at.isoformat(),
+            ended_at=ended_at.isoformat(),
+            status=status,
+            success_counts=dict(self.successes),
+            throttle_counts=None,
+            unmatched_sample=sorted(self.unmatched),
+            error_event_count=len(self.events),
+            events=list(self.events),
+        )
+
     def _bucket(self, source: str, path: str) -> str:
         """Normalize ``path`` to a bucket, loudly sampling unmatched paths."""
-        bucket = normalize(source, path)
+        bucket, matched = normalize(source, path)
         if (
-            bucket == f"{source}:unmatched"
+            not matched
             and path not in self.unmatched
             and len(self.unmatched) < _MAX_UNMATCHED_SAMPLE
         ):
@@ -351,88 +351,39 @@ def scrape_run(
         if body_failed:
             status = "error"
         elif any(event.final_status == "failed" for event in recorder.events):
+            # Reachable only when a scraper catches a request failure and
+            # carries on (e.g. Bills enrich's per-section failures, and PR 2's
+            # other scrapers). The Bills basic path lets an ApiError propagate,
+            # so its terminal failures land in the body_failed -> "error" branch
+            # above; "partial" is the forward-looking middle state.
             status = "partial"
         else:
             status = "ok"
         try:
-            _flush(
-                recorder,
-                run_id=run_id,
-                ended_at=ended_at,
-                status=status,
-                db_path=db_path,
-                data_dir=data_dir,
-            )
+            record = recorder.to_run_record(run_id=run_id, ended_at=ended_at, status=status)
+            _flush(record, db_path=db_path, data_dir=data_dir)
         except Exception:
             _log.exception("failed to persist scrape run %s", run_id)
 
 
-def _flush(
-    recorder: Recorder,
-    *,
-    run_id: str,
-    ended_at: datetime,
-    status: str,
-    db_path: Path,
-    data_dir: Path | None,
-) -> None:
-    """Write the run row + events to SQLite, then append the JSONL backup."""
+def _flush(record: RunRecord, *, db_path: Path, data_dir: Path | None) -> None:
+    """Persist one :class:`RunRecord`: SQLite ledger (authoritative) + JSONL backup.
+
+    The same ``record`` drives both writes, so the DB row and the cold backup
+    are provably the same value.
+    """
     from concord.storage.sqlite import SqliteStorage  # noqa: PLC0415 - keeps module a leaf
 
-    success_counts = dict(recorder.successes)
-    unmatched_sample = sorted(recorder.unmatched)
-    events_payload: list[dict[str, Any]] = [
-        {
-            "endpoint_bucket": event.bucket,
-            "attempts": [dataclasses.asdict(attempt) for attempt in event.attempts],
-            "overflow_count": event.overflow_count,
-            "final_status": event.final_status,
-            "ts": event.ts,
-        }
-        for event in recorder.events
-    ]
-    started_at_iso = recorder.started_at.isoformat()
-    ended_at_iso = ended_at.isoformat()
-
     # DB authoritative.
-    storage = SqliteStorage(db_path, load_vec=False)
-    try:
-        with storage.transaction():
-            storage.insert_run(
-                run_id=run_id,
-                entity=recorder.entity,
-                command=recorder.command,
-                started_at=started_at_iso,
-                ended_at=ended_at_iso,
-                status=status,
-                success_counts=success_counts,
-                throttle_counts=None,
-                unmatched_sample=unmatched_sample,
-                error_event_count=len(recorder.events),
-            )
-            storage.insert_run_events(run_id, events_payload)
-    finally:
-        storage.close()
+    with SqliteStorage(db_path, load_vec=False) as storage, storage.transaction():
+        storage.insert_run(record)
+        storage.insert_run_events(record.run_id, record.events)
 
     # Cold backup — never read in normal operation, disaster-recovery only
-    # (ADR 0021); a full row + events on one line.
+    # (ADR 0021); the full record (row + nested events) on one line. Serialized
+    # with sorted keys throughout so the backup is byte-reproducible for diffing.
     backup_dir = data_dir if data_dir is not None else db_path.parent
     backup_dir.mkdir(parents=True, exist_ok=True)
-    line = json.dumps(
-        {
-            "run_id": run_id,
-            "entity": recorder.entity,
-            "command": recorder.command,
-            "started_at": started_at_iso,
-            "ended_at": ended_at_iso,
-            "status": status,
-            "success_counts": success_counts,
-            "throttle_counts": None,
-            "unmatched_sample": unmatched_sample,
-            "error_event_count": len(recorder.events),
-            "events": events_payload,
-        },
-        sort_keys=True,
-    )
+    line = json.dumps(record.model_dump(mode="json"), sort_keys=True)
     with (backup_dir / "runs.jsonl").open("a", encoding="utf-8") as handle:
         handle.write(line + "\n")

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -22,8 +22,9 @@ default (``True``) is what the pipeline needs. Tests and any Stage-1-only
 caller can pass ``load_vec=False`` to skip the extension entirely.
 """
 
+import json
 import sqlite3
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from types import TracebackType
@@ -369,6 +370,38 @@ CREATE TABLE IF NOT EXISTS bill_briefs (
     generated_at       TEXT NOT NULL,
     PRIMARY KEY (bill_id, lens)
 );
+
+-- runs + run_events are RECORD tables (ADR 0019), not mirrors: each row is
+-- the durable ledger of one Stage-0 Scrape Run (ADR 0021). They are
+-- Concord-originated, not rebuildable from upstream JSONL, and an entity
+-- re-derivation (re-run scrape/load/index) must NOT touch them — ensure_schema
+-- is CREATE IF NOT EXISTS so they survive a rebuild. runs.jsonl is written
+-- alongside as a cold backup; this table is the queried source of truth.
+-- success_counts / throttle_counts / unmatched_sample hold JSON; throttle_counts
+-- is reserved for a later throttle-aware metric. status is ok/partial/error.
+CREATE TABLE IF NOT EXISTS runs (
+    run_id             TEXT PRIMARY KEY,
+    entity             TEXT NOT NULL,
+    command            TEXT NOT NULL,
+    started_at         TEXT NOT NULL,
+    ended_at           TEXT,
+    status             TEXT NOT NULL,
+    success_counts     TEXT NOT NULL,
+    throttle_counts    TEXT,
+    unmatched_sample   TEXT,
+    error_event_count  INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS run_events (
+    run_id           TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+    seq              INTEGER NOT NULL,
+    endpoint_bucket  TEXT NOT NULL,
+    attempts         TEXT NOT NULL,
+    overflow_count   INTEGER NOT NULL DEFAULT 0,
+    final_status     TEXT NOT NULL,
+    ts               TEXT NOT NULL,
+    PRIMARY KEY (run_id, seq)
+);
 """
 
 # Column lists for members + member_terms tables. Mirrors the ``_PROCEEDING_COLUMNS``
@@ -604,6 +637,35 @@ _BILL_BRIEF_UPSERT_SQL = (
     )
 )
 
+# runs / run_events are record tables (ADR 0019, 0021); these power the
+# ledger inserts in insert_run / insert_run_events. Plain INSERTs (no
+# UPSERT): a run_id is minted fresh per Scrape Run, so a conflict is a bug.
+_RUN_COLUMNS: tuple[str, ...] = (
+    "run_id",
+    "entity",
+    "command",
+    "started_at",
+    "ended_at",
+    "status",
+    "success_counts",
+    "throttle_counts",
+    "unmatched_sample",
+    "error_event_count",
+)
+
+_RUN_EVENT_COLUMNS: tuple[str, ...] = (
+    "run_id",
+    "seq",
+    "endpoint_bucket",
+    "attempts",
+    "overflow_count",
+    "final_status",
+    "ts",
+)
+
+_RUN_INSERT_SQL = _insert_sql("runs", _RUN_COLUMNS)
+_RUN_EVENT_INSERT_SQL = _insert_sql("run_events", _RUN_EVENT_COLUMNS)
+
 # Vec-only schema. Only created when load_vec=True.
 _VEC_SCHEMA = """
 CREATE VIRTUAL TABLE IF NOT EXISTS chunks_vec USING vec0(
@@ -688,6 +750,44 @@ def _m002_add_bill_briefs(conn: sqlite3.Connection) -> None:
     )
 
 
+def _m003_add_runs_tables(conn: sqlite3.Connection) -> None:
+    """ADR 0021: the ``runs`` + ``run_events`` Scrape Run ledger tables.
+
+    ``CREATE TABLE IF NOT EXISTS`` is idempotent against fresh installs
+    (whose ``_BASE_SCHEMA`` already declares both tables; this is a no-op)
+    and against pre-0021 DBs (which gain the tables here). The DDL must stay
+    byte-equivalent to the ``_BASE_SCHEMA`` declaration — the
+    schema-equivalence test (ADR 0017) fails if they drift.
+    """
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS runs (
+            run_id             TEXT PRIMARY KEY,
+            entity             TEXT NOT NULL,
+            command            TEXT NOT NULL,
+            started_at         TEXT NOT NULL,
+            ended_at           TEXT,
+            status             TEXT NOT NULL,
+            success_counts     TEXT NOT NULL,
+            throttle_counts    TEXT,
+            unmatched_sample   TEXT,
+            error_event_count  INTEGER NOT NULL DEFAULT 0
+        );
+
+        CREATE TABLE IF NOT EXISTS run_events (
+            run_id           TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+            seq              INTEGER NOT NULL,
+            endpoint_bucket  TEXT NOT NULL,
+            attempts         TEXT NOT NULL,
+            overflow_count   INTEGER NOT NULL DEFAULT 0,
+            final_status     TEXT NOT NULL,
+            ts               TEXT NOT NULL,
+            PRIMARY KEY (run_id, seq)
+        );
+        """
+    )
+
+
 #: Ordered, append-only schema migrations. Each entry is
 #: ``(version, callable)``; the callable receives a connection and
 #: mutates it to bring the DB from version N-1 to version N. The
@@ -699,6 +799,7 @@ def _m002_add_bill_briefs(conn: sqlite3.Connection) -> None:
 _MIGRATIONS: tuple[tuple[int, Callable[[sqlite3.Connection], None]], ...] = (
     (1, _m001_add_bill_last_enrichment_error),
     (2, _m002_add_bill_briefs),
+    (3, _m003_add_runs_tables),
 )
 _HEAD: int = _MIGRATIONS[-1][0] if _MIGRATIONS else 0
 
@@ -1201,6 +1302,89 @@ class SqliteStorage:
                     generated_at,
                 ),
             )
+
+    # -- Scrape Run ledger (ADR 0021) -------------------------------------
+
+    def insert_run(  # noqa: PLR0913 — one kwarg per `runs` ledger column (ADR 0021)
+        self,
+        *,
+        run_id: str,
+        entity: str,
+        command: str,
+        started_at: str,
+        ended_at: str | None,
+        status: str,
+        success_counts: dict[str, int],
+        throttle_counts: dict[str, int] | None,
+        unmatched_sample: Sequence[str],
+        error_event_count: int,
+    ) -> None:
+        """INSERT one ``runs`` ledger row (ADR 0021).
+
+        A record-table write (ADR 0019): re-running scrape/load/index never
+        rewrites it. The JSON columns are serialized here — ``success_counts``
+        with sorted keys for stable output; ``unmatched_sample`` and a missing
+        ``throttle_counts`` collapse to SQL ``NULL`` when empty.
+        """
+        with self._maybe_transaction():
+            self._conn.execute(
+                _RUN_INSERT_SQL,
+                (
+                    run_id,
+                    entity,
+                    command,
+                    started_at,
+                    ended_at,
+                    status,
+                    json.dumps(success_counts, sort_keys=True),
+                    json.dumps(throttle_counts, sort_keys=True)
+                    if throttle_counts is not None
+                    else None,
+                    json.dumps(list(unmatched_sample)) if unmatched_sample else None,
+                    error_event_count,
+                ),
+            )
+
+    def insert_run_events(self, run_id: str, events: Sequence[Mapping[str, Any]]) -> None:
+        """Bulk-INSERT the Run Events for one Scrape Run (ADR 0021).
+
+        ``seq`` is assigned from the list order. Each event maps
+        ``endpoint_bucket`` / ``attempts`` (a list serialized to JSON) /
+        ``overflow_count`` / ``final_status`` / ``ts``. A no-op for a clean
+        run with zero error events. The parent ``runs`` row must already
+        exist (FKs are on); :func:`concord.observability.scrape_run` inserts
+        it first in the same transaction.
+        """
+        if not events:
+            return
+        rows = [
+            (
+                run_id,
+                seq,
+                event["endpoint_bucket"],
+                json.dumps(event["attempts"]),
+                event["overflow_count"],
+                event["final_status"],
+                event["ts"],
+            )
+            for seq, event in enumerate(events)
+        ]
+        with self._maybe_transaction():
+            self._conn.executemany(_RUN_EVENT_INSERT_SQL, rows)
+
+    def get_run(self, run_id: str) -> sqlite3.Row | None:
+        """Return the ``runs`` row for ``run_id``, or ``None`` if absent."""
+        cursor = self._conn.execute("SELECT * FROM runs WHERE run_id = ?", (run_id,))
+        row: sqlite3.Row | None = cursor.fetchone()
+        return row
+
+    def list_run_events(self, run_id: str) -> list[sqlite3.Row]:
+        """Return every ``run_events`` row for ``run_id``, ordered by ``seq``."""
+        cursor = self._conn.execute(
+            "SELECT * FROM run_events WHERE run_id = ? ORDER BY seq ASC",
+            (run_id,),
+        )
+        return cursor.fetchall()
 
     # -- Votes (Phase 3a) -------------------------------------------------
 

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -24,7 +24,7 @@ caller can pass ``load_vec=False`` to skip the extension entirely.
 
 import json
 import sqlite3
-from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from types import TracebackType
@@ -41,6 +41,8 @@ from concord.models import (
     BillTitle,
     Member,
     Proceeding,
+    RunEvent,
+    RunRecord,
     Term,
     Vote,
     VotePosition,
@@ -1305,70 +1307,28 @@ class SqliteStorage:
 
     # -- Scrape Run ledger (ADR 0021) -------------------------------------
 
-    def insert_run(  # noqa: PLR0913 — one kwarg per `runs` ledger column (ADR 0021)
-        self,
-        *,
-        run_id: str,
-        entity: str,
-        command: str,
-        started_at: str,
-        ended_at: str | None,
-        status: str,
-        success_counts: dict[str, int],
-        throttle_counts: dict[str, int] | None,
-        unmatched_sample: Sequence[str],
-        error_event_count: int,
-    ) -> None:
-        """INSERT one ``runs`` ledger row (ADR 0021).
+    def insert_run(self, run: RunRecord) -> None:
+        """INSERT one ``runs`` ledger row from a :class:`RunRecord` (ADR 0021).
 
         A record-table write (ADR 0019): re-running scrape/load/index never
-        rewrites it. The JSON columns are serialized here — ``success_counts``
-        with sorted keys for stable output; ``unmatched_sample`` and a missing
-        ``throttle_counts`` collapse to SQL ``NULL`` when empty.
+        rewrites it. Column projection + JSON serialization live in
+        :func:`_row_from_run`, mirroring :func:`_row_from_vote`. Does not
+        write ``run.events`` — those fan out via :meth:`insert_run_events`.
         """
         with self._maybe_transaction():
-            self._conn.execute(
-                _RUN_INSERT_SQL,
-                (
-                    run_id,
-                    entity,
-                    command,
-                    started_at,
-                    ended_at,
-                    status,
-                    json.dumps(success_counts, sort_keys=True),
-                    json.dumps(throttle_counts, sort_keys=True)
-                    if throttle_counts is not None
-                    else None,
-                    json.dumps(list(unmatched_sample)) if unmatched_sample else None,
-                    error_event_count,
-                ),
-            )
+            self._conn.execute(_RUN_INSERT_SQL, _row_from_run(run))
 
-    def insert_run_events(self, run_id: str, events: Sequence[Mapping[str, Any]]) -> None:
-        """Bulk-INSERT the Run Events for one Scrape Run (ADR 0021).
+    def insert_run_events(self, run_id: str, events: Sequence[RunEvent]) -> None:
+        """Bulk-INSERT the :class:`RunEvent` rows for one Scrape Run (ADR 0021).
 
-        ``seq`` is assigned from the list order. Each event maps
-        ``endpoint_bucket`` / ``attempts`` (a list serialized to JSON) /
-        ``overflow_count`` / ``final_status`` / ``ts``. A no-op for a clean
-        run with zero error events. The parent ``runs`` row must already
-        exist (FKs are on); :func:`concord.observability.scrape_run` inserts
-        it first in the same transaction.
+        ``seq`` is assigned from the list order. A no-op for a clean run with
+        zero error events. The parent ``runs`` row must already exist (FKs are
+        on); :func:`concord.observability.scrape_run` inserts it first in the
+        same transaction.
         """
         if not events:
             return
-        rows = [
-            (
-                run_id,
-                seq,
-                event["endpoint_bucket"],
-                json.dumps(event["attempts"]),
-                event["overflow_count"],
-                event["final_status"],
-                event["ts"],
-            )
-            for seq, event in enumerate(events)
-        ]
+        rows = [_row_from_run_event(run_id, seq, event) for seq, event in enumerate(events)]
         with self._maybe_transaction():
             self._conn.executemany(_RUN_EVENT_INSERT_SQL, rows)
 
@@ -1609,3 +1569,53 @@ def _row_from_vote(vote: Vote, *, fetched_at: str) -> tuple[Any, ...]:
     dumped["fetched_at"] = fetched_at
     dumped["is_party_unity"] = 1 if dumped.get("is_party_unity") else 0
     return tuple(dumped[col] for col in _VOTE_COLUMNS)
+
+
+def _row_from_run(run: RunRecord) -> tuple[Any, ...]:
+    """Project a :class:`RunRecord` into the ``runs`` column tuple (ADR 0021).
+
+    Owns the JSON-column serialization: ``success_counts`` /
+    ``throttle_counts`` / ``unmatched_sample`` are dumped with sorted keys for
+    a byte-stable row, and an empty ``unmatched_sample`` or absent
+    ``throttle_counts`` collapses to SQL ``NULL``.
+    """
+    values: dict[str, Any] = {
+        "run_id": run.run_id,
+        "entity": run.entity,
+        "command": run.command,
+        "started_at": run.started_at,
+        "ended_at": run.ended_at,
+        "status": run.status,
+        "success_counts": json.dumps(run.success_counts, sort_keys=True),
+        "throttle_counts": (
+            json.dumps(run.throttle_counts, sort_keys=True)
+            if run.throttle_counts is not None
+            else None
+        ),
+        "unmatched_sample": (
+            json.dumps(run.unmatched_sample, sort_keys=True) if run.unmatched_sample else None
+        ),
+        "error_event_count": run.error_event_count,
+    }
+    return tuple(values[col] for col in _RUN_COLUMNS)
+
+
+def _row_from_run_event(run_id: str, seq: int, event: RunEvent) -> tuple[Any, ...]:
+    """Project one :class:`RunEvent` into the ``run_events`` column tuple.
+
+    ``run_id`` / ``seq`` are supplied by the caller (the parent run and the
+    event's position); ``attempts`` is dumped with sorted keys to match
+    :func:`_row_from_run`'s byte-stable policy.
+    """
+    values: dict[str, Any] = {
+        "run_id": run_id,
+        "seq": seq,
+        "endpoint_bucket": event.endpoint_bucket,
+        "attempts": json.dumps(
+            [attempt.model_dump() for attempt in event.attempts], sort_keys=True
+        ),
+        "overflow_count": event.overflow_count,
+        "final_status": event.final_status,
+        "ts": event.ts,
+    }
+    return tuple(values[col] for col in _RUN_EVENT_COLUMNS)

--- a/tests/test_api_recording.py
+++ b/tests/test_api_recording.py
@@ -71,7 +71,7 @@ class TestErrorRecording:
         assert rec.successes == {"api:daily-record/list": 1}
         assert len(rec.events) == 1
         event = rec.events[0]
-        assert event.bucket == "api:daily-record/list"
+        assert event.endpoint_bucket == "api:daily-record/list"
         assert event.final_status == "resolved"
         assert [a.status for a in event.attempts] == [503]
 

--- a/tests/test_api_recording.py
+++ b/tests/test_api_recording.py
@@ -1,0 +1,129 @@
+"""api.py chokepoint recording — successes bump the right bucket, error
+outcomes emit Run Events with retry resolution, and 429s are recorded as
+errors (ADR 0021). Retry *behavior* is covered by test_api.py and unchanged.
+
+All tests run inside a manually-installed Recorder contextvar rather than a
+full ``scrape_run`` so they assert against in-memory state without touching
+SQLite.
+"""
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from concord.api import ApiError, Client
+from concord.observability import Recorder, _recorder
+
+
+@contextmanager
+def _active_recorder() -> Iterator[Recorder]:
+    rec = Recorder(entity="bills", command="scrape bills", started_at=datetime.now(UTC))
+    token = _recorder.set(rec)
+    try:
+        yield rec
+    finally:
+        _recorder.reset(token)
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> Client:
+    return Client(api_key="test-key", transport=httpx.MockTransport(handler), sleep=lambda _s: None)
+
+
+def _sequenced(items: list[httpx.Response]) -> Callable[[httpx.Request], httpx.Response]:
+    iterator = iter(items)
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return next(iterator)
+
+    return handler
+
+
+def _ok() -> httpx.Response:
+    return httpx.Response(
+        200,
+        content=b'{"dailyCongressionalRecord": [], "pagination": {"count": 0}}',
+        headers={"content-type": "application/json"},
+    )
+
+
+class TestSuccessRecording:
+    def test_clean_request_bumps_bucket_and_emits_no_event(self) -> None:
+        with _active_recorder() as rec, _client(lambda _r: _ok()) as client:
+            client.list_issues()
+        assert rec.successes == {"api:daily-record/list": 1}
+        assert rec.events == []
+
+    def test_no_recorder_is_a_noop(self) -> None:
+        # Outside a run there is no recorder; the client must not raise.
+        with _client(lambda _r: _ok()) as client:
+            issues, _ = client.list_issues()
+        assert issues == []
+
+
+class TestErrorRecording:
+    def test_503_then_200_emits_one_resolved_event(self) -> None:
+        handler = _sequenced([httpx.Response(503), _ok()])
+        with _active_recorder() as rec, _client(handler) as client:
+            client.list_issues()
+        assert rec.successes == {"api:daily-record/list": 1}
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.bucket == "api:daily-record/list"
+        assert event.final_status == "resolved"
+        assert [a.status for a in event.attempts] == [503]
+
+    def test_terminal_503_emits_one_failed_event(self) -> None:
+        handler = _sequenced([httpx.Response(503) for _ in range(6)])
+        with (
+            _active_recorder() as rec,
+            _client(handler) as client,
+            pytest.raises(ApiError, match="gave up after 5 attempts"),
+        ):
+            client.list_issues()
+        assert rec.successes == {}
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.final_status == "failed"
+        # Six attempts: the initial try + five retries, all 503.
+        assert [a.status for a in event.attempts] == [503] * 6
+
+    def test_429_then_200_records_resolved_event_with_429_attempt(self) -> None:
+        handler = _sequenced([httpx.Response(429), _ok()])
+        with _active_recorder() as rec, _client(handler) as client:
+            client.list_issues()
+        assert rec.successes == {"api:daily-record/list": 1}
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.final_status == "resolved"
+        assert [a.status for a in event.attempts] == [429]
+
+    def test_non_retryable_4xx_emits_failed_event(self) -> None:
+        with (
+            _active_recorder() as rec,
+            _client(lambda _r: httpx.Response(404)) as client,
+            pytest.raises(ApiError),
+        ):
+            client.list_issues()
+        assert rec.successes == {}
+        assert len(rec.events) == 1
+        assert rec.events[0].final_status == "failed"
+        assert rec.events[0].attempts[0].status == 404
+
+    def test_transport_error_then_success_records_transport_class(self) -> None:
+        calls = {"n": 0}
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise httpx.ConnectError("dns")
+            return _ok()
+
+        with _active_recorder() as rec, _client(handler) as client:
+            client.list_issues()
+        assert len(rec.events) == 1
+        attempt = rec.events[0].attempts[0]
+        assert attempt.status is None
+        assert attempt.transport_class == "ConnectError"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1132,6 +1132,38 @@ class TestScrapeBillsCommand:
         assert backup["run_id"] == run["run_id"]
         assert backup["success_counts"] == counts
 
+    def test_missing_key_records_no_ledger_artifacts(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A missing API key is a config error, not a scrape: it must exit 2
+        and mint no ledger DB or runs.jsonl (ADR 0021; consistent with
+        `run bills`). Client construction lives outside the scrape seam."""
+        monkeypatch.delenv(ENV_API_KEY, raising=False)
+        db_path = tmp_path / "ledger.db"
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "--congresses",
+                "119",
+                "--bill-types",
+                "hr",
+                "--storage-dir",
+                str(tmp_path),
+                "--db",
+                str(db_path),
+                "--no-progress",
+            ],
+        )
+        assert result.exit_code == 2
+        # No network was touched, so nothing should have been minted.
+        assert not db_path.exists()
+        assert not (tmp_path / "runs.jsonl").exists()
+
     def test_rejects_unknown_bill_type(
         self,
         runner: CliRunner,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1060,6 +1060,8 @@ class TestScrapeBillsCommand:
                 "hr",
                 "--storage-dir",
                 str(tmp_path),
+                "--db",
+                str(tmp_path / "ledger.db"),
                 "--limit",
                 "2",
                 "--no-progress",
@@ -1070,6 +1072,65 @@ class TestScrapeBillsCommand:
         assert out.exists()
         lines = out.read_text().splitlines()
         assert len(lines) == 2
+
+    def test_scrape_records_a_scrape_run(
+        self,
+        runner: CliRunner,
+        with_api_key: None,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A bills scrape persists a complete Scrape Run: DB row + JSONL line
+        with per-bucket success counts (ADR 0021)."""
+        handler = _bills_handler()
+        original_init = Client.__init__
+
+        def patched_init(self, **kwargs):
+            kwargs.setdefault("transport", httpx.MockTransport(handler))
+            kwargs.setdefault("sleep", lambda _s: None)
+            original_init(self, **kwargs)
+
+        monkeypatch.setattr(Client, "__init__", patched_init)
+
+        db_path = tmp_path / "ledger.db"
+        result = runner.invoke(
+            cli_module.app,
+            [
+                "scrape",
+                "bills",
+                "--congresses",
+                "119",
+                "--bill-types",
+                "hr",
+                "--storage-dir",
+                str(tmp_path),
+                "--db",
+                str(db_path),
+                "--limit",
+                "2",
+                "--no-progress",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        storage = SqliteStorage(db_path, load_vec=False)
+        try:
+            runs = storage._conn.execute("SELECT * FROM runs").fetchall()
+        finally:
+            storage.close()
+        assert len(runs) == 1
+        run = dict(runs[0])
+        assert run["entity"] == "bills"
+        assert run["command"] == "scrape bills"
+        assert run["status"] == "ok"
+        counts = json.loads(run["success_counts"])
+        # One list page + two detail fetches, bucketed by endpoint.
+        assert counts["api:bill/list"] == 1
+        assert counts["api:bill/detail"] == 2
+
+        backup = json.loads((tmp_path / "runs.jsonl").read_text().splitlines()[0])
+        assert backup["run_id"] == run["run_id"]
+        assert backup["success_counts"] == counts
 
     def test_rejects_unknown_bill_type(
         self,

--- a/tests/test_observability_logging.py
+++ b/tests/test_observability_logging.py
@@ -1,0 +1,64 @@
+"""Central run_id-stamped logging — the formatter reads the run_id contextvar
+and the handler install is idempotent (ADR 0021)."""
+
+import logging
+
+from concord.observability import (
+    _HANDLER_FLAG,
+    RunIdFormatter,
+    _run_id,
+    configure_logging,
+)
+
+
+def _make_record() -> logging.LogRecord:
+    return logging.LogRecord(
+        name="concord.api",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=1,
+        msg="429 from %s",
+        args=("/bill/119/hr",),
+        exc_info=None,
+    )
+
+
+class TestRunIdFormatter:
+    def test_stamps_active_run_id(self) -> None:
+        formatter = RunIdFormatter("[%(run_id)s] %(message)s")
+        token = _run_id.set("20260603T120000-deadbeef")
+        try:
+            out = formatter.format(_make_record())
+        finally:
+            _run_id.reset(token)
+        assert out == "[20260603T120000-deadbeef] 429 from /bill/119/hr"
+
+    def test_stamps_dash_outside_a_run(self) -> None:
+        formatter = RunIdFormatter("[%(run_id)s] %(message)s")
+        out = formatter.format(_make_record())
+        assert out == "[-] 429 from /bill/119/hr"
+
+
+class TestConfigureLogging:
+    def _our_handlers(self) -> list[logging.Handler]:
+        logger = logging.getLogger("concord")
+        return [h for h in logger.handlers if getattr(h, _HANDLER_FLAG, False)]
+
+    def test_installs_one_handler(self) -> None:
+        logger = logging.getLogger("concord")
+        # Tear down any handler left by a previous test/CLI invocation.
+        for handler in self._our_handlers():
+            logger.removeHandler(handler)
+        configure_logging()
+        assert len(self._our_handlers()) == 1
+
+    def test_is_idempotent(self) -> None:
+        configure_logging()
+        configure_logging()
+        configure_logging()
+        assert len(self._our_handlers()) == 1
+
+    def test_handler_uses_run_id_formatter(self) -> None:
+        configure_logging()
+        handler = self._our_handlers()[0]
+        assert isinstance(handler.formatter, RunIdFormatter)

--- a/tests/test_observability_recorder.py
+++ b/tests/test_observability_recorder.py
@@ -3,7 +3,8 @@ resolved/failed Run Event classification (ADR 0021)."""
 
 from datetime import UTC, datetime
 
-from concord.observability import Attempt, Recorder
+from concord.models import Attempt
+from concord.observability import Recorder
 
 
 def _recorder() -> Recorder:
@@ -35,7 +36,7 @@ class TestRunEventClassification:
         rec.note_request_outcome("api", "/bill/119/hr/1", _attempts(2), resolved=True)
         assert len(rec.events) == 1
         event = rec.events[0]
-        assert event.bucket == "api:bill/detail"
+        assert event.endpoint_bucket == "api:bill/detail"
         assert event.final_status == "resolved"
         assert len(event.attempts) == 2
         assert event.overflow_count == 0
@@ -45,7 +46,7 @@ class TestRunEventClassification:
         rec = _recorder()
         rec.note_request_outcome("api", "/bill/119/hr", _attempts(6), resolved=False)
         assert rec.events[0].final_status == "failed"
-        assert rec.events[0].bucket == "api:bill/list"
+        assert rec.events[0].endpoint_bucket == "api:bill/list"
 
     def test_first_try_success_emits_no_event(self) -> None:
         rec = _recorder()

--- a/tests/test_observability_recorder.py
+++ b/tests/test_observability_recorder.py
@@ -1,0 +1,79 @@
+"""Recorder — success counting, attempt capping + overflow, and
+resolved/failed Run Event classification (ADR 0021)."""
+
+from datetime import UTC, datetime
+
+from concord.observability import Attempt, Recorder
+
+
+def _recorder() -> Recorder:
+    return Recorder(entity="bills", command="scrape bills", started_at=datetime.now(UTC))
+
+
+def _attempts(n: int) -> list[Attempt]:
+    return [
+        Attempt(n=i + 1, status=503, transport_class=None, message="Service Unavailable")
+        for i in range(n)
+    ]
+
+
+class TestSuccessCounting:
+    def test_counts_per_bucket(self) -> None:
+        rec = _recorder()
+        rec.note_success("api", "/bill/119/hr")
+        rec.note_success("api", "/bill/119/hr")
+        rec.note_success("api", "/bill/119/hr/1")
+        assert rec.successes == {"api:bill/list": 2, "api:bill/detail": 1}
+
+    def test_no_successes_starts_empty(self) -> None:
+        assert _recorder().successes == {}
+
+
+class TestRunEventClassification:
+    def test_resolved_event(self) -> None:
+        rec = _recorder()
+        rec.note_request_outcome("api", "/bill/119/hr/1", _attempts(2), resolved=True)
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.bucket == "api:bill/detail"
+        assert event.final_status == "resolved"
+        assert len(event.attempts) == 2
+        assert event.overflow_count == 0
+        assert event.ts  # a non-empty ISO timestamp
+
+    def test_failed_event(self) -> None:
+        rec = _recorder()
+        rec.note_request_outcome("api", "/bill/119/hr", _attempts(6), resolved=False)
+        assert rec.events[0].final_status == "failed"
+        assert rec.events[0].bucket == "api:bill/list"
+
+    def test_first_try_success_emits_no_event(self) -> None:
+        rec = _recorder()
+        rec.note_success("api", "/bill/119/hr")
+        assert rec.events == []
+
+
+class TestAttemptCapping:
+    def test_under_cap_keeps_all_attempts(self) -> None:
+        rec = _recorder()
+        rec.note_request_outcome("api", "/bill/119/hr/1", _attempts(20), resolved=True)
+        event = rec.events[0]
+        assert len(event.attempts) == 20
+        assert event.overflow_count == 0
+
+    def test_over_cap_truncates_and_counts_overflow(self) -> None:
+        rec = _recorder()
+        rec.note_request_outcome("api", "/bill/119/hr/1", _attempts(25), resolved=True)
+        event = rec.events[0]
+        assert len(event.attempts) == 20
+        assert event.overflow_count == 5
+        # The earliest attempts are the ones retained.
+        assert [a.n for a in event.attempts] == list(range(1, 21))
+
+    def test_attempt_carries_transport_class(self) -> None:
+        rec = _recorder()
+        attempts = [Attempt(n=1, status=None, transport_class="ConnectError", message="boom")]
+        rec.note_request_outcome("api", "/bill/119/hr", attempts, resolved=False)
+        recorded = rec.events[0].attempts[0]
+        assert recorded.status is None
+        assert recorded.transport_class == "ConnectError"

--- a/tests/test_observability_routes.py
+++ b/tests/test_observability_routes.py
@@ -33,10 +33,12 @@ class TestNormalize:
         ],
     )
     def test_known_api_paths_map_to_buckets(self, path: str, expected: str) -> None:
-        assert normalize("api", path) == expected
+        bucket, matched = normalize("api", path)
+        assert bucket == expected
+        assert matched is True
 
     def test_trailing_slash_does_not_change_bucket(self) -> None:
-        assert normalize("api", "/bill/119/hr/1234/") == "api:bill/detail"
+        assert normalize("api", "/bill/119/hr/1234/") == ("api:bill/detail", True)
 
     @pytest.mark.parametrize(
         "path",
@@ -49,11 +51,11 @@ class TestNormalize:
         ],
     )
     def test_unknown_path_falls_to_unmatched(self, path: str) -> None:
-        assert normalize("api", path) == "api:unmatched"
+        assert normalize("api", path) == ("api:unmatched", False)
 
     def test_unknown_source_is_unmatched(self) -> None:
-        assert normalize("text", "/anything") == "text:unmatched"
-        assert normalize("senate", "/anything") == "senate:unmatched"
+        assert normalize("text", "/anything") == ("text:unmatched", False)
+        assert normalize("senate", "/anything") == ("senate:unmatched", False)
 
 
 class TestUnmatchedSampling:

--- a/tests/test_observability_routes.py
+++ b/tests/test_observability_routes.py
@@ -1,0 +1,82 @@
+"""Endpoint-bucket route table — every api.congress.gov path shape maps to a
+stable bucket, and an unknown path falls to ``api:unmatched`` (ADR 0021)."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from concord.observability import Recorder, normalize
+
+
+class TestNormalize:
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            # daily congressional record — list + articles
+            ("/daily-congressional-record", "api:daily-record/list"),
+            ("/daily-congressional-record/", "api:daily-record/list"),
+            ("/daily-congressional-record/172/88/articles", "api:daily-record/articles"),
+            # members
+            ("/member/congress/119", "api:member/list"),
+            # bills — list, detail, and each sub-endpoint
+            ("/bill/119/hr", "api:bill/list"),
+            ("/bill/119/hr/1234", "api:bill/detail"),
+            ("/bill/119/hr/1234/cosponsors", "api:bill/cosponsors"),
+            ("/bill/119/hjres/22/actions", "api:bill/actions"),
+            ("/bill/118/sconres/3/subjects", "api:bill/subjects"),
+            ("/bill/119/s/5/titles", "api:bill/titles"),
+            ("/bill/119/hr/1/summaries", "api:bill/summaries"),
+            # house votes — list, detail, members
+            ("/house-vote/119/1", "api:house-vote/list"),
+            ("/house-vote/119/1/42", "api:house-vote/detail"),
+            ("/house-vote/119/1/42/members", "api:house-vote/members"),
+        ],
+    )
+    def test_known_api_paths_map_to_buckets(self, path: str, expected: str) -> None:
+        assert normalize("api", path) == expected
+
+    def test_trailing_slash_does_not_change_bucket(self) -> None:
+        assert normalize("api", "/bill/119/hr/1234/") == "api:bill/detail"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/totally-unknown-endpoint",
+            "/bill",
+            "/bill/119",
+            "/member",
+            "/house-vote/119",  # one numeric segment short of the list shape
+        ],
+    )
+    def test_unknown_path_falls_to_unmatched(self, path: str) -> None:
+        assert normalize("api", path) == "api:unmatched"
+
+    def test_unknown_source_is_unmatched(self) -> None:
+        assert normalize("text", "/anything") == "text:unmatched"
+        assert normalize("senate", "/anything") == "senate:unmatched"
+
+
+class TestUnmatchedSampling:
+    def _recorder(self) -> Recorder:
+        return Recorder(entity="bills", command="scrape bills", started_at=datetime.now(UTC))
+
+    def test_unmatched_path_is_sampled_on_success(self) -> None:
+        rec = self._recorder()
+        rec.note_success("api", "/brand-new-endpoint/42")
+        assert rec.successes == {"api:unmatched": 1}
+        assert "/brand-new-endpoint/42" in rec.unmatched
+
+    def test_unmatched_sample_deduplicates(self) -> None:
+        rec = self._recorder()
+        rec.note_success("api", "/x/1")
+        rec.note_success("api", "/x/1")
+        assert rec.successes == {"api:unmatched": 2}
+        assert rec.unmatched == {"/x/1"}
+
+    def test_unmatched_sample_is_capped(self) -> None:
+        rec = self._recorder()
+        for i in range(50):
+            rec.note_success("api", f"/unknown/{i}")
+        assert len(rec.unmatched) <= 20
+        # All 50 still counted into the bucket, even though only 20 are sampled.
+        assert rec.successes == {"api:unmatched": 50}

--- a/tests/test_observability_scrape_run.py
+++ b/tests/test_observability_scrape_run.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from concord.observability import Attempt, active_recorder, current_run_id, scrape_run
+from concord.models import Attempt
+from concord.observability import active_recorder, current_run_id, scrape_run
 from concord.storage.sqlite import SqliteStorage
 
 

--- a/tests/test_observability_scrape_run.py
+++ b/tests/test_observability_scrape_run.py
@@ -1,0 +1,142 @@
+"""scrape_run lifecycle — enter/exit persists a runs row + run_events, the
+JSONL backup is appended, and an exception in the body still flushes with
+status="error" (ADR 0021)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from concord.observability import Attempt, active_recorder, current_run_id, scrape_run
+from concord.storage.sqlite import SqliteStorage
+
+
+def _read_run(db_path: Path, run_id: str) -> dict[str, object]:
+    storage = SqliteStorage(db_path, load_vec=False)
+    try:
+        row = storage.get_run(run_id)
+        assert row is not None
+        return dict(row)
+    finally:
+        storage.close()
+
+
+class TestScrapeRunPersistence:
+    def test_clean_run_persists_success_counts(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        with scrape_run(entity="bills", command="scrape bills", db_path=db_path) as rec:
+            run_id = current_run_id()
+            assert run_id is not None
+            assert active_recorder() is rec
+            rec.note_success("api", "/bill/119/hr")
+            rec.note_success("api", "/bill/119/hr/1")
+
+        # contextvars reset on exit
+        assert current_run_id() is None
+        assert active_recorder() is None
+
+        row = _read_run(db_path, run_id)
+        assert row["status"] == "ok"
+        assert row["entity"] == "bills"
+        assert row["command"] == "scrape bills"
+        assert json.loads(row["success_counts"]) == {"api:bill/list": 1, "api:bill/detail": 1}
+        assert row["error_event_count"] == 0
+        assert row["ended_at"]
+
+    def test_run_events_persist_with_seq(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        with scrape_run(entity="bills", command="scrape bills", db_path=db_path) as rec:
+            run_id = current_run_id()
+            rec.note_request_outcome(
+                "api",
+                "/bill/119/hr/1",
+                [Attempt(n=1, status=503, transport_class=None, message="x")],
+                resolved=True,
+            )
+            rec.note_request_outcome(
+                "api",
+                "/bill/119/hr",
+                [Attempt(n=1, status=500, transport_class=None, message="y")],
+                resolved=False,
+            )
+
+        assert run_id is not None
+        storage = SqliteStorage(db_path, load_vec=False)
+        try:
+            events = storage.list_run_events(run_id)
+        finally:
+            storage.close()
+        assert [e["seq"] for e in events] == [0, 1]
+        assert events[0]["final_status"] == "resolved"
+        assert events[1]["final_status"] == "failed"
+        assert json.loads(events[0]["attempts"])[0]["status"] == 503
+
+    def test_failed_event_without_body_error_is_partial(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        with scrape_run(entity="bills", command="scrape bills", db_path=db_path) as rec:
+            run_id = current_run_id()
+            rec.note_request_outcome(
+                "api",
+                "/bill/119/hr",
+                [Attempt(n=1, status=500, transport_class=None, message="y")],
+                resolved=False,
+            )
+        assert run_id is not None
+        assert _read_run(db_path, run_id)["status"] == "partial"
+
+    def test_jsonl_backup_is_appended(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        with scrape_run(entity="bills", command="scrape bills", db_path=db_path) as rec:
+            run_id = current_run_id()
+            rec.note_success("api", "/bill/119/hr")
+
+        backup = tmp_path / "runs.jsonl"
+        assert backup.exists()
+        lines = backup.read_text().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["run_id"] == run_id
+        assert record["success_counts"] == {"api:bill/list": 1}
+        assert record["events"] == []
+
+    def test_custom_data_dir_for_backup(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "db" / "ledger.db"
+        backup_dir = tmp_path / "audit"
+        with scrape_run(
+            entity="bills",
+            command="scrape bills",
+            db_path=db_path,
+            data_dir=backup_dir,
+        ):
+            pass
+        assert (backup_dir / "runs.jsonl").exists()
+
+
+class TestScrapeRunExceptionPath:
+    def test_body_exception_still_flushes_error_run(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        captured: dict[str, object] = {}
+
+        def _crash() -> None:
+            with scrape_run(entity="bills", command="scrape bills", db_path=db_path) as rec:
+                captured["run_id"] = current_run_id()
+                rec.note_success("api", "/bill/119/hr")
+                raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            _crash()
+
+        run_id = captured["run_id"]
+        assert isinstance(run_id, str)
+        row = _read_run(db_path, run_id)
+        assert row["status"] == "error"
+        # Work done before the crash is still recorded.
+        assert json.loads(row["success_counts"]) == {"api:bill/list": 1}
+
+    def test_each_run_gets_a_unique_id(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        ids = []
+        for _ in range(3):
+            with scrape_run(entity="bills", command="scrape bills", db_path=db_path):
+                ids.append(current_run_id())
+        assert len(set(ids)) == 3

--- a/tests/test_sqlite_runs.py
+++ b/tests/test_sqlite_runs.py
@@ -1,0 +1,153 @@
+"""runs / run_events record tables — insert/read round-trip and the
+schema-equivalence guarantee at the new _HEAD (ADR 0017, 0021)."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+from concord.storage.sqlite import _HEAD, SqliteStorage, ensure_schema
+
+
+class TestRunsRoundTrip:
+    def test_insert_and_read_run(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        storage = SqliteStorage(db_path, load_vec=False)
+        try:
+            storage.insert_run(
+                run_id="20260603T120000-deadbeef",
+                entity="bills",
+                command="scrape bills",
+                started_at="2026-06-03T12:00:00+00:00",
+                ended_at="2026-06-03T12:05:00+00:00",
+                status="ok",
+                success_counts={"api:bill/list": 3, "api:bill/detail": 12},
+                throttle_counts=None,
+                unmatched_sample=[],
+                error_event_count=0,
+            )
+            row = storage.get_run("20260603T120000-deadbeef")
+        finally:
+            storage.close()
+
+        assert row is not None
+        assert row["entity"] == "bills"
+        assert row["status"] == "ok"
+        assert json.loads(row["success_counts"]) == {"api:bill/detail": 12, "api:bill/list": 3}
+        # Empty optional JSON columns collapse to NULL.
+        assert row["throttle_counts"] is None
+        assert row["unmatched_sample"] is None
+
+    def test_insert_run_events_round_trip(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        storage = SqliteStorage(db_path, load_vec=False)
+        try:
+            storage.insert_run(
+                run_id="r1",
+                entity="bills",
+                command="scrape bills",
+                started_at="2026-06-03T12:00:00+00:00",
+                ended_at="2026-06-03T12:05:00+00:00",
+                status="partial",
+                success_counts={"api:bill/list": 1},
+                throttle_counts=None,
+                unmatched_sample=["/odd/path"],
+                error_event_count=1,
+            )
+            storage.insert_run_events(
+                "r1",
+                [
+                    {
+                        "endpoint_bucket": "api:bill/detail",
+                        "attempts": [{"n": 1, "status": 503, "transport_class": None, "msg": "x"}],
+                        "overflow_count": 0,
+                        "final_status": "resolved",
+                        "ts": "2026-06-03T12:01:00+00:00",
+                    }
+                ],
+            )
+            events = storage.list_run_events("r1")
+            run = storage.get_run("r1")
+        finally:
+            storage.close()
+
+        assert run is not None
+        assert json.loads(run["unmatched_sample"]) == ["/odd/path"]
+        assert len(events) == 1
+        assert events[0]["seq"] == 0
+        assert events[0]["endpoint_bucket"] == "api:bill/detail"
+        assert json.loads(events[0]["attempts"])[0]["status"] == 503
+
+    def test_empty_events_is_a_noop(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        storage = SqliteStorage(db_path, load_vec=False)
+        try:
+            storage.insert_run(
+                run_id="r2",
+                entity="bills",
+                command="scrape bills",
+                started_at="2026-06-03T12:00:00+00:00",
+                ended_at=None,
+                status="ok",
+                success_counts={},
+                throttle_counts=None,
+                unmatched_sample=[],
+                error_event_count=0,
+            )
+            storage.insert_run_events("r2", [])
+            assert storage.list_run_events("r2") == []
+        finally:
+            storage.close()
+
+    def test_run_events_cascade_on_run_delete(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        storage = SqliteStorage(db_path, load_vec=False)
+        try:
+            storage.insert_run(
+                run_id="r3",
+                entity="bills",
+                command="scrape bills",
+                started_at="2026-06-03T12:00:00+00:00",
+                ended_at=None,
+                status="ok",
+                success_counts={},
+                throttle_counts=None,
+                unmatched_sample=[],
+                error_event_count=1,
+            )
+            storage.insert_run_events(
+                "r3",
+                [
+                    {
+                        "endpoint_bucket": "api:bill/list",
+                        "attempts": [],
+                        "overflow_count": 0,
+                        "final_status": "failed",
+                        "ts": "2026-06-03T12:01:00+00:00",
+                    }
+                ],
+            )
+            storage._conn.execute("DELETE FROM runs WHERE run_id = ?", ("r3",))
+            storage._conn.commit()
+            assert storage.list_run_events("r3") == []
+        finally:
+            storage.close()
+
+
+class TestSchemaVersion:
+    def test_head_is_three(self) -> None:
+        assert _HEAD == 3
+
+    def test_fresh_db_has_runs_tables_at_head(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "ledger.db"
+        ensure_schema(db_path)
+        conn = sqlite3.connect(db_path)
+        try:
+            tables = {
+                name
+                for (name,) in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            }
+            version = conn.execute("PRAGMA user_version").fetchone()[0]
+        finally:
+            conn.close()
+        assert {"runs", "run_events"} <= tables
+        assert version == 3

--- a/tests/test_sqlite_runs.py
+++ b/tests/test_sqlite_runs.py
@@ -1,33 +1,39 @@
-"""runs / run_events record tables — insert/read round-trip and the
+"""runs / run_events record tables — RunRecord insert/read round-trip and the
 schema-equivalence guarantee at the new _HEAD (ADR 0017, 0021)."""
 
 import json
 import sqlite3
 from pathlib import Path
 
+from concord.models import Attempt, RunEvent, RunRecord
 from concord.storage.sqlite import _HEAD, SqliteStorage, ensure_schema
+
+
+def _record(**overrides: object) -> RunRecord:
+    base: dict[str, object] = {
+        "run_id": "20260603T120000-deadbeef",
+        "entity": "bills",
+        "command": "scrape bills",
+        "started_at": "2026-06-03T12:00:00+00:00",
+        "ended_at": "2026-06-03T12:05:00+00:00",
+        "status": "ok",
+        "success_counts": {},
+        "throttle_counts": None,
+        "unmatched_sample": [],
+        "error_event_count": 0,
+        "events": [],
+    }
+    base.update(overrides)
+    return RunRecord(**base)  # type: ignore[arg-type]
 
 
 class TestRunsRoundTrip:
     def test_insert_and_read_run(self, tmp_path: Path) -> None:
         db_path = tmp_path / "ledger.db"
-        storage = SqliteStorage(db_path, load_vec=False)
-        try:
-            storage.insert_run(
-                run_id="20260603T120000-deadbeef",
-                entity="bills",
-                command="scrape bills",
-                started_at="2026-06-03T12:00:00+00:00",
-                ended_at="2026-06-03T12:05:00+00:00",
-                status="ok",
-                success_counts={"api:bill/list": 3, "api:bill/detail": 12},
-                throttle_counts=None,
-                unmatched_sample=[],
-                error_event_count=0,
-            )
-            row = storage.get_run("20260603T120000-deadbeef")
-        finally:
-            storage.close()
+        record = _record(success_counts={"api:bill/list": 3, "api:bill/detail": 12})
+        with SqliteStorage(db_path, load_vec=False) as storage:
+            storage.insert_run(record)
+            row = storage.get_run(record.run_id)
 
         assert row is not None
         assert row["entity"] == "bills"
@@ -39,98 +45,73 @@ class TestRunsRoundTrip:
 
     def test_insert_run_events_round_trip(self, tmp_path: Path) -> None:
         db_path = tmp_path / "ledger.db"
-        storage = SqliteStorage(db_path, load_vec=False)
-        try:
-            storage.insert_run(
-                run_id="r1",
-                entity="bills",
-                command="scrape bills",
-                started_at="2026-06-03T12:00:00+00:00",
-                ended_at="2026-06-03T12:05:00+00:00",
-                status="partial",
-                success_counts={"api:bill/list": 1},
-                throttle_counts=None,
-                unmatched_sample=["/odd/path"],
-                error_event_count=1,
-            )
-            storage.insert_run_events(
-                "r1",
-                [
-                    {
-                        "endpoint_bucket": "api:bill/detail",
-                        "attempts": [{"n": 1, "status": 503, "transport_class": None, "msg": "x"}],
-                        "overflow_count": 0,
-                        "final_status": "resolved",
-                        "ts": "2026-06-03T12:01:00+00:00",
-                    }
-                ],
-            )
-            events = storage.list_run_events("r1")
-            run = storage.get_run("r1")
-        finally:
-            storage.close()
+        record = _record(
+            run_id="r1",
+            status="partial",
+            success_counts={"api:bill/list": 1},
+            unmatched_sample=["/odd/path"],
+            error_event_count=1,
+            events=[
+                RunEvent(
+                    endpoint_bucket="api:bill/detail",
+                    attempts=[
+                        Attempt(
+                            n=1, status=503, transport_class=None, message="Service Unavailable"
+                        )
+                    ],
+                    overflow_count=0,
+                    final_status="resolved",
+                    ts="2026-06-03T12:01:00+00:00",
+                )
+            ],
+        )
+        with SqliteStorage(db_path, load_vec=False) as storage:
+            storage.insert_run(record)
+            storage.insert_run_events(record.run_id, record.events)
+            events = storage.list_run_events(record.run_id)
+            run = storage.get_run(record.run_id)
 
         assert run is not None
         assert json.loads(run["unmatched_sample"]) == ["/odd/path"]
         assert len(events) == 1
         assert events[0]["seq"] == 0
         assert events[0]["endpoint_bucket"] == "api:bill/detail"
-        assert json.loads(events[0]["attempts"])[0]["status"] == 503
+        attempt = json.loads(events[0]["attempts"])[0]
+        assert attempt["status"] == 503
+        # The attempt is the producer's real field name — the model would have
+        # rejected a stray key, so DB and producer can't disagree (review #1).
+        assert attempt["message"] == "Service Unavailable"
 
     def test_empty_events_is_a_noop(self, tmp_path: Path) -> None:
         db_path = tmp_path / "ledger.db"
-        storage = SqliteStorage(db_path, load_vec=False)
-        try:
-            storage.insert_run(
-                run_id="r2",
-                entity="bills",
-                command="scrape bills",
-                started_at="2026-06-03T12:00:00+00:00",
-                ended_at=None,
-                status="ok",
-                success_counts={},
-                throttle_counts=None,
-                unmatched_sample=[],
-                error_event_count=0,
-            )
-            storage.insert_run_events("r2", [])
+        record = _record(run_id="r2", ended_at=None)
+        with SqliteStorage(db_path, load_vec=False) as storage:
+            storage.insert_run(record)
+            storage.insert_run_events(record.run_id, record.events)
             assert storage.list_run_events("r2") == []
-        finally:
-            storage.close()
 
     def test_run_events_cascade_on_run_delete(self, tmp_path: Path) -> None:
         db_path = tmp_path / "ledger.db"
-        storage = SqliteStorage(db_path, load_vec=False)
-        try:
-            storage.insert_run(
-                run_id="r3",
-                entity="bills",
-                command="scrape bills",
-                started_at="2026-06-03T12:00:00+00:00",
-                ended_at=None,
-                status="ok",
-                success_counts={},
-                throttle_counts=None,
-                unmatched_sample=[],
-                error_event_count=1,
-            )
-            storage.insert_run_events(
-                "r3",
-                [
-                    {
-                        "endpoint_bucket": "api:bill/list",
-                        "attempts": [],
-                        "overflow_count": 0,
-                        "final_status": "failed",
-                        "ts": "2026-06-03T12:01:00+00:00",
-                    }
-                ],
-            )
+        record = _record(
+            run_id="r3",
+            ended_at=None,
+            error_event_count=1,
+            events=[
+                RunEvent(
+                    endpoint_bucket="api:bill/list",
+                    attempts=[],
+                    overflow_count=0,
+                    final_status="failed",
+                    ts="2026-06-03T12:01:00+00:00",
+                )
+            ],
+        )
+        with SqliteStorage(db_path, load_vec=False) as storage:
+            storage.insert_run(record)
+            storage.insert_run_events(record.run_id, record.events)
             storage._conn.execute("DELETE FROM runs WHERE run_id = ?", ("r3",))
             storage._conn.commit()
             assert storage.list_run_events("r3") == []
-        finally:
-            storage.close()
 
 
 class TestSchemaVersion:


### PR DESCRIPTION
Closes #104.

Builds the **Scrape Run** ledger end-to-end for the api.congress.gov path, as the foundation for full scraping observability ([ADR 0021](docs/adr/0021-scrape-run-observability.md), [plan](docs/plans/scrape-run-observability-foundation.md)). Proves the whole architecture on **one client (`api.py`) + one scraper (Bills)** before the fan-out in PR 2.

## What's here

**New module — `src/concord/observability.py`**
- `run_id` + `recorder` contextvars with `current_run_id()` / `active_recorder()` readers.
- A `_ROUTES` route table (keyed by source, so PR 2 can add `text`/`senate`) + `normalize(source, path)` — first-match-wins regex→template via `re.Match.expand`, with a loud `<source>:unmatched` fallback that samples (deduped, capped) the concrete path.
- `Recorder` — a plain dataclass (no base class, ADR 0007): per-bucket success counts, `note_success` / `note_request_outcome`, attempt capping + overflow count, resolved/failed classification.
- `RunIdFormatter` + idempotent `configure_logging()` — run_id-stamped **text** (no JSON), scoped to the `concord` logger with propagation left on so `caplog` keeps working.
- `scrape_run(...)` context manager — mints a sortable, collision-resistant run_id (Blake2b of timestamp+entity+pid+counter; no `random`/`uuid4`, so test ids are stable), `ensure_schema`, sets/resets both contextvars, and best-effort flushes (DB row + events, then `runs.jsonl` backup) **without masking** an in-flight body exception. Kept a **leaf module** (lazy-imports SQLite) so `api.py` can read the recorder on its hot path with no import cycle.

**Storage — `src/concord/storage/sqlite.py`**
- `runs` + `run_events` **record** tables (ADR 0019) declared in `_BASE_SCHEMA`, a **byte-equivalent** `_m003_add_runs_tables` migration, and `_HEAD` → 3 (ADR 0017). DB-authoritative; `runs.jsonl` is a cold backup.
- `insert_run` / `insert_run_events` / `get_run` / `list_run_events`.

**Instrumentation + wiring**
- `api.py:_get` accumulates `attempts` and records successes + resolved/failed outcomes — **429s counted as errors** per ADR 0021. **Retry behavior is unchanged** (recording kept to one statement per site via two helpers, so the retry loop stays under the linter complexity ceiling).
- `cli/bills.py` wraps `_run_scrape_bills` (shared by `scrape bills` + `run bills`) in `scrape_run`; `scrape bills` gains a `--db` ledger option.
- `configure_logging()` installed at the CLI callback and `serve` startup (never at import time, ADR 0014).

## Out of scope (→ PR 2 / later)
- `text.py` + `senate_xml.py` instrumentation and the Proceedings/Members/Votes scrapers → **PR 2** (blocked by this).
- The `/runs` web dashboard → deferred; this PR creates the tables it will read.

## Testing
All four CI gates green (`ruff check`, `ruff format --check`, `mypy src`, `pytest`); **728 tests pass**, including 57 new across 6 files + a CLI integration test. The four ADR-0021 scenarios are covered (503→resolved, terminal→failed, 429→resolved-with-429-attempt, clean→count-only), and existing `api.py` retry tests pass verbatim.

## Note for review
A `scrape bills` that fails at `Client()` construction (e.g. missing API key) now records a `status="error"` run and bootstraps the ledger DB, since the plan specifies wrapping the whole body. If you'd prefer a pure config error to leave no trace, client construction can move outside `scrape_run` — flagged here rather than decided unilaterally (relates to the plan's `--db` open question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)