### PR TITLE
refactor(scraper): serialize the snapshot envelope through Snapshot

### DIFF
--- a/docs/adr/0018-pydantic-at-the-load-boundary.md
+++ b/docs/adr/0018-pydantic-at-the-load-boundary.md
@@ -79,10 +79,10 @@ The Senate vote wire shapes do need renames. The current `ParsedVoteDetail` and 
 The ADR 0006 envelope is implemented as a Pydantic generic:
 
 ```python
-class Snapshot(BaseModel, Generic[T]):
+class Snapshot[PayloadT](BaseModel):
     fetched_at: datetime
-    key: dict[str, Any]
-    payload: T
+    key: dict[str, str | int]
+    payload: PayloadT
 ```
 
 Loaders read JSONL via `Snapshot[BillDetail]`, `Snapshot[Cosponsor]`, `Snapshot[Member]`, etc. The existing `MemberSnapshot`, `BillSnapshot`, `VoteSnapshot`, and `VotePositionsSnapshot` classes are deleted, not aliased — `Snapshot[BillDetail]` carries its payload type at the import site, where an alias would silently bind one of six possible sub-endpoint snapshots to a single ambiguous name (`BillSnapshot`). The word "envelope" stays in prose to describe the on-disk shape; the class is `Snapshot[T]`.
@@ -108,12 +108,13 @@ WARN, not INFO: the cause is an upstream contract violation, and routine occurre
 
 ### Rule 5 — Scrapers serialize the envelope (not the payload) through `Snapshot`
 
-Scrapers construct and serialize the ADR 0006 envelope via `Snapshot[Any](...).model_dump_json()` through the shared `append_snapshot` helper in `scraper/_common.py`. The payload is typed `Any` (the generic is instantiated as `Snapshot[Any]`), so it is written verbatim and never schema-validated — **Rule 1's payload contract is unchanged.** This makes `Snapshot` the single source of truth for the envelope shape on both the write (scraper) and read (loader) sides, replacing the hand-rolled `json.dumps` that previously diverged across three scraper modules.
+Scrapers construct and serialize the ADR 0006 envelope via `Snapshot[Any](...).model_dump_json()` through the shared `append_snapshot` helper in `scraper/_common.py`. The payload is typed `Any` (the generic is instantiated as `Snapshot[Any]`), so the payload *object* is passed through unchanged and never schema-validated — **Rule 1's payload contract is unchanged** (its JSON *rendering* follows Pydantic's encoder; see the value-level differences in consequences below). This makes `Snapshot` the single source of truth for the envelope shape on the write (scraper) and **loader** read sides, replacing the hand-rolled `json.dumps` that previously diverged across three scraper modules. (The scraper-side freshness scanners `load_freshness_map` / `load_bill_signal_map` deliberately stay on raw `json.loads` — they read only `key`/`fetched_at`, run on the hot path, and need softer per-line failure semantics; see that module's docstring.)
 
-The `concord.models` import is confined to `scraper/_common.py`; entity scraper modules call `append_snapshot` and stay model-free. Two consequences are accepted:
+The `concord.models` import is confined to `scraper/_common.py`; entity scraper modules call `append_snapshot` and stay model-free. Three consequences are accepted:
 
 1. A malformed envelope `key` (a non-`str | int` value) now raises `ValidationError` at scrape time rather than serializing silently — a fail-fast that never fires on current paths, since the scraper skip rule above already guarantees a well-formed scalar key by envelope-build time.
 2. `model_dump_json()` emits compact JSON and renders `fetched_at` as `…Z` rather than the `…+00:00` the previous `datetime.isoformat()` produced. Both are ISO-8601 UTC for the same instant and round-trip through `Snapshot[...].model_validate_json` and `datetime.fromisoformat`, so existing JSONL and freshness maps load unchanged; data files may carry a mix of both renderings across appends, which is harmless — mutable-entity JSONL has no byte-reproducibility contract (unlike `runs.jsonl`, [ADR 0019](./0019-mirror-tables-vs-record-tables.md)).
+3. Non-finite floats (`NaN`, `Infinity`, `-Infinity`) in a payload are rendered as JSON `null`, where the previous `json.dumps` (default `allow_nan=True`) emitted the bare `NaN`/`Infinity` tokens. This is lossy, but accepted: the upstream sources (api.congress.gov JSON, decoded Senate XML strings) never emit non-finite floats, so no scraper payload contains one; and unlike the old tokens — which are not strict-valid JSON — the `null` output keeps every line strict-JSON-parseable.
 
 ## Consequences
 

--- a/docs/adr/0018-pydantic-at-the-load-boundary.md
+++ b/docs/adr/0018-pydantic-at-the-load-boundary.md
@@ -1,6 +1,6 @@
 # 0018 — Pydantic validation at the load boundary
 
-**Status**: Proposed, 2026-05-29.
+**Status**: Accepted, 2026-05-29; amended 2026-06-06 (Rule 5 — scraper envelope serialization).
 
 ## Context
 
@@ -25,7 +25,7 @@ The rule for *what a model is, where it lives, what its constructor looks like, 
 
 ## Decision
 
-Four rules and a vocabulary.
+Five rules and a vocabulary.
 
 ### Rule 1 — Validation lives at the JSONL read boundary
 
@@ -105,6 +105,15 @@ logger.warning(
 ```
 
 WARN, not INFO: the cause is an upstream contract violation, and routine occurrence is signal a maintainer should notice.
+
+### Rule 5 — Scrapers serialize the envelope (not the payload) through `Snapshot`
+
+Scrapers construct and serialize the ADR 0006 envelope via `Snapshot[Any](...).model_dump_json()` through the shared `append_snapshot` helper in `scraper/_common.py`. The payload is typed `Any` (the generic is instantiated as `Snapshot[Any]`), so it is written verbatim and never schema-validated — **Rule 1's payload contract is unchanged.** This makes `Snapshot` the single source of truth for the envelope shape on both the write (scraper) and read (loader) sides, replacing the hand-rolled `json.dumps` that previously diverged across three scraper modules.
+
+The `concord.models` import is confined to `scraper/_common.py`; entity scraper modules call `append_snapshot` and stay model-free. Two consequences are accepted:
+
+1. A malformed envelope `key` (a non-`str | int` value) now raises `ValidationError` at scrape time rather than serializing silently — a fail-fast that never fires on current paths, since the scraper skip rule above already guarantees a well-formed scalar key by envelope-build time.
+2. `model_dump_json()` emits compact JSON and renders `fetched_at` as `…Z` rather than the `…+00:00` the previous `datetime.isoformat()` produced. Both are ISO-8601 UTC for the same instant and round-trip through `Snapshot[...].model_validate_json` and `datetime.fromisoformat`, so existing JSONL and freshness maps load unchanged; data files may carry a mix of both renderings across appends, which is harmless — mutable-entity JSONL has no byte-reproducibility contract (unlike `runs.jsonl`, [ADR 0019](./0019-mirror-tables-vs-record-tables.md)).
 
 ## Consequences
 

--- a/docs/plans/unify-snapshot-serialization.md
+++ b/docs/plans/unify-snapshot-serialization.md
@@ -1,0 +1,158 @@
+# Unify JSONL snapshot-envelope serialization across the scrapers
+
+> Make the scrapers serialize the ADR 0006 `{fetched_at, key, payload}` envelope through the existing `Snapshot[T]` Pydantic model — the same model the loaders already parse with — instead of hand-rolling `json.dumps` at six sites, so the envelope shape is single-sourced on both the write and read sides.
+
+## Source
+
+Conversation context only (no durable issue/doc). This plan is the output of a thermo-nuclear code-quality audit of the `storage/` + scraper write paths, followed by a grilling pass that resolved the ADR-boundary and wire-format decisions. The audit's headline finding: the SQLite write path is already unified (`SqliteStorage` facade + per-domain modules), so the only real asymmetry is on the **JSONL write side** — the snapshot envelope is parsed through one model on read but hand-rolled three different ways on write.
+
+## Context
+
+Concord's mutable entities (Members, Bills, Votes) persist each upstream fetch as one JSONL line in the **snapshot envelope** shape `{"fetched_at": ..., "key": {...}, "payload": ...}` (see [ADR 0006](../adr/0006-snapshot-on-fetch-for-mutable-entities.md) and [ADR 0009](../adr/0009-multi-endpoint-entities-split-jsonl.md)). The envelope is implemented as a Pydantic generic, `Snapshot[PayloadT]`, defined in [src/concord/models/_common.py:35](../../src/concord/models/_common.py). The **loaders** already validate every JSONL line through it (`Snapshot[dict[str, Any]].model_validate_json(line)` in `load_members.py`, `load_bills.py`, and `Snapshot[str]` for the Senate XML payload in `load_votes.py`).
+
+The **scrapers**, however, do not use `Snapshot`. They each build the envelope as a raw dict and call `json.dumps(...)`, in three different idioms:
+
+- `scraper/members.py` — inline dict + `json.dumps` ([members.py:114](../../src/concord/scraper/members.py))
+- `scraper/bills.py` — inline literal, twice (`_scrape_basic_pair` at [bills.py:159](../../src/concord/scraper/bills.py), `_enrich_one_bill` at [bills.py:356](../../src/concord/scraper/bills.py))
+- `scraper/votes.py` — a private `_append_envelope(fh, *, iso, key, payload)` helper ([votes.py:290](../../src/concord/scraper/votes.py)), called at 4 sites
+
+So the envelope's canonical shape lives in `Snapshot`, but the write side reimplements it. The fix is to serialize through `Snapshot` on the write side too, via one shared helper.
+
+Why this wasn't already done: [ADR 0018](../adr/0018-pydantic-at-the-load-boundary.md) ("Pydantic validation at the load boundary", currently marked *Proposed* though fully implemented) **Rule 1** deliberately keeps the scraper Pydantic-free *with respect to the payload* — "the scraper writes raw payloads to JSONL unchanged. The scraper does not Pydantic-validate the payload." That contract exists so JSONL faithfully mirrors what the API returned and a model fix is a re-load away, not a re-scrape away. Crucially, Rule 1 is about the **payload**, not the **envelope** (`fetched_at`/`key`, which the scraper authors itself). Serializing the envelope through `Snapshot[Any]` leaves the payload untyped and unvalidated, so it honours Rule 1 while single-sourcing the envelope. This plan ratifies that distinction by amending ADR 0018.
+
+## Goals
+
+1. One shared `append_snapshot(...)` helper in `scraper/_common.py` serializes the snapshot envelope via `Snapshot`, used at all six current write sites.
+2. The `concord.models` import is confined to `scraper/_common.py`; the entity scraper modules (`members.py`, `bills.py`, `votes.py`) stay free of direct `concord.models` imports.
+3. `votes._append_envelope` and the three inline `json.dumps` envelope literals are gone — no hand-rolled envelope serialization remains in the scraper package.
+4. ADR 0018 gains a "Rule 5" documenting write-side envelope serialization through `Snapshot`, and its status is flipped Proposed → Accepted.
+5. Full test suite, `mypy --strict src`, and `ruff` all pass.
+
+## Non-goals
+
+1. **Proceedings stay flat.** `JsonlStorage` ([storage/jsonl.py](../../src/concord/storage/jsonl.py)) writes one flat `Proceeding` per line with write-time dedup — a deliberately different contract ([ADR 0002](../adr/0002-jsonl-as-canonical-raw-store.md); ADR 0006 explicitly says do not unify Proceedings into the envelope). Not touched.
+2. **`runs.jsonl` cold-backup stays as-is.** `observability.py:_flush` writes a flat `RunRecord` dump (a record table, [ADR 0019](../adr/0019-mirror-tables-vs-record-tables.md)/0021), not an envelope. It cannot use `Snapshot`/`append_snapshot`. Not touched.
+3. **No payload validation in the scraper.** The payload stays `Any` and is written verbatim. ADR 0018 Rule 1 is preserved, not weakened.
+4. **No change to the SQLite write path.** It is already unified.
+5. **No `field_serializer` added to `Snapshot`.** We accept Pydantic's native `fetched_at` rendering (see Approach).
+6. **No new base class across entity scrapers** ([ADR 0007](../adr/0007-parallel-pipelines-per-entity.md)). `append_snapshot` is a thin free function, not a base class.
+
+## Relevant prior decisions
+
+- [ADR 0002 — JSONL as the canonical raw store](../adr/0002-jsonl-as-canonical-raw-store.md) — Proceedings are flat; do not envelope them.
+- [ADR 0006 — Snapshot-on-fetch for mutable entities](../adr/0006-snapshot-on-fetch-for-mutable-entities.md) — defines the `{fetched_at, key, payload}` envelope.
+- [ADR 0007 — Parallel pipelines per entity](../adr/0007-parallel-pipelines-per-entity.md) — no base classes across entity pipelines; shared utilities live in thin `_common.py` helpers.
+- [ADR 0009 — Multi-endpoint entities split their JSONL](../adr/0009-multi-endpoint-entities-split-jsonl.md) — bills/votes open multiple handles; the writer must be handle-agnostic (a free function, not a stateful per-file writer).
+- [ADR 0018 — Pydantic validation at the load boundary](../adr/0018-pydantic-at-the-load-boundary.md) — **amended by this plan** (new Rule 5; status → Accepted). Rule 1 (no payload validation in the scraper) and the scraper skip rule are preserved.
+- [ADR 0019 — Mirror tables vs. record tables](../adr/0019-mirror-tables-vs-record-tables.md) — `runs` is a record table; out of scope.
+
+## Relevant files and code
+
+- `src/concord/models/_common.py:35` — `Snapshot[PayloadT]` generic. **Unchanged**; reused on the write side.
+- `src/concord/scraper/_common.py` — shared scraper helpers (currently freshness-map *read* mechanics). **Add `append_snapshot` here** + the single `from concord.models import Snapshot` import. Update the module docstring to note it now owns both envelope read and write mechanics.
+- `src/concord/scraper/members.py:74,114-126` — drop the `iso = fetched_at.isoformat()` precompute; replace the inline envelope write with `append_snapshot`.
+- `src/concord/scraper/bills.py` — `_scrape_basic_pair` ([:112-195](../../src/concord/scraper/bills.py), envelope at 159-169) and `_enrich_one_bill` ([:314-370](../../src/concord/scraper/bills.py), envelope at 356-366). Re-thread `fetched_at: datetime` in place of `iso: str`; drop the `iso = fetched_at.isoformat()` lines in `scrape_basic` (~230) and `scrape_enrichment` (~408); replace both writes with `append_snapshot`.
+- `src/concord/scraper/votes.py` — delete `_append_envelope` ([:290-298](../../src/concord/scraper/votes.py)); re-thread `fetched_at: datetime` through `_scrape_pair` (param at 183), `_fetch_and_write_members` (301), `_scrape_senate_pair` (435), and the roster write in `scrape_senate` (364); drop the `iso` precomputes (107, 359); replace the 4 call sites (244, 326, 365, 455) with `append_snapshot`.
+- `docs/adr/0018-pydantic-at-the-load-boundary.md` — amend (Rule 5 + status).
+- `tests/test_scraper_members.py:68`, `tests/test_scraper_bills.py:88,255`, `tests/test_scraper_votes.py:134` — the `== FIXED_FETCHED_AT.isoformat()` assertions that break on the wire-format shift; update to parse-and-compare.
+- `tests/test_scraper_common.py` — add focused `append_snapshot` round-trip + fail-fast tests.
+
+## Approach
+
+The envelope's canonical shape already exists as `Snapshot[PayloadT]`; the only gap is that serialization was unified on the read side (loaders) and hand-rolled on the write side (scrapers). We close the gap with a single free function:
+
+```python
+# src/concord/scraper/_common.py
+from typing import IO, Any
+from concord.models import Snapshot
+
+def append_snapshot(
+    fh: IO[str],
+    *,
+    fetched_at: datetime,
+    key: dict[str, str | int],
+    payload: Any,
+) -> None:
+    """Append one ADR 0006 snapshot envelope line to an open handle.
+
+    Serializes via ``Snapshot`` so the envelope shape is single-sourced
+    across the scraper (write) and loader (read) sides. ``payload`` is left
+    as ``Any`` — written verbatim, never schema-validated (ADR 0018 Rule 1).
+    """
+    fh.write(Snapshot[Any](fetched_at=fetched_at, key=key, payload=payload).model_dump_json())
+    fh.write("\n")
+```
+
+It is a **free function, not a stateful writer**, because bills and votes open several handles at once and write to whichever they just fetched (ADR 0009) — the file lifecycle has to stay with the scraper. This is exactly the shape `votes._append_envelope` already discovered locally; we promote the best-of-the-three to canonical and route the other five sites through it. Storage ownership note: the envelope's *read* helpers (`load_freshness_map`) already live in `scraper/_common.py`, so the *write* helper belongs beside them (not in `storage/`, which owns the unrelated flat-Proceedings `JsonlStorage`).
+
+Two deliberate, accepted behavior changes fall out, both vetted during grilling:
+
+- **Wire format shifts (accepted, not papered over).** `model_dump_json()` emits compact JSON and renders `fetched_at` as `…T14:02:11Z`, where the current `json.dumps({"fetched_at": fetched_at.isoformat()})` emits spaced JSON and `…T14:02:11+00:00`. Both are ISO-8601 UTC for the same instant; both round-trip through `Snapshot[...].model_validate_json` and `datetime.fromisoformat` (Python 3.12 accepts `Z`), so the loaders and freshness maps are unaffected — verified. Real data files will contain mixed `Z`/`+00:00` lines across old and new appends; this is harmless (mutable-entity JSONL has no byte-reproducibility contract, unlike `runs.jsonl`). We do **not** add a `field_serializer` to `Snapshot` to preserve `+00:00`; we accept Pydantic's native output and update the affected test assertions to compare the parsed instant instead of the literal string.
+- **Fail-fast on a malformed key (accepted safety net).** `Snapshot.key` is typed `dict[str, str | int]`, so a key value that isn't a scalar now raises `ValidationError` at scrape time. This never fires on current paths — every scraper already skips a record when it cannot construct the key (ADR 0018 scraper skip rule), so the key is always well-formed scalars by envelope-build time. It is a latent guard against future bugs, not a regression. Confirmed current key shapes all satisfy the type: members `{bioguide_id: str, congress: int}`, bills `{congress: int, bill_type: str, bill_number: int}`, votes `{chamber: str, congress: int, session: int, roll_number: int}`, Senate roster `{source: "senators_cfm"}`.
+
+The `fetched_at: datetime` parameter (rather than the pre-stringified `iso`) lets each scraper drop its `iso = fetched_at.isoformat()` precompute and thread the actual `datetime` through its pair/helper functions — a small reduction in stringly-typed plumbing.
+
+There is no import-cycle risk: `concord.models` is a leaf (imports only pydantic/stdlib), so `scraper/_common.py → concord.models` is safe.
+
+## Step-by-step plan
+
+1. **Add `append_snapshot` to `scraper/_common.py`.** Insert the function shown in Approach. Add `from concord.models import Snapshot` and ensure `IO`/`Any` are imported from `typing` (and `datetime` from `datetime`, already present). Add it to `__all__`. Update the module docstring's opening lines so it describes both the freshness-map *read* mechanics (existing) and the envelope *write* mechanics (new) — it remains a thin utility module, not a base class (ADR 0007). Verify: `uv run python -c "from concord.scraper._common import append_snapshot"` imports cleanly.
+
+2. **Route `members.py` through `append_snapshot`.** In `scrape` ([members.py](../../src/concord/scraper/members.py)): delete the `iso = fetched_at.isoformat()` line (74); replace the inline `envelope = {...}` + two `fh.write(...)` lines (114-126) with a single `append_snapshot(fh, fetched_at=fetched_at, key={"bioguide_id": bioguide_id, "congress": congress}, payload=payload)`. Import `append_snapshot` from `._common`. Verify: `uv run pytest tests/test_scraper_members.py` (expect the `fetched_at` assertion at :68 to fail until step 6 — that is the only expected failure).
+
+3. **Route `bills.py` through `append_snapshot`.** Change `_scrape_basic_pair`'s `iso: str` param to `fetched_at: datetime` and `_enrich_one_bill`'s `iso: str` to `fetched_at: datetime`; update `scrape_basic` and `scrape_enrichment` to pass `fetched_at=fetched_at` to those helpers and delete their `iso = fetched_at.isoformat()` lines. Replace the two envelope writes (159-169 detail; 356-366 enrichment) with `append_snapshot(fh, fetched_at=fetched_at, key={...}, payload=...)` and `append_snapshot(handles[section], fetched_at=fetched_at, key={...}, payload=payload)` respectively. Import `append_snapshot`. Verify: `uv run pytest tests/test_scraper_bills.py` (expect only the `fetched_at` assertions at :88/:255 to fail until step 6).
+
+4. **Route `votes.py` through `append_snapshot`; delete `_append_envelope`.** Change the `iso: str` params to `fetched_at: datetime` on `_scrape_pair` (183), `_fetch_and_write_members` (301), and `_scrape_senate_pair` (435); update `scrape_house`/`scrape_senate` to thread `fetched_at` and delete their `iso` precomputes (107, 359). Replace the 4 `_append_envelope(...)` call sites (244, 326, 365, 455) with `append_snapshot(...)`, passing `fetched_at=fetched_at`. Delete the `_append_envelope` function (290-298). Import `append_snapshot`. Verify: `uv run pytest tests/test_scraper_votes.py` (expect only the `fetched_at` assertion at :134 to fail until step 6).
+
+5. **Confirm the entity scrapers are `concord.models`-free.** `grep -n "concord.models" src/concord/scraper/members.py src/concord/scraper/bills.py src/concord/scraper/votes.py` returns nothing; `grep -rn "json.dumps" src/concord/scraper/` shows no envelope serialization remains (only `_common.py` imports `Snapshot`).
+
+6. **Update the broken `fetched_at` test assertions.** In `tests/test_scraper_members.py:68`, `tests/test_scraper_bills.py:88` and `:255`, `tests/test_scraper_votes.py:134`, replace `assert envelope["fetched_at"] == FIXED_FETCHED_AT.isoformat()` with a format-agnostic instant comparison: `assert datetime.fromisoformat(envelope["fetched_at"]) == FIXED_FETCHED_AT` (add `from datetime import datetime` if not already imported). This asserts the actual contract (the captured instant) rather than a cosmetic string. Verify: the three scraper test modules pass.
+
+7. **Add focused tests for `append_snapshot`** in `tests/test_scraper_common.py`: (a) write a snapshot to a tmp handle, read the line back through `Snapshot[dict[str, Any]].model_validate_json`, assert `fetched_at`/`key`/`payload` round-trip; (b) assert a payload with non-ASCII and nested structures survives byte-for-byte (`json.loads(line)["payload"] == payload`); (c) assert a `str` payload (Senate XML case) round-trips; (d) assert a malformed key (e.g. `{"bad": [1, 2]}`) raises `pydantic.ValidationError`, documenting the fail-fast. Verify: `uv run pytest tests/test_scraper_common.py`.
+
+8. **Amend ADR 0018.** Edit `docs/adr/0018-pydantic-at-the-load-boundary.md`:
+   - Status line (3): change to `**Status**: Accepted, 2026-05-29; amended 2026-06-06 (Rule 5 — scraper envelope serialization).`
+   - Add, after the "Scraper skip rule" subsection within **Decision**, a new subsection:
+
+     > ### Rule 5 — Scrapers serialize the envelope (not the payload) through `Snapshot`
+     >
+     > Scrapers construct and serialize the ADR 0006 envelope via `Snapshot[Any](...).model_dump_json()` through the shared `append_snapshot` helper in `scraper/_common.py`. The payload is left as the unsubscripted `Any` type, so it is written verbatim and never schema-validated — **Rule 1's payload contract is unchanged.** This makes `Snapshot` the single source of truth for the envelope shape on both the write (scraper) and read (loader) sides, replacing the hand-rolled `json.dumps` that previously diverged across three scraper modules.
+     >
+     > The `concord.models` import is confined to `scraper/_common.py`; entity scraper modules call `append_snapshot` and stay model-free. Two consequences are accepted: (1) a malformed envelope `key` (a non-`str | int` value) now raises `ValidationError` at scrape time rather than serializing silently — a fail-fast that never fires on current paths, since the scraper skip rule above already guarantees a well-formed key by envelope-build time; (2) `model_dump_json()` emits compact JSON and renders `fetched_at` as `…Z` rather than `…+00:00`. Both are ISO-8601 UTC and round-trip through `Snapshot[...].model_validate_json` and `datetime.fromisoformat`, so existing JSONL and freshness maps load unchanged; data files may contain a mix of both renderings across appends, which is harmless (mutable-entity JSONL carries no byte-reproducibility contract).
+
+9. **Run the full gate.** `uv run ruff format`, `uv run ruff check`, `uv run mypy src`, `uv run pytest`. All clean. Pay attention to mypy on the unsubscripted-generic instantiation — `Snapshot[Any](...)` is written explicitly in the helper to keep the type obvious to mypy strict and to readers.
+
+## Demo seed data
+
+Not applicable — this is a pure serialization refactor. No new tables, columns, entity types, relationships, or API capabilities; `data/` file contents are semantically identical. `backend/demo/seed.sql` (if present) needs no change.
+
+## Testing strategy
+
+- **Unit (new):** `tests/test_scraper_common.py` — `append_snapshot` round-trip, non-ASCII/nested payload fidelity, `str` payload (Senate), and malformed-key `ValidationError` (step 7).
+- **Unit (updated):** `tests/test_scraper_members.py`, `tests/test_scraper_bills.py`, `tests/test_scraper_votes.py` — the four `fetched_at` assertions switch to parse-and-compare (step 6). All other assertions in these files already `json.loads` each line, so the compact-vs-spaced whitespace change is invisible to them.
+- **Regression (must stay green):** the loader tests (`tests/test_pipeline_*` / `tests/test_storage_*`) read the written envelope format; they parse via `Snapshot`/`json.loads` and must pass unchanged, proving write/read compatibility. Any end-to-end scrape→load test is the strongest signal that the new wire format loads correctly.
+- **Static:** `mypy --strict src` (covers the generic instantiation and the new helper signature) and `ruff check`/`ruff format --check`.
+- **No live scrapes.** The api.data.gov rate limits make live verification impractical; all scraper tests use recorded fixtures, which is sufficient because the change is purely in serialization, not fetching.
+
+## Acceptance criteria
+
+- [ ] `append_snapshot` exists in `src/concord/scraper/_common.py`, is in `__all__`, and is the sole envelope-serialization path in the scraper package.
+- [ ] `grep -rn "json.dumps" src/concord/scraper/` shows no envelope literals; `votes._append_envelope` is deleted.
+- [ ] `grep -n "concord.models" src/concord/scraper/{members,bills,votes}.py` returns nothing (only `_common.py` imports `Snapshot`).
+- [ ] ADR 0018 has Rule 5 and status `Accepted … amended 2026-06-06`.
+- [ ] New `append_snapshot` tests pass, including the malformed-key fail-fast assertion.
+- [ ] The four updated `fetched_at` assertions pass against the new wire format.
+- [ ] `uv run pytest` is fully green (loaders included).
+- [ ] `uv run mypy src` is clean.
+- [ ] `uv run ruff check` and `uv run ruff format --check` are clean.
+
+## Open questions
+
+None — all design decisions were resolved during grilling (ADR mechanics: extend 0018 + accept; wire format: accept `Z`, update tests; seam: helper in `scraper/_common.py`; scope: envelope entities only).
+
+## Out-of-band work (optional)
+
+Two lower-value findings from the same audit are **deliberately deferred** (not part of this plan), recorded so they aren't lost:
+
+- The `storage/__init__.py` docstring oversells the `Storage` Protocol as "a seam for a future alternative raw-store implementation" — a leftover framing from the Mongo era (ADR 0013). The Protocol is now Proceeding-specific (it does earn its keep abstracting JSONL-vs-SQLite for the proceedings scrape/load), but the docstring is misleading. A doc-only fix.
+- `observability.py:_flush` writes `runs.jsonl` inline; folding it into a `storage/runs.py` helper would give that domain module ownership of all its persistence (SQLite + JSONL backup). Single call site, marginal; a different (non-envelope) shape, so unrelated to this plan.

--- a/src/concord/scraper/_common.py
+++ b/src/concord/scraper/_common.py
@@ -21,6 +21,18 @@ The exports are:
 * :func:`load_bill_signal_map` — Bills-specific helper that reads
   ``bills.jsonl`` and returns ``{key: max(updateDate, updateDateIncludingText)}``
   off each line's ``payload``; used to gate enrichment fetches.
+
+Note the deliberate asymmetry: :func:`append_snapshot` serializes through
+:class:`~concord.models.Snapshot`, but :func:`load_freshness_map` and
+:func:`load_bill_signal_map` parse the same envelope with raw ``json.loads``,
+*not* ``Snapshot``. That is intentional — these scanners read only ``key`` and
+``fetched_at`` (never ``payload``), run on the hot scrape path over files up to
+tens of thousands of lines, and need a softer per-line failure mode (warn-and-skip
+a malformed line, treat the record as stale) than ``Snapshot.model_validate_json``'s
+fail-fast. ``Snapshot`` is the single envelope vocabulary for the *write* (scraper)
+and *load* (Stage 1 loader, ADR 0018) sides; these freshness scanners are a third,
+intentionally lightweight reader. Don't "unify" them onto ``Snapshot`` — it would
+force eager full-payload validation on the hot path for no benefit.
 """
 
 import json
@@ -50,8 +62,8 @@ def append_snapshot(
     ``str | int`` raises ``pydantic.ValidationError`` here rather than
     serializing a malformed envelope silently (ADR 0018 Rule 5).
     """
-    fh.write(Snapshot[Any](fetched_at=fetched_at, key=key, payload=payload).model_dump_json())
-    fh.write("\n")
+    line = Snapshot[Any](fetched_at=fetched_at, key=key, payload=payload).model_dump_json()
+    fh.write(line + "\n")
 
 
 def _coerce_utc(dt: datetime) -> datetime:

--- a/src/concord/scraper/_common.py
+++ b/src/concord/scraper/_common.py
@@ -1,12 +1,18 @@
-"""Shared helpers for staleness-aware re-scrape (ADR 0015).
+"""Shared scraper helpers — ADR 0006 snapshot-envelope read/write mechanics.
 
 This is a thin utility module — *not* a base class. Per
 [ADR 0007](../../../docs/adr/0007-parallel-pipelines-per-entity.md), each
 entity's scraper stays a standalone module; the helpers here only encode
-the JSONL freshness-map mechanics that every entity needs identically.
+the snapshot-envelope mechanics that every entity needs identically — both
+the *write* side (serialize one envelope line) and the ADR 0015 freshness-map
+*read* side (decide whether a record is already fresh enough to skip).
 
-The three exports are:
+The exports are:
 
+* :func:`append_snapshot` — serialize one ADR 0006 ``{fetched_at, key,
+  payload}`` envelope line through :class:`~concord.models.Snapshot`, the
+  same model the loaders parse with. Confining the ``concord.models`` import
+  to this module keeps the entity scrapers model-free (ADR 0018 Rule 5).
 * :func:`load_freshness_map` — read a JSONL file once and return
   ``{key_tuple: latest fetched_at}``.
 * :func:`parse_signal_timestamp` — parse the per-record ``updateDate``
@@ -21,9 +27,31 @@ import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
+
+from concord.models import Snapshot
 
 _log = logging.getLogger("concord.scraper._common")
+
+
+def append_snapshot(
+    fh: IO[str],
+    *,
+    fetched_at: datetime,
+    key: dict[str, str | int],
+    payload: Any,
+) -> None:
+    """Append one ADR 0006 snapshot envelope line to an open handle.
+
+    Serializes through :class:`~concord.models.Snapshot` so the envelope
+    shape is single-sourced across the scraper (write) and loader (read)
+    sides. ``payload`` is left as ``Any`` — written verbatim, never
+    schema-validated (ADR 0018 Rule 1). A ``key`` value that is not
+    ``str | int`` raises ``pydantic.ValidationError`` here rather than
+    serializing a malformed envelope silently (ADR 0018 Rule 5).
+    """
+    fh.write(Snapshot[Any](fetched_at=fetched_at, key=key, payload=payload).model_dump_json())
+    fh.write("\n")
 
 
 def _coerce_utc(dt: datetime) -> datetime:
@@ -168,6 +196,7 @@ def load_bill_signal_map(
 
 
 __all__ = [
+    "append_snapshot",
     "is_stub_unchanged",
     "load_bill_signal_map",
     "load_freshness_map",

--- a/src/concord/scraper/bills.py
+++ b/src/concord/scraper/bills.py
@@ -17,7 +17,7 @@ import logging
 from collections.abc import Callable, Iterable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import IO, Any, NamedTuple
 
 from concord.api import Client
 from concord.scraper._common import (
@@ -114,7 +114,7 @@ def _scrape_basic_pair(  # noqa: PLR0913 — per-pair worker, all kwargs are sta
     client: Client,
     congress: int,
     bt: str,
-    fh: Any,
+    fh: IO[str],
     fetched_at: datetime,
     remaining: float,
     skip_unchanged: bool,
@@ -314,7 +314,7 @@ def _enrich_one_bill(
     client: Client,
     bill_key: tuple[int, str, int],
     requested_sections: tuple[str, ...],
-    handles: dict[str, Any],
+    handles: dict[str, IO[str]],
     fetched_at: datetime,
     skip_unchanged: bool,
     section_freshness: dict[str, dict[tuple[Any, ...], datetime]],
@@ -415,7 +415,7 @@ def scrape_enrichment(  # noqa: PLR0913 — one kwarg per knob; collapsing into 
 
     # Open every requested section's file once; the per-bill loop writes
     # to whichever it just fetched.
-    handles: dict[str, Any] = {}
+    handles: dict[str, IO[str]] = {}
     try:
         for section in requested_sections:
             handles[section] = (storage_dir / enrichment_jsonl_name(section)).open(

--- a/src/concord/scraper/bills.py
+++ b/src/concord/scraper/bills.py
@@ -13,7 +13,6 @@ identity record per Bill plus the five tier-2 enrichment streams:
    per ADR 0009.
 """
 
-import json
 import logging
 from collections.abc import Callable, Iterable
 from datetime import datetime
@@ -22,6 +21,7 @@ from typing import Any, NamedTuple
 
 from concord.api import Client
 from concord.scraper._common import (
+    append_snapshot,
     is_stub_unchanged,
     load_freshness_map,
     parse_signal_timestamp,
@@ -115,7 +115,7 @@ def _scrape_basic_pair(  # noqa: PLR0913 — per-pair worker, all kwargs are sta
     congress: int,
     bt: str,
     fh: Any,
-    iso: str,
+    fetched_at: datetime,
     remaining: float,
     skip_unchanged: bool,
     freshness: dict[tuple[Any, ...], datetime],
@@ -156,17 +156,16 @@ def _scrape_basic_pair(  # noqa: PLR0913 — per-pair worker, all kwargs are sta
             pair_skipped += 1
             continue
         detail = client.get_bill_detail(congress, bt, bill_number)
-        envelope = {
-            "fetched_at": iso,
-            "key": {
+        append_snapshot(
+            fh,
+            fetched_at=fetched_at,
+            key={
                 "congress": congress,
                 "bill_type": bt,
                 "bill_number": bill_number,
             },
-            "payload": detail,
-        }
-        fh.write(json.dumps(envelope, ensure_ascii=False))
-        fh.write("\n")
+            payload=detail,
+        )
         pair_written += 1
         if progress is not None:
             progress(
@@ -227,7 +226,6 @@ def scrape_basic(
     """
     storage_dir.mkdir(parents=True, exist_ok=True)
     out_path = storage_dir / BILLS_JSONL_NAME
-    iso = fetched_at.isoformat()
 
     types = tuple(bill_types) if bill_types is not None else DEFAULT_BILL_TYPES
     _limit: float = float("inf") if limit is None else limit
@@ -255,7 +253,7 @@ def scrape_basic(
                     congress=congress,
                     bt=bill_type.lower(),
                     fh=fh,
-                    iso=iso,
+                    fetched_at=fetched_at,
                     remaining=remaining,
                     skip_unchanged=skip_unchanged,
                     freshness=freshness,
@@ -317,7 +315,7 @@ def _enrich_one_bill(
     bill_key: tuple[int, str, int],
     requested_sections: tuple[str, ...],
     handles: dict[str, Any],
-    iso: str,
+    fetched_at: datetime,
     skip_unchanged: bool,
     section_freshness: dict[str, dict[tuple[Any, ...], datetime]],
     signal: datetime | None,
@@ -353,17 +351,16 @@ def _enrich_one_bill(
             partial.append(section)
             failures += 1
             continue
-        envelope = {
-            "fetched_at": iso,
-            "key": {
+        append_snapshot(
+            handles[section],
+            fetched_at=fetched_at,
+            key={
                 "congress": congress,
                 "bill_type": bt,
                 "bill_number": bill_number,
             },
-            "payload": payload,
-        }
-        handles[section].write(json.dumps(envelope, ensure_ascii=False))
-        handles[section].write("\n")
+            payload=payload,
+        )
         written += 1
     return _BillEnrichResult(
         written=written, failures=failures, skipped=skipped, partial=tuple(partial)
@@ -405,7 +402,6 @@ def scrape_enrichment(  # noqa: PLR0913 — one kwarg per knob; collapsing into 
                 f"expected one of {', '.join(BILL_ENRICHMENT_SECTIONS)}"
             )
 
-    iso = fetched_at.isoformat()
     # Per-section freshness maps gate which sub-endpoint fetches we
     # skip when ``skip_unchanged`` is set (ADR 0015). Each section can
     # refresh independently — see ADR 0009.
@@ -444,7 +440,7 @@ def scrape_enrichment(  # noqa: PLR0913 — one kwarg per knob; collapsing into 
                 bill_key=bill_key,
                 requested_sections=requested_sections,
                 handles=handles,
-                iso=iso,
+                fetched_at=fetched_at,
                 skip_unchanged=skip_unchanged,
                 section_freshness=section_freshness,
                 signal=signal,

--- a/src/concord/scraper/members.py
+++ b/src/concord/scraper/members.py
@@ -13,7 +13,6 @@ envelope key," and every such skip emits a WARN log naming the source
 endpoint and the missing field.
 """
 
-import json
 import logging
 from collections.abc import Callable, Iterable
 from datetime import datetime
@@ -22,6 +21,7 @@ from typing import NamedTuple
 
 from concord.api import Client
 from concord.scraper._common import (
+    append_snapshot,
     is_stub_unchanged,
     load_freshness_map,
     parse_signal_timestamp,
@@ -71,7 +71,6 @@ def scrape(
     cost, not an HTTP call. See ADR 0015.
     """
     storage_path.parent.mkdir(parents=True, exist_ok=True)
-    iso = fetched_at.isoformat()
     freshness = (
         load_freshness_map(storage_path, ("bioguide_id", "congress")) if skip_unchanged else {}
     )
@@ -111,19 +110,18 @@ def scrape(
                 ):
                     total_skipped += 1
                     continue
-                envelope = {
-                    "fetched_at": iso,
-                    # Composite key: the same Member appears in the listing
-                    # for every Congress they served in, and the payload is
-                    # identical across those queries. Without ``congress``
-                    # in the key we'd lose track of which Congress this
-                    # snapshot represents and the loader would collapse
-                    # multi-Congress careers into a single Term row.
-                    "key": {"bioguide_id": bioguide_id, "congress": congress},
-                    "payload": payload,
-                }
-                fh.write(json.dumps(envelope, ensure_ascii=False))
-                fh.write("\n")
+                # Composite key: the same Member appears in the listing for
+                # every Congress they served in, and the payload is identical
+                # across those queries. Without ``congress`` in the key we'd
+                # lose track of which Congress this snapshot represents and the
+                # loader would collapse multi-Congress careers into a single
+                # Term row.
+                append_snapshot(
+                    fh,
+                    fetched_at=fetched_at,
+                    key={"bioguide_id": bioguide_id, "congress": congress},
+                    payload=payload,
+                )
                 written_in_congress += 1
                 total_written += 1
                 if progress is not None:

--- a/src/concord/scraper/votes.py
+++ b/src/concord/scraper/votes.py
@@ -14,7 +14,6 @@ Phase 3b adds ``scrape_senate`` alongside ``scrape_house`` here; both
 write into the same canonical ``votes`` table via the loader.
 """
 
-import json
 import logging
 import time
 from collections.abc import Callable, Iterable
@@ -24,6 +23,7 @@ from typing import IO, Any, NamedTuple
 
 from concord.api import Client
 from concord.scraper._common import (
+    append_snapshot,
     is_stub_unchanged,
     load_freshness_map,
     parse_signal_timestamp,
@@ -104,7 +104,6 @@ def scrape_house(
     storage_dir.mkdir(parents=True, exist_ok=True)
     detail_path = storage_dir / HOUSE_VOTES_JSONL_NAME
     members_path = storage_dir / HOUSE_VOTE_POSITIONS_JSONL_NAME
-    iso = fetched_at.isoformat()
     sessions_tuple = tuple(sessions)
 
     # Detail and positions refresh independently under ``skip_unchanged``
@@ -137,7 +136,7 @@ def scrape_house(
                     session=session,
                     detail_fh=detail_fh,
                     members_fh=members_fh,
-                    iso=iso,
+                    fetched_at=fetched_at,
                     remaining=remaining,
                     skip_unchanged=skip_unchanged,
                     detail_freshness=detail_freshness,
@@ -179,7 +178,7 @@ def _scrape_pair(  # noqa: PLR0913 — pair worker forwards state from scrape_ho
     session: int,
     detail_fh: IO[str],
     members_fh: IO[str],
-    iso: str,
+    fetched_at: datetime,
     remaining: int | None,
     per_vote_progress: Callable[[ScrapeProgressEvent], None] | None = None,
     skip_unchanged: bool = False,
@@ -233,7 +232,7 @@ def _scrape_pair(  # noqa: PLR0913 — pair worker forwards state from scrape_ho
             skipped += 1
             positions_skipped += 1
             continue
-        key = {
+        key: dict[str, str | int] = {
             "chamber": "house",
             "congress": congress,
             "session": session,
@@ -241,13 +240,13 @@ def _scrape_pair(  # noqa: PLR0913 — pair worker forwards state from scrape_ho
         }
         if not skip_detail:
             detail = client.get_house_vote_detail(congress, session, roll_number)
-            _append_envelope(detail_fh, iso=iso, key=key, payload=detail)
+            append_snapshot(detail_fh, fetched_at=fetched_at, key=key, payload=detail)
             written += 1
         else:
             skipped += 1
         if not skip_positions:
             if _fetch_and_write_members(
-                client, congress, session, roll_number, members_fh, iso, key
+                client, congress, session, roll_number, members_fh, fetched_at, key
             ):
                 positions_written += 1
         else:
@@ -287,25 +286,14 @@ def _parse_roll_number(stub: dict[str, Any]) -> int | None:
         return None
 
 
-def _append_envelope(
-    fh: IO[str],
-    *,
-    iso: str,
-    key: dict[str, Any],
-    payload: Any,
-) -> None:
-    fh.write(json.dumps({"fetched_at": iso, "key": key, "payload": payload}, ensure_ascii=False))
-    fh.write("\n")
-
-
 def _fetch_and_write_members(
     client: Client,
     congress: int,
     session: int,
     roll_number: int,
     fh: IO[str],
-    iso: str,
-    key: dict[str, Any],
+    fetched_at: datetime,
+    key: dict[str, str | int],
 ) -> bool:
     """Best-effort fetch + write of the members payload; returns True on success.
 
@@ -323,7 +311,7 @@ def _fetch_and_write_members(
             exc,
         )
         return False
-    _append_envelope(fh, iso=iso, key=key, payload=members)
+    append_snapshot(fh, fetched_at=fetched_at, key=key, payload=members)
     return True
 
 
@@ -356,15 +344,14 @@ def scrape_senate(  # noqa: PLR0913 — kwargs match scrape_house surface
     storage_dir.mkdir(parents=True, exist_ok=True)
     detail_path = storage_dir / SENATE_VOTES_JSONL_NAME
     roster_path = storage_dir / SENATE_ROSTER_JSONL_NAME
-    iso = fetched_at.isoformat()
     sessions_tuple = tuple(sessions)
 
     # Roster envelope — always fetched, even if --limit truncates votes.
     roster_xml = client_xml.get_current_senators_xml().decode("utf-8")
     with roster_path.open("a", encoding="utf-8") as roster_fh:
-        _append_envelope(
+        append_snapshot(
             roster_fh,
-            iso=iso,
+            fetched_at=fetched_at,
             key={"source": "senators_cfm"},
             payload=roster_xml,
         )
@@ -399,7 +386,7 @@ def scrape_senate(  # noqa: PLR0913 — kwargs match scrape_house surface
                     congress=congress,
                     session=session,
                     detail_fh=detail_fh,
-                    iso=iso,
+                    fetched_at=fetched_at,
                     remaining=None if limit is None else max(0, limit - total_written),
                     skip_unchanged=skip_unchanged,
                     known_keys=known_keys,
@@ -433,7 +420,7 @@ def _scrape_senate_pair(  # noqa: PLR0913 — pair worker forwards state from sc
     congress: int,
     session: int,
     detail_fh: IO[str],
-    iso: str,
+    fetched_at: datetime,
     remaining: int | None,
     skip_unchanged: bool,
     known_keys: set[tuple[Any, ...]],
@@ -452,9 +439,9 @@ def _scrape_senate_pair(  # noqa: PLR0913 — pair worker forwards state from sc
             continue
         detail_bytes = client_xml.get_roll_call_xml(congress, session, roll_number)
         detail_xml = detail_bytes.decode("utf-8")
-        _append_envelope(
+        append_snapshot(
             detail_fh,
-            iso=iso,
+            fetched_at=fetched_at,
             key={
                 "chamber": "senate",
                 "congress": congress,

--- a/tests/test_scraper_bills.py
+++ b/tests/test_scraper_bills.py
@@ -85,7 +85,7 @@ class TestScrapeBasic:
         lines = out.read_text().splitlines()
         assert len(lines) == 2
         envelopes = [json.loads(line) for line in lines]
-        assert envelopes[0]["fetched_at"] == FIXED_FETCHED_AT.isoformat()
+        assert datetime.fromisoformat(envelopes[0]["fetched_at"]) == FIXED_FETCHED_AT
         # bill_type in key is lowercased.
         assert envelopes[0]["key"] == {"congress": 119, "bill_type": "hr", "bill_number": 1}
         assert envelopes[1]["key"]["bill_number"] == 22
@@ -252,7 +252,7 @@ class TestScrapeEnrichment:
             assert len(lines) == 1
             env = json.loads(lines[0])
             assert env["key"] == {"congress": 119, "bill_type": "hr", "bill_number": 1}
-            assert env["fetched_at"] == FIXED_FETCHED_AT.isoformat()
+            assert datetime.fromisoformat(env["fetched_at"]) == FIXED_FETCHED_AT
 
     def test_sections_subset_only_writes_listed_files(self, tmp_path: Path) -> None:
         client = _enrichment_client()

--- a/tests/test_scraper_common.py
+++ b/tests/test_scraper_common.py
@@ -281,3 +281,35 @@ class TestAppendSnapshot:
                 payload={},
             )
         assert path.read_text() == ""  # nothing was written
+
+    def test_emits_compact_json_with_z_timestamp(self, tmp_path: Path) -> None:
+        # Pins the on-disk rendering ADR 0018 Rule 5 documents: compact JSON
+        # (no spaces after ':'/','), field order fetched_at/key/payload, and a
+        # 'Z'-suffixed UTC fetched_at (not '+00:00'). Loaders and freshness maps
+        # accept this; pinning it catches a future Pydantic change that flips it.
+        path = tmp_path / "out.jsonl"
+        with path.open("a", encoding="utf-8") as fh:
+            append_snapshot(
+                fh,
+                fetched_at=datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC),
+                key={"s": 1},
+                payload={"n": 1},
+            )
+        line = path.read_text().splitlines()[0]
+        assert line == '{"fetched_at":"2026-05-25T14:02:11Z","key":{"s":1},"payload":{"n":1}}'
+
+    def test_non_finite_floats_become_null(self, tmp_path: Path) -> None:
+        # ADR 0018 Rule 5, consequence 3: Pydantic renders NaN/Infinity as JSON
+        # null, where the old json.dumps emitted bare NaN/Infinity tokens. Lossy,
+        # but the upstream sources never emit non-finite floats. Pinned so the
+        # divergence stays visible rather than being discovered in production.
+        path = tmp_path / "out.jsonl"
+        with path.open("a", encoding="utf-8") as fh:
+            append_snapshot(
+                fh,
+                fetched_at=datetime(2026, 5, 25, tzinfo=UTC),
+                key={"k": 1},
+                payload={"a": float("nan"), "b": float("inf"), "c": 1.5},
+            )
+        loaded = json.loads(path.read_text())["payload"]
+        assert loaded == {"a": None, "b": None, "c": 1.5}

--- a/tests/test_scraper_common.py
+++ b/tests/test_scraper_common.py
@@ -1,10 +1,16 @@
-"""Unit tests for :mod:`concord.scraper._common` (ADR 0015 helpers)."""
+"""Unit tests for :mod:`concord.scraper._common` (envelope read/write helpers)."""
 
 import json
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
+import pytest
+from pydantic import ValidationError
+
+from concord.models import Snapshot
 from concord.scraper._common import (
+    append_snapshot,
     is_stub_unchanged,
     load_bill_signal_map,
     load_freshness_map,
@@ -190,3 +196,88 @@ class TestLoadBillSignalMap:
         )
         result = load_bill_signal_map(path)
         assert result[(119, "hr", 1)] == datetime(2026, 5, 15, tzinfo=UTC)
+
+
+class TestAppendSnapshot:
+    """The ADR 0006 envelope *write* helper (ADR 0018 Rule 5).
+
+    Serializes through :class:`Snapshot`, the same model the loaders parse
+    with, so these tests assert the write side stays compatible with that
+    read side and honours the payload-verbatim contract (ADR 0018 Rule 1).
+    """
+
+    def test_round_trips_through_snapshot_model(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.jsonl"
+        fetched_at = datetime(2026, 5, 25, 14, 2, 11, tzinfo=UTC)
+        key: dict[str, str | int] = {"bioguide_id": "O000172", "congress": 119}
+        payload = {"bioguideId": "O000172", "name": "Last, First"}
+        with path.open("a", encoding="utf-8") as fh:
+            append_snapshot(fh, fetched_at=fetched_at, key=key, payload=payload)
+
+        lines = path.read_text().splitlines()
+        assert len(lines) == 1
+        snap = Snapshot[dict[str, Any]].model_validate_json(lines[0])
+        assert snap.fetched_at == fetched_at
+        assert snap.key == key
+        assert snap.payload == payload
+
+    def test_non_ascii_and_nested_payload_preserved(self, tmp_path: Path) -> None:
+        # ADR 0018 Rule 1: the payload is written verbatim, including non-ASCII
+        # (unescaped) and arbitrarily nested structures.
+        path = tmp_path / "out.jsonl"
+        payload = {
+            "title": "Café résumé — naïve façade",
+            "nested": {"items": [1, 2, {"x": "ü"}], "flag": True},
+        }
+        with path.open("a", encoding="utf-8") as fh:
+            append_snapshot(
+                fh,
+                fetched_at=datetime(2026, 5, 25, tzinfo=UTC),
+                key={"k": 1},
+                payload=payload,
+            )
+
+        line = path.read_text().splitlines()[0]
+        assert "Café résumé" in line  # written unescaped, not \uXXXX
+        assert json.loads(line)["payload"] == payload
+
+    def test_str_payload_round_trips(self, tmp_path: Path) -> None:
+        # Senate case: the payload is the raw decoded XML string, not a dict.
+        path = tmp_path / "out.jsonl"
+        payload = "<rollcall>café</rollcall>"
+        with path.open("a", encoding="utf-8") as fh:
+            append_snapshot(
+                fh,
+                fetched_at=datetime(2026, 5, 25, tzinfo=UTC),
+                key={"source": "senators_cfm"},
+                payload=payload,
+            )
+
+        snap = Snapshot[str].model_validate_json(path.read_text().splitlines()[0])
+        assert snap.payload == payload
+
+    def test_appends_one_line_per_call(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.jsonl"
+        with path.open("a", encoding="utf-8") as fh:
+            append_snapshot(
+                fh, fetched_at=datetime(2026, 5, 25, tzinfo=UTC), key={"k": 1}, payload={}
+            )
+            append_snapshot(
+                fh, fetched_at=datetime(2026, 5, 26, tzinfo=UTC), key={"k": 2}, payload={}
+            )
+        assert len(path.read_text().splitlines()) == 2
+
+    def test_malformed_key_raises_validation_error(self, tmp_path: Path) -> None:
+        # ADR 0018 Rule 5 fail-fast: a non-(str | int) key value raises at write
+        # time rather than serializing a malformed envelope silently. This never
+        # fires on current scraper paths (the skip rule guarantees scalar keys).
+        path = tmp_path / "out.jsonl"
+        bad_key: dict[str, Any] = {"bad": [1, 2]}
+        with path.open("a", encoding="utf-8") as fh, pytest.raises(ValidationError):
+            append_snapshot(
+                fh,
+                fetched_at=datetime(2026, 5, 25, tzinfo=UTC),
+                key=bad_key,
+                payload={},
+            )
+        assert path.read_text() == ""  # nothing was written

--- a/tests/test_scraper_members.py
+++ b/tests/test_scraper_members.py
@@ -65,7 +65,7 @@ class TestScrape:
         lines = out.read_text().splitlines()
         assert len(lines) == 1
         envelope = json.loads(lines[0])
-        assert envelope["fetched_at"] == FIXED_FETCHED_AT.isoformat()
+        assert datetime.fromisoformat(envelope["fetched_at"]) == FIXED_FETCHED_AT
         assert envelope["key"] == {"bioguide_id": "O000172", "congress": 119}
         assert envelope["payload"]["bioguideId"] == "O000172"
 

--- a/tests/test_scraper_votes.py
+++ b/tests/test_scraper_votes.py
@@ -131,7 +131,7 @@ class TestScrapeHouse:
                 sessions=(1,),
             )
         env = json.loads((tmp_path / HOUSE_VOTES_JSONL_NAME).read_text().splitlines()[0])
-        assert env["fetched_at"] == FIXED_FETCHED_AT.isoformat()
+        assert datetime.fromisoformat(env["fetched_at"]) == FIXED_FETCHED_AT
         assert env["key"] == {
             "chamber": "house",
             "congress": 119,


### PR DESCRIPTION
## What & why

The ADR 0006 `{fetched_at, key, payload}` snapshot envelope was hand-rolled with `json.dumps` at **six scraper write sites in three different idioms**, while the loaders already parse every line through the `Snapshot[T]` Pydantic model (`models/_common.py`). The envelope shape was single-sourced on the **read** side only.

This routes the **write** side through the same model via one shared helper, so `Snapshot` becomes the single source of truth for the envelope on both sides.

## The move

A free function `append_snapshot(fh, *, fetched_at, key, payload)` in `scraper/_common.py` serializes through `Snapshot[Any](...).model_dump_json()`. `payload` stays `Any` — written verbatim, never schema-validated, honoring **ADR 0018 Rule 1**. It's a free function (not a stateful writer) because bills/votes open several handles at once (ADR 0009); the file lifecycle stays with the scraper.

- The `concord.models` import is **confined to `scraper/_common.py`**; `members.py` / `bills.py` / `votes.py` stay model-free and now thread a `fetched_at: datetime` instead of a pre-stringified `iso`.
- `votes._append_envelope` and the three inline `json.dumps` envelope literals are gone.

## Accepted behavior changes (both vetted in grilling)

- **Wire format:** `model_dump_json()` emits compact JSON and renders `fetched_at` as `…Z` (vs `…+00:00`). Both are ISO-8601 UTC for the same instant and round-trip through `Snapshot.model_validate_json` / `datetime.fromisoformat`, so loaders and freshness maps are unaffected. Four scraper test assertions switch from literal-string compare to parsed-instant compare. Mutable-entity JSONL has no byte-reproducibility contract.
- **Fail-fast:** a malformed envelope `key` (non-`str | int` value) now raises `ValidationError` at scrape time. Never fires on current paths (the ADR 0018 scraper skip rule guarantees scalar keys); it's a latent guard.

## ADR

Amends **ADR 0018** — adds *Rule 5* (scrapers serialize the envelope, not the payload, through `Snapshot`) and flips status Proposed → Accepted.

## Out of scope (unchanged)

Proceedings (`JsonlStorage`, flat per ADR 0002/0006) and `runs.jsonl` (flat record table, ADR 0019) — neither uses the envelope. SQLite write path was already unified.

## Verification

`ruff format --check`, `ruff check`, `mypy --strict src`, and the full `pytest` suite (**779 passed**) are all green. New `tests/test_scraper_common.py::TestAppendSnapshot` covers round-trip, non-ASCII/nested payload fidelity, `str` payload (Senate), one-line-per-call, and the malformed-key fail-fast.

Full plan: `docs/plans/unify-snapshot-serialization.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)