### PR TITLE
feat(observability): fan out the Scrape Run ledger to text/senate + all scrapers (#105)

### DIFF
--- a/src/concord/cli/members.py
+++ b/src/concord/cli/members.py
@@ -8,6 +8,7 @@ from typing import Annotated
 import typer
 
 from concord.api import ENV_API_KEY, ApiError, Client
+from concord.observability import scrape_run
 from concord.pipeline.index_members import index as index_members
 from concord.pipeline.load_members import load as load_members
 from concord.scraper import members as members_scraper
@@ -32,41 +33,48 @@ def _run_scrape_members(
     congresses: list[int],
     storage_path: Path,
     show_progress: bool,
+    db_path: Path,
+    command: str,
     skip_unchanged: bool = False,
 ) -> int:
+    # Construct (and validate) the client BEFORE the scrape seam so a pure
+    # config error (missing API key) doesn't mint a Scrape Run or bootstrap the
+    # ledger DB — the recorder is born where the network is (ADR 0021), matching
+    # the Bills wiring.
     try:
         api_client = Client()
     except ApiError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
 
-    progress = Progress(enabled=show_progress)
-    tracker = RateTracker()
+    with scrape_run(entity="members", command=command, db_path=db_path):
+        progress = Progress(enabled=show_progress)
+        tracker = RateTracker()
 
-    def _on_progress(event: members_scraper.ScrapeProgressEvent) -> None:
-        if not progress.interactive and not event.is_congress_done:
-            return
-        tracker.update_total(event.category_total)
-        label = f"  congress {event.congress:>3}  "
-        if event.is_congress_done:
-            progress.update(label + tracker.finish(event.written_in_congress))
+        def _on_progress(event: members_scraper.ScrapeProgressEvent) -> None:
+            if not progress.interactive and not event.is_congress_done:
+                return
+            tracker.update_total(event.category_total)
+            label = f"  congress {event.congress:>3}  "
+            if event.is_congress_done:
+                progress.update(label + tracker.finish(event.written_in_congress))
+                progress.commit()
+                tracker.reset()
+            else:
+                progress.update(label + tracker.tick(event.written_in_congress))
+
+        try:
+            with api_client:
+                stats = members_scraper.scrape(
+                    client=api_client,
+                    congresses=congresses,
+                    storage_path=storage_path,
+                    fetched_at=datetime.now(UTC),
+                    progress=_on_progress if show_progress else None,
+                    skip_unchanged=skip_unchanged,
+                )
+        finally:
             progress.commit()
-            tracker.reset()
-        else:
-            progress.update(label + tracker.tick(event.written_in_congress))
-
-    try:
-        with api_client:
-            stats = members_scraper.scrape(
-                client=api_client,
-                congresses=congresses,
-                storage_path=storage_path,
-                fetched_at=datetime.now(UTC),
-                progress=_on_progress if show_progress else None,
-                skip_unchanged=skip_unchanged,
-            )
-    finally:
-        progress.commit()
 
     suffix = f" ({stats.members_skipped} skipped)" if stats.members_skipped else ""
     typer.echo(
@@ -131,6 +139,16 @@ def scrape_members_command(
         Path,
         typer.Option("--storage", help="JSONL output file. Created if missing."),
     ] = DEFAULT_MEMBERS_JSONL,
+    db_path: Annotated[
+        Path,
+        typer.Option(
+            "--db",
+            help=(
+                "SQLite DB for the Scrape Run ledger (ADR 0021). Stage 0 still "
+                "writes entity data only to JSONL; this DB receives telemetry only."
+            ),
+        ),
+    ] = DEFAULT_DB,
     show_progress: Annotated[
         bool,
         typer.Option(
@@ -161,6 +179,8 @@ def scrape_members_command(
         congresses=parsed,
         storage_path=storage_path,
         show_progress=show_progress,
+        db_path=db_path,
+        command="scrape members",
         skip_unchanged=skip_unchanged,
     )
 
@@ -244,6 +264,8 @@ def run_members_command(
         congresses=parsed,
         storage_path=storage_path,
         show_progress=show_progress,
+        db_path=db_path,
+        command="run members",
     )
 
     typer.echo("→ Stage 1: load", err=True)

--- a/src/concord/cli/proceedings.py
+++ b/src/concord/cli/proceedings.py
@@ -14,6 +14,7 @@ from concord.api import ENV_API_KEY
 from concord.chunking import Chunker
 from concord.embedding import Embedder
 from concord.models import Proceeding
+from concord.observability import scrape_run
 from concord.pipeline.index_proceedings import IndexResult, index
 from concord.pipeline.index_proceedings import ProgressEvent as IndexProgressEvent
 from concord.pipeline.load_proceedings import ProgressEvent as ScrapeProgressEvent
@@ -48,12 +49,18 @@ def _run_scrape_proceedings(
     storage_label: str,
     limit: int | None,
     show_progress: bool,
+    db_path: Path,
+    command: str,
 ) -> None:
-    """Wrap :func:`_run_pull` with a :class:`Progress` display.
+    """Wrap :func:`_run_pull` with a :class:`Progress` display and Scrape Run.
 
     Matches the ``_run_scrape_*`` pattern used by every other entity module:
     the CLI layer owns the ``Progress`` instance and passes a callback down
     to the scraper, keeping ``scraper.proceedings`` free of any CLI imports.
+
+    A single Proceedings scrape spans two HTTP clients — api.congress.gov for
+    issue/article metadata and congress.gov for article text — so its Scrape
+    Run (ADR 0021) carries both ``api:*`` and ``text:*`` buckets.
     """
     progress = Progress(enabled=show_progress)
 
@@ -69,17 +76,18 @@ def _run_scrape_proceedings(
             f"{event.total_failed})"
         )
 
-    try:
-        _run_pull(
-            start=start,
-            end=end,
-            storage=storage,
-            storage_label=storage_label,
-            limit=limit,
-            progress=_on_progress if show_progress else None,
-        )
-    finally:
-        progress.commit()
+    with scrape_run(entity="proceedings", command=command, db_path=db_path):
+        try:
+            _run_pull(
+                start=start,
+                end=end,
+                storage=storage,
+                storage_label=storage_label,
+                limit=limit,
+                progress=_on_progress if show_progress else None,
+            )
+        finally:
+            progress.commit()
 
 
 def _run_load(
@@ -237,6 +245,16 @@ def scrape_proceedings_command(
         Path,
         typer.Option("--storage", help="JSONL output file. Created if missing."),
     ] = DEFAULT_JSONL,
+    db_path: Annotated[
+        Path,
+        typer.Option(
+            "--db",
+            help=(
+                "SQLite DB for the Scrape Run ledger (ADR 0021). Stage 0 still "
+                "writes entity data only to JSONL; this DB receives telemetry only."
+            ),
+        ),
+    ] = DEFAULT_DB,
     limit: Annotated[
         int | None,
         typer.Option("--limit", help="Maximum number of new proceedings to write."),
@@ -265,6 +283,8 @@ def scrape_proceedings_command(
         storage_label=str(storage_path),
         limit=limit,
         show_progress=show_progress,
+        db_path=db_path,
+        command="scrape proceedings",
     )
 
 
@@ -401,6 +421,8 @@ def run_proceedings_command(
         storage_label=str(storage_path),
         limit=limit,
         show_progress=show_progress,
+        db_path=db_path,
+        command="run proceedings",
     )
 
     typer.echo("→ Stage 1: load", err=True)

--- a/src/concord/cli/proceedings.py
+++ b/src/concord/cli/proceedings.py
@@ -273,6 +273,17 @@ def scrape_proceedings_command(
     safe: already-stored articles are detected by their granule ID and
     skipped without re-fetching.
     """
+    # Gate the API key upfront so a pure config error doesn't mint a Scrape Run
+    # or bootstrap the ledger DB (ADR 0021): the proceedings scraper builds its
+    # Client internally, so without this guard the failure would surface inside
+    # the scrape seam. Mirrors `run proceedings` and the Bills/Members wiring.
+    if not os.environ.get(ENV_API_KEY):
+        typer.echo(
+            f"error: {ENV_API_KEY} is not set; required for `concord scrape proceedings`",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
     start = _parse_date(from_)
     end = _parse_date(to or _today())
 

--- a/src/concord/cli/votes.py
+++ b/src/concord/cli/votes.py
@@ -8,6 +8,7 @@ from typing import Annotated
 import typer
 
 from concord.api import ENV_API_KEY, ApiError, Client
+from concord.observability import scrape_run
 from concord.pipeline.index_votes import index as index_votes
 from concord.pipeline.load_votes import load as load_votes
 from concord.scraper import votes as votes_scraper
@@ -63,7 +64,7 @@ def _parse_chambers(raw: str) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _run_scrape_votes(
+def _run_scrape_votes(  # noqa: PLR0913 — one kwarg per scrape knob; +db_path/command thread the Scrape Run
     *,
     congresses: list[int],
     sessions: list[int],
@@ -71,68 +72,82 @@ def _run_scrape_votes(
     storage_dir: Path,
     limit: int | None,
     show_progress: bool,
+    db_path: Path,
+    command: str,
     skip_unchanged: bool = False,
 ) -> int:
     fetched_at = datetime.now(UTC)
-    progress = Progress(enabled=show_progress)
-    tracker = RateTracker()
 
-    def _on_progress(event: votes_scraper.ScrapeProgressEvent) -> None:
-        if not progress.interactive and not event.is_pair_done:
-            return
-        tracker.update_total(event.category_total)
-        label = f"  {event.chamber} {event.congress}/{event.session}  "
-        if event.is_pair_done:
-            progress.update(label + tracker.finish(event.votes_written))
+    # Pre-construct the House client (config, not network) BEFORE the scrape
+    # seam so a missing API key doesn't mint a Scrape Run or bootstrap the
+    # ledger DB (ADR 0021), matching the Bills/Members wiring. The Senate LIS
+    # client needs no key, so it's constructed inside the run.
+    api_client = None
+    if "house" in chambers:
+        try:
+            api_client = Client()
+        except ApiError as exc:
+            typer.echo(f"error: {exc}", err=True)
+            raise typer.Exit(code=2) from exc
+
+    # A single Votes scrape can span both HTTP clients — api.congress.gov for
+    # House votes and senate.gov LIS XML for Senate — so its Scrape Run carries
+    # ``api:house-vote/*`` and/or ``senate:*`` buckets depending on --chambers.
+    with scrape_run(entity="votes", command=command, db_path=db_path):
+        progress = Progress(enabled=show_progress)
+        tracker = RateTracker()
+
+        def _on_progress(event: votes_scraper.ScrapeProgressEvent) -> None:
+            if not progress.interactive and not event.is_pair_done:
+                return
+            tracker.update_total(event.category_total)
+            label = f"  {event.chamber} {event.congress}/{event.session}  "
+            if event.is_pair_done:
+                progress.update(label + tracker.finish(event.votes_written))
+                progress.commit()
+                tracker.reset()
+            else:
+                progress.update(label + tracker.tick(event.votes_written))
+
+        total_votes = 0
+        total_positions = 0
+        total_skipped = 0
+        total_positions_skipped = 0
+
+        try:
+            if api_client is not None:
+                with api_client:
+                    stats = votes_scraper.scrape_house(
+                        client=api_client,
+                        congresses=congresses,
+                        storage_dir=storage_dir,
+                        fetched_at=fetched_at,
+                        sessions=tuple(sessions),
+                        limit=limit,
+                        progress=_on_progress if show_progress else None,
+                        skip_unchanged=skip_unchanged,
+                    )
+                total_votes += stats.votes_written
+                total_positions += stats.positions_written
+                total_skipped += stats.votes_skipped
+                total_positions_skipped += stats.positions_skipped
+
+            if "senate" in chambers:
+                with SenateClient() as senate_client:
+                    stats = votes_scraper.scrape_senate(
+                        client_xml=senate_client,
+                        congresses=congresses,
+                        storage_dir=storage_dir,
+                        fetched_at=fetched_at,
+                        sessions=tuple(sessions),
+                        limit=limit,
+                        progress=_on_progress if show_progress else None,
+                        skip_unchanged=skip_unchanged,
+                    )
+                total_votes += stats.votes_written
+                total_skipped += stats.votes_skipped
+        finally:
             progress.commit()
-            tracker.reset()
-        else:
-            progress.update(label + tracker.tick(event.votes_written))
-
-    total_votes = 0
-    total_positions = 0
-    total_skipped = 0
-    total_positions_skipped = 0
-
-    try:
-        if "house" in chambers:
-            try:
-                api_client = Client()
-            except ApiError as exc:
-                typer.echo(f"error: {exc}", err=True)
-                raise typer.Exit(code=2) from exc
-            with api_client:
-                stats = votes_scraper.scrape_house(
-                    client=api_client,
-                    congresses=congresses,
-                    storage_dir=storage_dir,
-                    fetched_at=fetched_at,
-                    sessions=tuple(sessions),
-                    limit=limit,
-                    progress=_on_progress if show_progress else None,
-                    skip_unchanged=skip_unchanged,
-                )
-            total_votes += stats.votes_written
-            total_positions += stats.positions_written
-            total_skipped += stats.votes_skipped
-            total_positions_skipped += stats.positions_skipped
-
-        if "senate" in chambers:
-            with SenateClient() as senate_client:
-                stats = votes_scraper.scrape_senate(
-                    client_xml=senate_client,
-                    congresses=congresses,
-                    storage_dir=storage_dir,
-                    fetched_at=fetched_at,
-                    sessions=tuple(sessions),
-                    limit=limit,
-                    progress=_on_progress if show_progress else None,
-                    skip_unchanged=skip_unchanged,
-                )
-            total_votes += stats.votes_written
-            total_skipped += stats.votes_skipped
-    finally:
-        progress.commit()
 
     skip_suffix = ""
     if total_skipped or total_positions_skipped:
@@ -226,6 +241,16 @@ def scrape_votes_command(
             help="Directory holding house_votes.jsonl + senate_votes.jsonl + sidecar files.",
         ),
     ] = DEFAULT_VOTES_STORAGE_DIR,
+    db_path: Annotated[
+        Path,
+        typer.Option(
+            "--db",
+            help=(
+                "SQLite DB for the Scrape Run ledger (ADR 0021). Stage 0 still "
+                "writes entity data only to JSONL; this DB receives telemetry only."
+            ),
+        ),
+    ] = DEFAULT_DB,
     limit: Annotated[
         int | None,
         typer.Option(
@@ -263,6 +288,8 @@ def scrape_votes_command(
         storage_dir=storage_dir,
         limit=limit,
         show_progress=show_progress,
+        db_path=db_path,
+        command="scrape votes",
         skip_unchanged=skip_unchanged,
     )
 
@@ -373,6 +400,8 @@ def run_votes_command(
         storage_dir=storage_dir,
         limit=limit,
         show_progress=show_progress,
+        db_path=db_path,
+        command="run votes",
     )
 
     typer.echo("→ Stage 1: load", err=True)

--- a/src/concord/models/votes.py
+++ b/src/concord/models/votes.py
@@ -29,7 +29,6 @@ from pydantic import BaseModel, ConfigDict
 
 from concord.models._common import Chamber, SessionNumber, normalize_chamber
 from concord.models.bills import bill_id_from_components
-from concord.senate_xml import SenateXmlError
 
 _log = logging.getLogger("concord.models.votes")
 
@@ -361,6 +360,13 @@ class SenateVoteDetail(BaseModel):
         or missing required date fields; raises ``pydantic.ValidationError``
         for any field that doesn't match the model's schema.
         """
+        # Lazy import: ``concord.senate_xml`` now records into the observability
+        # ledger, which imports ``concord.models`` — so a top-level import here
+        # would close a models<->senate_xml cycle. ``SenateXmlError`` lives with
+        # its client (project convention), and it's only needed inside this one
+        # parse path, so importing it lazily keeps senate_xml a clean dependency.
+        from concord.senate_xml import SenateXmlError  # noqa: PLC0415 - breaks an import cycle
+
         try:
             root = ET.fromstring(xml_bytes)  # noqa: S314 — senate.gov XML is trusted (no DTD, no external entities)
         except ET.ParseError as exc:

--- a/src/concord/observability.py
+++ b/src/concord/observability.py
@@ -95,9 +95,9 @@ _UNMATCHED_SUFFIX = ":unmatched"
 # routes must precede their prefixes (``…/articles`` before the list,
 # ``bill/{sub}`` before ``bill/detail`` before ``bill/list``).
 #
-# PR 1 (this slice) populates only ``"api"``; PR 2 adds ``"text"`` and
-# ``"senate"`` keys here and instruments their clients — the public shape
-# of this table is part of the contract those edits build on.
+# ``"api"`` covers api.congress.gov paths; ``"text"`` and ``"senate"`` cover
+# the full congress.gov / senate.gov URLs their clients fetch. The public
+# shape of this table is part of the recorder's contract.
 _ROUTES: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
     "api": (
         (
@@ -112,6 +112,25 @@ _ROUTES: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
         (re.compile(r"^/?house-vote/\d+/\d+/\d+/members/?$"), "api:house-vote/members"),
         (re.compile(r"^/?house-vote/\d+/\d+/\d+/?$"), "api:house-vote/detail"),
         (re.compile(r"^/?house-vote/\d+/\d+/?$"), "api:house-vote/list"),
+    ),
+    # text.py fetches full congress.gov URLs (not api.congress.gov paths), so
+    # these routes match on the whole URL. The Congressional Record article
+    # tier serves one ``…/modified/CREC-*.htm`` shape — effectively the only
+    # endpoint — so a single ``text:article`` bucket suffices (ADR 0021).
+    "text": (
+        (
+            re.compile(r"^https?://(?:www\.)?congress\.gov/.+/modified/.+\.htm$"),
+            "text:article",
+        ),
+    ),
+    # senate_xml.py also fetches full URLs. The three LIS feeds map to three
+    # buckets keyed on their stable path shapes (see MENU_URL/DETAIL_URL/
+    # ROSTER_URL in senate_xml.py); concrete (congress, session, roll) values
+    # never enter the bucket, preserving aggregation.
+    "senate": (
+        (re.compile(r"^https?://.+/roll_call_lists/vote_menu_\d+_\d+\.xml$"), "senate:menu"),
+        (re.compile(r"^https?://.+/roll_call_votes/.+\.xml$"), "senate:detail"),
+        (re.compile(r"^https?://.+/senators_cfm\.xml$"), "senate:roster"),
     ),
 }
 

--- a/src/concord/senate_xml.py
+++ b/src/concord/senate_xml.py
@@ -27,20 +27,12 @@ import time
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from types import TracebackType
-from typing import TYPE_CHECKING
 
 import httpx
 
 from . import __version__
 from .models import Attempt
-
-if TYPE_CHECKING:
-    # Import-time only. ``concord.models.votes`` imports this module, and
-    # ``observability`` imports ``concord.models`` — so a top-level
-    # ``from .observability import Recorder`` would close a
-    # models<->senate_xml<->observability cycle. ``active_recorder`` is imported
-    # lazily inside ``_get_xml`` for the same reason; the type is annotation-only.
-    from .observability import Recorder
+from .observability import Recorder, active_recorder
 
 _log = logging.getLogger("concord.senate_xml")
 
@@ -159,10 +151,7 @@ class SenateClient:
         # accumulates every non-success try (transport failure, 5xx, the
         # non-200/HTML-trap terminal cases) so a resolved-on-retry fetch can
         # report what it weathered. ``rec`` is None outside an active scrape,
-        # making the recording a no-op. Retry *behavior* is unchanged. The
-        # import is lazy to avoid the models<->senate_xml<->observability cycle.
-        from .observability import active_recorder  # noqa: PLC0415 - breaks an import cycle
-
+        # making the recording a no-op. Retry *behavior* is unchanged.
         rec = active_recorder()
         attempts: list[Attempt] = []
 
@@ -251,7 +240,7 @@ def _note_attempt(
     )
 
 
-def _record_success(rec: "Recorder | None", url: str, attempts: list[Attempt]) -> None:
+def _record_success(rec: Recorder | None, url: str, attempts: list[Attempt]) -> None:
     """Record a successful XML fetch, plus a resolved Run Event if it retried."""
     if rec is None:
         return
@@ -260,17 +249,25 @@ def _record_success(rec: "Recorder | None", url: str, attempts: list[Attempt]) -
         rec.note_request_outcome("senate", url, attempts, resolved=True)
 
 
-def _record_failure(rec: "Recorder | None", url: str, attempts: list[Attempt]) -> None:
+def _record_failure(rec: Recorder | None, url: str, attempts: list[Attempt]) -> None:
     """Record a terminal XML fetch failure as a failed Run Event (no-op without a recorder)."""
     if rec is not None:
         rec.note_request_outcome("senate", url, attempts, resolved=False)
 
 
-def _record_html_trap(rec: "Recorder | None", url: str, attempts: list[Attempt]) -> None:
+def _record_html_trap(rec: Recorder | None, url: str, attempts: list[Attempt]) -> None:
     """Record the HTML-as-200 trap as a failed Run Event.
 
     The HTTP status was 200, so a synthetic attempt carrying status 200 and the
     :data:`_HTML_TRAP_MARKER` makes the "looked OK, was an HTML 404" cause legible.
+
+    Note the deliberate asymmetry with ``text.py``'s "no <pre>" structural
+    failure: there the HTTP request is a genuine success (counted) *and* a
+    separate failed event records the unparseable body, because the content
+    check happens after the chokepoint returns. Here the content check lives
+    inside the chokepoint, so the trap is recorded as a failure *only* — never a
+    success. Both are correct given where each parse check sits; the success
+    counts mean "successful network requests", and an HTML 404 is not one.
     """
     if rec is None:
         return

--- a/src/concord/senate_xml.py
+++ b/src/concord/senate_xml.py
@@ -27,10 +27,20 @@ import time
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from types import TracebackType
+from typing import TYPE_CHECKING
 
 import httpx
 
 from . import __version__
+from .models import Attempt
+
+if TYPE_CHECKING:
+    # Import-time only. ``concord.models.votes`` imports this module, and
+    # ``observability`` imports ``concord.models`` — so a top-level
+    # ``from .observability import Recorder`` would close a
+    # models<->senate_xml<->observability cycle. ``active_recorder`` is imported
+    # lazily inside ``_get_xml`` for the same reason; the type is annotation-only.
+    from .observability import Recorder
 
 _log = logging.getLogger("concord.senate_xml")
 
@@ -145,12 +155,24 @@ class SenateClient:
     # -- internals --------------------------------------------------------
 
     def _get_xml(self, url: str) -> bytes:
+        # Observability (ADR 0021): mirror api.py's chokepoint. ``attempts``
+        # accumulates every non-success try (transport failure, 5xx, the
+        # non-200/HTML-trap terminal cases) so a resolved-on-retry fetch can
+        # report what it weathered. ``rec`` is None outside an active scrape,
+        # making the recording a no-op. Retry *behavior* is unchanged. The
+        # import is lazy to avoid the models<->senate_xml<->observability cycle.
+        from .observability import active_recorder  # noqa: PLC0415 - breaks an import cycle
+
+        rec = active_recorder()
+        attempts: list[Attempt] = []
+
         last_exc: Exception | None = None
         for attempt in range(MAX_RETRIES):
             try:
                 response = self._client.get(url)
             except httpx.HTTPError as exc:
                 last_exc = exc
+                _note_attempt(attempts, transport_class=type(exc).__name__, message=str(exc))
                 _log.warning(
                     "senate.gov transport error (attempt %d/%d) at %s: %s",
                     attempt + 1,
@@ -162,6 +184,7 @@ class SenateClient:
                 status = response.status_code
                 if HTTP_SERVER_ERROR_MIN <= status < HTTP_SERVER_ERROR_MAX:
                     last_exc = SenateXmlError(f"senate.gov returned {status} for {url}")
+                    _note_attempt(attempts, status=status, message=f"senate.gov returned {status}")
                     _log.warning(
                         "senate.gov %d (attempt %d/%d) at %s",
                         status,
@@ -170,12 +193,24 @@ class SenateClient:
                         url,
                     )
                 elif status != HTTP_OK:
+                    _note_attempt(attempts, status=status, message=f"senate.gov returned {status}")
+                    _record_failure(rec, url, attempts)
                     raise SenateXmlError(f"senate.gov returned {status} for {url}")
                 else:
-                    _check_xml_content_type(response, url)
+                    # 200 OK, but senate.gov serves an HTML error page (not a
+                    # 404) for missing roll-call files. That HTML-as-200 trap is
+                    # a structural failure even though the status was 200 —
+                    # record it before re-raising.
+                    try:
+                        _check_xml_content_type(response, url)
+                    except SenateXmlError:
+                        _record_html_trap(rec, url, attempts)
+                        raise
+                    _record_success(rec, url, attempts)
                     return response.content
             if attempt < MAX_RETRIES - 1:
                 self._sleep(_BACKOFF_BASE**attempt)
+        _record_failure(rec, url, attempts)
         assert last_exc is not None  # noqa: S101
         raise SenateXmlError(f"senate.gov failed after {MAX_RETRIES} attempts at {url}: {last_exc}")
 
@@ -185,6 +220,62 @@ def _check_xml_content_type(response: httpx.Response, url: str) -> None:
     content_type = response.headers.get("Content-Type", "").lower()
     if "text/html" in content_type:
         raise SenateXmlError(f"got HTML response, expected XML, at {url}")
+
+
+# -- observability helpers --------------------------------------------------
+#
+# Module-level (rather than inline blocks) so each recording stays one
+# statement in the retry loop. The route table maps the full senate.gov URL to
+# the right ``senate:*`` bucket, so callers pass ``"senate"`` + the URL.
+
+#: Synthetic ``message`` marker for the HTML-as-200 trap (status is a real 200,
+#: so the marker is what distinguishes it from a genuine fetch).
+_HTML_TRAP_MARKER = "html-not-xml"
+
+
+def _note_attempt(
+    attempts: list[Attempt],
+    *,
+    status: int | None = None,
+    transport_class: str | None = None,
+    message: str,
+) -> None:
+    """Append one non-success :class:`Attempt`; ``n`` derives from list position."""
+    attempts.append(
+        Attempt(
+            n=len(attempts) + 1,
+            status=status,
+            transport_class=transport_class,
+            message=message,
+        )
+    )
+
+
+def _record_success(rec: "Recorder | None", url: str, attempts: list[Attempt]) -> None:
+    """Record a successful XML fetch, plus a resolved Run Event if it retried."""
+    if rec is None:
+        return
+    rec.note_success("senate", url)
+    if attempts:
+        rec.note_request_outcome("senate", url, attempts, resolved=True)
+
+
+def _record_failure(rec: "Recorder | None", url: str, attempts: list[Attempt]) -> None:
+    """Record a terminal XML fetch failure as a failed Run Event (no-op without a recorder)."""
+    if rec is not None:
+        rec.note_request_outcome("senate", url, attempts, resolved=False)
+
+
+def _record_html_trap(rec: "Recorder | None", url: str, attempts: list[Attempt]) -> None:
+    """Record the HTML-as-200 trap as a failed Run Event.
+
+    The HTTP status was 200, so a synthetic attempt carrying status 200 and the
+    :data:`_HTML_TRAP_MARKER` makes the "looked OK, was an HTML 404" cause legible.
+    """
+    if rec is None:
+        return
+    _note_attempt(attempts, status=HTTP_OK, message=_HTML_TRAP_MARKER)
+    rec.note_request_outcome("senate", url, attempts, resolved=False)
 
 
 # ---------------------------------------------------------------------------

--- a/src/concord/text.py
+++ b/src/concord/text.py
@@ -51,6 +51,8 @@ from concord.api import (
     HTTP_SERVER_ERROR_MIN,
     HTTP_TOO_MANY_REQUESTS,
 )
+from concord.models import Attempt
+from concord.observability import Recorder, active_recorder
 
 #: Cap on a single backoff delay, in seconds. Applied to both the exponential
 #: schedule and Retry-After values so a server-suggested 1-hour wait can't
@@ -216,6 +218,11 @@ def fetch_text(
     extractor.feed(response.text)
     text = extractor.text
     if not text:
+        # The HTTP fetch succeeded (counted above) but the body has no <pre>
+        # block — a structural failure distinct from any network error. Record
+        # it so "page fetched but unparseable" is visible in the Scrape Run,
+        # not silently dropped (ADR 0021). status_code is None for this class.
+        _record_structural_failure(active_recorder(), url)
         raise TextFetchError(f"no <pre> content found at {url}")
     return text
 
@@ -226,6 +233,15 @@ def _get_with_retry(
     throttle: AdaptiveThrottle,
     sleep: Callable[[float], None],
 ) -> httpx.Response:
+    # Observability (ADR 0021): mirror api.py's chokepoint. ``attempts``
+    # accumulates every non-success try — transport failure, 403/429 throttle
+    # (recorded as errors even though we retry them indefinitely), 5xx — so a
+    # resolved-on-retry fetch can report what it weathered. ``rec`` is None
+    # outside an active scrape, making the recording a no-op. Retry *behavior*
+    # is unchanged.
+    rec = active_recorder()
+    attempts: list[Attempt] = []
+
     # Proactively wait out any backoff carried over from earlier URLs before the
     # first attempt — congress.gov rate-limits per client, so hammering the next
     # URL immediately after a throttle just re-trips the limit.
@@ -235,7 +251,9 @@ def _get_with_retry(
         try:
             response = client.get(url, follow_redirects=True)
         except httpx.HTTPError as exc:
+            _note_attempt(attempts, transport_class=type(exc).__name__, message=str(exc))
             if transient_attempts >= MAX_5XX_RETRIES:
+                _record_failure(rec, url, attempts)
                 raise TextFetchError(
                     f"transport error fetching {url} "
                     f"(gave up after {MAX_5XX_RETRIES} attempts): {exc}"
@@ -254,6 +272,7 @@ def _get_with_retry(
             # Escalate the shared throttle and retry indefinitely. Throttle waits
             # do not increment transient_attempts — being blocked is a wait
             # condition, not a fault, and must not burn the 5xx budget.
+            _note_attempt(attempts, status=status, message=response.reason_phrase)
             delay = throttle.penalize(_retry_after_seconds(response))
             _log.warning(
                 "%d from %s (rate-limited?); backing off %.1fs before retry (level %d)",
@@ -265,7 +284,9 @@ def _get_with_retry(
             continue
 
         if HTTP_SERVER_ERROR_MIN <= status < HTTP_SERVER_ERROR_MAX:
+            _note_attempt(attempts, status=status, message=response.reason_phrase)
             if transient_attempts >= MAX_5XX_RETRIES:
+                _record_failure(rec, url, attempts)
                 raise TextFetchError(
                     f"{status} {response.reason_phrase} fetching {url} "
                     f"(gave up after {MAX_5XX_RETRIES} attempts)",
@@ -285,13 +306,76 @@ def _get_with_retry(
             continue
 
         if not response.is_success:
+            _note_attempt(attempts, status=status, message=response.reason_phrase)
+            _record_failure(rec, url, attempts)
             raise TextFetchError(
                 f"{status} {response.reason_phrase} fetching {url}",
                 status_code=status,
             )
 
         throttle.recover()
+        _record_success(rec, url, attempts)
         return response
+
+
+# -- observability helpers --------------------------------------------------
+#
+# Module-level (rather than inline blocks) so each recording stays one
+# statement in the retry loop, which is already at the project's complexity
+# ceiling. Source bucket is always ``"text"`` — the route table maps the full
+# URL to ``text:article``.
+
+#: Synthetic ``transport_class`` marker for the "fetched but no <pre> block"
+#: structural failure, which has no HTTP status of its own (the fetch was a 200).
+_NO_PRE_MARKER = "NoPreContent"
+
+
+def _note_attempt(
+    attempts: list[Attempt],
+    *,
+    status: int | None = None,
+    transport_class: str | None = None,
+    message: str,
+) -> None:
+    """Append one non-success :class:`Attempt`; ``n`` derives from list position."""
+    attempts.append(
+        Attempt(
+            n=len(attempts) + 1,
+            status=status,
+            transport_class=transport_class,
+            message=message,
+        )
+    )
+
+
+def _record_success(rec: Recorder | None, url: str, attempts: list[Attempt]) -> None:
+    """Record a successful text fetch, plus a resolved Run Event if it retried."""
+    if rec is None:
+        return
+    rec.note_success("text", url)
+    if attempts:
+        rec.note_request_outcome("text", url, attempts, resolved=True)
+
+
+def _record_failure(rec: Recorder | None, url: str, attempts: list[Attempt]) -> None:
+    """Record a terminal text fetch failure as a failed Run Event (no-op without a recorder)."""
+    if rec is not None:
+        rec.note_request_outcome("text", url, attempts, resolved=False)
+
+
+def _record_structural_failure(rec: Recorder | None, url: str) -> None:
+    """Record the HTTP-200-but-no-<pre> structural failure as a failed Run Event.
+
+    Distinct from the network failures above: the fetch succeeded (and was
+    counted as a success) but the body was unparseable. A single synthetic
+    attempt carries the :data:`_NO_PRE_MARKER` so the cause is legible.
+    """
+    if rec is None:
+        return
+    attempts = [
+        Attempt(n=1, status=None, transport_class=_NO_PRE_MARKER, message="no <pre> content")
+    ]
+    rec.note_request_outcome("text", url, attempts, resolved=False)
 
 
 def _backoff_seconds(attempt: int) -> float:

--- a/tests/test_import_cycles.py
+++ b/tests/test_import_cycles.py
@@ -1,0 +1,38 @@
+"""Import-order regression guard.
+
+The observability ledger (ADR 0021) introduced cross-module edges:
+``senate_xml`` imports ``concord.models`` and ``concord.observability``, and
+``observability`` imports ``concord.models`` — while ``concord.models.votes``
+parses senate XML. A careless top-level import in any of these closes a cycle
+that only fires when a particular module is imported *first* (the rest of the
+suite imports ``concord.models`` early, masking it). These subprocess imports
+each start from a clean interpreter so an order-dependent ``ImportError`` can't
+hide behind collection order.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+# Every module on the observability<->models<->client cycle, as a first import.
+_LEAF_FIRST_IMPORTS = [
+    "concord.senate_xml",
+    "concord.observability",
+    "concord.models",
+    "concord.text",
+    "concord.api",
+]
+
+
+@pytest.mark.parametrize("module", _LEAF_FIRST_IMPORTS)
+def test_module_imports_cleanly_as_first_import(module: str) -> None:
+    result = subprocess.run(  # noqa: S603 - fixed args, no shell, trusted module list
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"importing {module} first failed (likely a circular import):\n{result.stderr}"
+    )

--- a/tests/test_observability_fanout_integration.py
+++ b/tests/test_observability_fanout_integration.py
@@ -1,0 +1,92 @@
+"""End-to-end fan-out: the text/senate/api clients record into a live
+``scrape_run`` that flushes to SQLite, and a normal run produces the expected
+source buckets with **no** ``*:unmatched`` bucket (ADR 0021, PR 2 acceptance).
+
+These mirror the cross-source shapes the Proceedings (api + text) and Votes
+(api + senate) scrapers exercise, driving the real chokepoints through mocked
+transports rather than re-running a whole CLI pipeline.
+"""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import httpx
+
+from concord.api import Client
+from concord.observability import current_run_id, scrape_run
+from concord.senate_xml import SenateClient
+from concord.storage.sqlite import SqliteStorage
+from concord.text import AdaptiveThrottle, fetch_text
+
+ARTICLE_URL = (
+    "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgD551-6.htm"
+)
+
+
+def _read_run(db_path: Path, run_id: str) -> dict[str, object]:
+    storage = SqliteStorage(db_path, load_vec=False)
+    try:
+        row = storage.get_run(run_id)
+        assert row is not None
+        return dict(row)
+    finally:
+        storage.close()
+
+
+def _api_client(handler: Callable[[httpx.Request], httpx.Response]) -> Client:
+    return Client(api_key="test-key", transport=httpx.MockTransport(handler), sleep=lambda _s: None)
+
+
+def _ok_json() -> httpx.Response:
+    return httpx.Response(
+        200,
+        content=b'{"dailyCongressionalRecord": [], "pagination": {"count": 0}}',
+        headers={"content-type": "application/json"},
+    )
+
+
+def _text_client(body: str) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(lambda _r: httpx.Response(200, text=body)))
+
+
+def _senate_client(xml: bytes) -> SenateClient:
+    handler = lambda _r: httpx.Response(  # noqa: E731 - terse mock handler
+        200, content=xml, headers={"content-type": "application/xml"}
+    )
+    return SenateClient(transport=httpx.MockTransport(handler), sleep=lambda _s: None)
+
+
+def test_proceedings_run_carries_both_api_and_text_buckets(tmp_path: Path) -> None:
+    db_path = tmp_path / "ledger.db"
+    with scrape_run(entity="proceedings", command="scrape proceedings", db_path=db_path):
+        run_id = current_run_id()
+        assert run_id is not None
+        with _api_client(lambda _r: _ok_json()) as api:
+            api.list_issues()
+        with _text_client("<pre>hello world</pre>") as http:
+            fetch_text(ARTICLE_URL, http, throttle=AdaptiveThrottle(sleep=lambda _s: None))
+
+    row = _read_run(db_path, run_id)
+    counts = json.loads(row["success_counts"])
+    assert counts == {"api:daily-record/list": 1, "text:article": 1}
+    # A clean run never falls back to the unmatched sentinel.
+    assert row["unmatched_sample"] is None  # empty sample stored as NULL
+    assert row["status"] == "ok"
+
+
+def test_votes_run_carries_both_api_and_senate_buckets(tmp_path: Path) -> None:
+    db_path = tmp_path / "ledger.db"
+    with scrape_run(entity="votes", command="scrape votes", db_path=db_path):
+        run_id = current_run_id()
+        assert run_id is not None
+        with _api_client(lambda _r: _ok_json()) as api:
+            api.list_issues()
+        with _senate_client(b"<doc></doc>") as senate:
+            senate.get_current_senators_xml()
+
+    row = _read_run(db_path, run_id)
+    counts = json.loads(row["success_counts"])
+    assert counts == {"api:daily-record/list": 1, "senate:roster": 1}
+    assert row["unmatched_sample"] is None  # empty sample stored as NULL
+    assert row["status"] == "ok"

--- a/tests/test_observability_routes.py
+++ b/tests/test_observability_routes.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import pytest
 
 from concord.observability import Recorder, normalize
+from concord.senate_xml import DETAIL_URL, MENU_URL, ROSTER_URL
 
 
 class TestNormalize:
@@ -56,6 +57,38 @@ class TestNormalize:
     def test_unknown_source_is_unmatched(self) -> None:
         assert normalize("text", "/anything") == ("text:unmatched", False)
         assert normalize("senate", "/anything") == ("senate:unmatched", False)
+
+    def test_congress_gov_article_url_maps_to_text_article(self) -> None:
+        url = (
+            "https://www.congress.gov/119/crec/2026/05/22/172/88/"
+            "modified/CREC-2026-05-22-pt1-PgD551-6.htm"
+        )
+        assert normalize("text", url) == ("text:article", True)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # a congress.gov URL that isn't an article-text page (no /modified/.htm)
+            "https://www.congress.gov/bill/119/hr/1234",
+            # the PDF sibling of an article, not the formatted-text .htm
+            "https://www.congress.gov/119/crec/2026/05/22/172/88/CREC-2026-05-22-pt1-PgD551-6.pdf",
+        ],
+    )
+    def test_unknown_congress_gov_text_url_is_unmatched(self, url: str) -> None:
+        assert normalize("text", url) == ("text:unmatched", False)
+
+    def test_senate_menu_detail_roster_urls_map_to_buckets(self) -> None:
+        menu = MENU_URL.format(congress=119, session=1)
+        detail = DETAIL_URL.format(congress=119, session=1, roll5=f"{42:05d}")
+        assert normalize("senate", menu) == ("senate:menu", True)
+        assert normalize("senate", detail) == ("senate:detail", True)
+        assert normalize("senate", ROSTER_URL) == ("senate:roster", True)
+
+    def test_unknown_senate_gov_url_is_unmatched(self) -> None:
+        assert normalize("senate", "https://www.senate.gov/something/else.html") == (
+            "senate:unmatched",
+            False,
+        )
 
 
 class TestUnmatchedSampling:

--- a/tests/test_senate_xml_recording.py
+++ b/tests/test_senate_xml_recording.py
@@ -1,0 +1,156 @@
+"""senate_xml.py chokepoint recording — successful fetches bump the right
+``senate:*`` bucket, error outcomes emit Run Events with retry resolution, and
+the HTML-as-200 trap is recorded as a failed event (ADR 0021). Retry *behavior*
+is covered by test_senate_xml.py and unchanged.
+
+All tests run inside a manually-installed Recorder contextvar rather than a
+full ``scrape_run`` so they assert against in-memory state without touching
+SQLite.
+"""
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from concord.observability import Recorder, _recorder
+from concord.senate_xml import SenateClient, SenateXmlError
+
+#: Minimal well-formed XML that the roster/menu parsers accept (empty result).
+_XML_BODY = b"<doc></doc>"
+
+
+@contextmanager
+def _active_recorder() -> Iterator[Recorder]:
+    rec = Recorder(entity="votes", command="scrape votes", started_at=datetime.now(UTC))
+    token = _recorder.set(rec)
+    try:
+        yield rec
+    finally:
+        _recorder.reset(token)
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> SenateClient:
+    return SenateClient(transport=httpx.MockTransport(handler), sleep=lambda _s: None)
+
+
+def _sequenced(items: list[httpx.Response]) -> Callable[[httpx.Request], httpx.Response]:
+    iterator = iter(items)
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return next(iterator)
+
+    return handler
+
+
+def _ok_xml() -> httpx.Response:
+    return httpx.Response(200, content=_XML_BODY, headers={"content-type": "application/xml"})
+
+
+def _ok_html() -> httpx.Response:
+    # The senate.gov "404-disguised-as-200" trap: a 200 carrying an HTML body.
+    return httpx.Response(
+        200, content=b"<html>not found</html>", headers={"content-type": "text/html"}
+    )
+
+
+class TestSuccessRecording:
+    def test_clean_roster_fetch_bumps_roster_bucket(self) -> None:
+        with _active_recorder() as rec, _client(lambda _r: _ok_xml()) as client:
+            client.get_current_senators_xml()
+        assert rec.successes == {"senate:roster": 1}
+        assert rec.events == []
+
+    def test_clean_menu_fetch_bumps_menu_bucket(self) -> None:
+        with _active_recorder() as rec, _client(lambda _r: _ok_xml()) as client:
+            client.list_roll_call_numbers(119, 1)
+        assert rec.successes == {"senate:menu": 1}
+        assert rec.events == []
+
+    def test_clean_detail_fetch_bumps_detail_bucket(self) -> None:
+        with _active_recorder() as rec, _client(lambda _r: _ok_xml()) as client:
+            client.get_roll_call_xml(119, 1, 42)
+        assert rec.successes == {"senate:detail": 1}
+        assert rec.events == []
+
+    def test_no_recorder_is_a_noop(self) -> None:
+        with _client(lambda _r: _ok_xml()) as client:
+            content = client.get_current_senators_xml()
+        assert content == _XML_BODY
+
+
+class TestErrorRecording:
+    def test_503_then_200_emits_one_resolved_event(self) -> None:
+        handler = _sequenced([httpx.Response(503), _ok_xml()])
+        with _active_recorder() as rec, _client(handler) as client:
+            client.get_current_senators_xml()
+        assert rec.successes == {"senate:roster": 1}
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.endpoint_bucket == "senate:roster"
+        assert event.final_status == "resolved"
+        assert [a.status for a in event.attempts] == [503]
+
+    def test_terminal_503_emits_one_failed_event(self) -> None:
+        handler = _sequenced([httpx.Response(503) for _ in range(3)])
+        with (
+            _active_recorder() as rec,
+            _client(handler) as client,
+            pytest.raises(SenateXmlError, match="failed after 3 attempts"),
+        ):
+            client.get_current_senators_xml()
+        assert rec.successes == {}
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.final_status == "failed"
+        assert [a.status for a in event.attempts] == [503] * 3
+
+    def test_non_200_emits_failed_event(self) -> None:
+        with (
+            _active_recorder() as rec,
+            _client(lambda _r: httpx.Response(404)) as client,
+            pytest.raises(SenateXmlError, match="returned 404"),
+        ):
+            client.get_roll_call_xml(119, 1, 42)
+        assert rec.successes == {}
+        assert len(rec.events) == 1
+        assert rec.events[0].endpoint_bucket == "senate:detail"
+        assert rec.events[0].final_status == "failed"
+        assert rec.events[0].attempts[0].status == 404
+
+    def test_transport_error_then_success_records_transport_class(self) -> None:
+        calls = {"n": 0}
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise httpx.ConnectError("dns")
+            return _ok_xml()
+
+        with _active_recorder() as rec, _client(handler) as client:
+            client.get_current_senators_xml()
+        assert len(rec.events) == 1
+        attempt = rec.events[0].attempts[0]
+        assert attempt.status is None
+        assert attempt.transport_class == "ConnectError"
+
+
+class TestHtmlTrapRecording:
+    def test_html_as_200_records_failed_event_with_marker(self) -> None:
+        with (
+            _active_recorder() as rec,
+            _client(lambda _r: _ok_html()) as client,
+            pytest.raises(SenateXmlError, match="HTML response"),
+        ):
+            client.get_roll_call_xml(119, 1, 42)
+        # The HTML trap is not a success — no bucket bump, one failed event.
+        assert rec.successes == {}
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.endpoint_bucket == "senate:detail"
+        assert event.final_status == "failed"
+        attempt = event.attempts[-1]
+        assert attempt.status == 200
+        assert attempt.message == "html-not-xml"

--- a/tests/test_senate_xml_recording.py
+++ b/tests/test_senate_xml_recording.py
@@ -16,7 +16,7 @@ import httpx
 import pytest
 
 from concord.observability import Recorder, _recorder
-from concord.senate_xml import SenateClient, SenateXmlError
+from concord.senate_xml import _HTML_TRAP_MARKER, SenateClient, SenateXmlError
 
 #: Minimal well-formed XML that the roster/menu parsers accept (empty result).
 _XML_BODY = b"<doc></doc>"
@@ -153,4 +153,4 @@ class TestHtmlTrapRecording:
         assert event.final_status == "failed"
         attempt = event.attempts[-1]
         assert attempt.status == 200
-        assert attempt.message == "html-not-xml"
+        assert attempt.message == _HTML_TRAP_MARKER

--- a/tests/test_text_recording.py
+++ b/tests/test_text_recording.py
@@ -1,0 +1,164 @@
+"""text.py chokepoint recording — successful fetches bump ``text:article``,
+error outcomes emit Run Events with retry resolution, 403/429 throttle hits
+are recorded as errors, and the "no <pre>" structural failure is recorded as a
+failed event (ADR 0021). Retry *behavior* is covered by test_text.py and
+unchanged.
+
+All tests run inside a manually-installed Recorder contextvar rather than a
+full ``scrape_run`` so they assert against in-memory state without touching
+SQLite.
+"""
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from concord.observability import Recorder, _recorder
+from concord.text import AdaptiveThrottle, TextFetchError, fetch_text
+
+SAMPLE_URL = (
+    "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgD551-6.htm"
+)
+
+
+@contextmanager
+def _active_recorder() -> Iterator[Recorder]:
+    rec = Recorder(entity="proceedings", command="scrape proceedings", started_at=datetime.now(UTC))
+    token = _recorder.set(rec)
+    try:
+        yield rec
+    finally:
+        _recorder.reset(token)
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _sequenced(items: list[httpx.Response]) -> Callable[[httpx.Request], httpx.Response]:
+    iterator = iter(items)
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return next(iterator)
+
+    return handler
+
+
+def _ok(body: str = "<pre>hello world</pre>") -> httpx.Response:
+    return httpx.Response(200, text=body, headers={"content-type": "text/html"})
+
+
+def _throttle() -> AdaptiveThrottle:
+    # Inject a no-op sleep so throttle penalties don't burn real wall time.
+    return AdaptiveThrottle(sleep=lambda _s: None)
+
+
+class TestSuccessRecording:
+    def test_clean_fetch_bumps_bucket_and_emits_no_event(self) -> None:
+        with _active_recorder() as rec, _client(lambda _r: _ok()) as client:
+            fetch_text(SAMPLE_URL, client, throttle=_throttle())
+        assert rec.successes == {"text:article": 1}
+        assert rec.events == []
+
+    def test_no_recorder_is_a_noop(self) -> None:
+        with _client(lambda _r: _ok()) as client:
+            text = fetch_text(SAMPLE_URL, client, throttle=_throttle())
+        assert text == "hello world"
+
+
+class TestErrorRecording:
+    def test_403_then_200_records_resolved_event_with_403_attempt(self) -> None:
+        handler = _sequenced([httpx.Response(403), _ok()])
+        with _active_recorder() as rec, _client(handler) as client:
+            fetch_text(SAMPLE_URL, client, throttle=_throttle())
+        assert rec.successes == {"text:article": 1}
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.endpoint_bucket == "text:article"
+        assert event.final_status == "resolved"
+        assert [a.status for a in event.attempts] == [403]
+
+    def test_429_then_200_records_resolved_event_with_429_attempt(self) -> None:
+        handler = _sequenced([httpx.Response(429), _ok()])
+        with _active_recorder() as rec, _client(handler) as client:
+            fetch_text(SAMPLE_URL, client, throttle=_throttle())
+        assert len(rec.events) == 1
+        assert rec.events[0].final_status == "resolved"
+        assert [a.status for a in rec.events[0].attempts] == [429]
+
+    def test_503_then_200_emits_one_resolved_event(self) -> None:
+        handler = _sequenced([httpx.Response(503), _ok()])
+        with _active_recorder() as rec, _client(handler) as client:
+            fetch_text(SAMPLE_URL, client, throttle=_throttle(), sleep=lambda _s: None)
+        assert rec.successes == {"text:article": 1}
+        assert len(rec.events) == 1
+        assert rec.events[0].final_status == "resolved"
+        assert [a.status for a in rec.events[0].attempts] == [503]
+
+    def test_terminal_503_emits_one_failed_event(self) -> None:
+        handler = _sequenced([httpx.Response(503) for _ in range(6)])
+        with (
+            _active_recorder() as rec,
+            _client(handler) as client,
+            pytest.raises(TextFetchError, match="gave up after 5 attempts"),
+        ):
+            fetch_text(SAMPLE_URL, client, throttle=_throttle(), sleep=lambda _s: None)
+        assert rec.successes == {}
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.final_status == "failed"
+        # Six attempts: the initial try + five retries, all 503.
+        assert [a.status for a in event.attempts] == [503] * 6
+
+    def test_non_retryable_4xx_emits_failed_event(self) -> None:
+        with (
+            _active_recorder() as rec,
+            _client(lambda _r: httpx.Response(404)) as client,
+            pytest.raises(TextFetchError),
+        ):
+            fetch_text(SAMPLE_URL, client, throttle=_throttle())
+        assert rec.successes == {}
+        assert len(rec.events) == 1
+        assert rec.events[0].final_status == "failed"
+        assert rec.events[0].attempts[0].status == 404
+
+    def test_transport_error_then_success_records_transport_class(self) -> None:
+        calls = {"n": 0}
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise httpx.ConnectError("dns")
+            return _ok()
+
+        with _active_recorder() as rec, _client(handler) as client:
+            fetch_text(SAMPLE_URL, client, throttle=_throttle(), sleep=lambda _s: None)
+        assert len(rec.events) == 1
+        attempt = rec.events[0].attempts[0]
+        assert attempt.status is None
+        assert attempt.transport_class == "ConnectError"
+
+
+class TestStructuralFailureRecording:
+    def test_no_pre_block_records_failed_event_after_a_counted_success(self) -> None:
+        # The HTTP fetch succeeds (counted as a success) but the body has no
+        # <pre> block — recorded as a separate failed event so "fetched but
+        # unparseable" is visible, not silently dropped.
+        body = "<html><body>nothing useful</body></html>"
+        with (
+            _active_recorder() as rec,
+            _client(lambda _r: _ok(body)) as client,
+            pytest.raises(TextFetchError, match="no <pre> content"),
+        ):
+            fetch_text(SAMPLE_URL, client, throttle=_throttle())
+        assert rec.successes == {"text:article": 1}
+        assert len(rec.events) == 1
+        event = rec.events[0]
+        assert event.endpoint_bucket == "text:article"
+        assert event.final_status == "failed"
+        attempt = event.attempts[0]
+        assert attempt.status is None
+        assert attempt.transport_class == "NoPreContent"

--- a/tests/test_text_recording.py
+++ b/tests/test_text_recording.py
@@ -17,7 +17,7 @@ import httpx
 import pytest
 
 from concord.observability import Recorder, _recorder
-from concord.text import AdaptiveThrottle, TextFetchError, fetch_text
+from concord.text import _NO_PRE_MARKER, AdaptiveThrottle, TextFetchError, fetch_text
 
 SAMPLE_URL = (
     "https://www.congress.gov/119/crec/2026/05/22/172/88/modified/CREC-2026-05-22-pt1-PgD551-6.htm"
@@ -161,4 +161,4 @@ class TestStructuralFailureRecording:
         assert event.final_status == "failed"
         attempt = event.attempts[0]
         assert attempt.status is None
-        assert attempt.transport_class == "NoPreContent"
+        assert attempt.transport_class == _NO_PRE_MARKER


### PR DESCRIPTION
Closes #105. PR 2 of 2 — extends the Scrape Run ledger (ADR 0021) built in #109 to the two remaining HTTP clients and the three remaining Stage-0 scrapers, so **every** scrape across every source produces a complete, correctly-bucketed Scrape Run.

## What changed

**Route table** (`observability.py`)
- `text:` entry — congress.gov formatted-text article URLs (`…/modified/CREC-*.htm`) → `text:article`.
- `senate:` entries — `senate:menu` / `senate:detail` / `senate:roster`, keyed on the `MENU_URL`/`DETAIL_URL`/`ROSTER_URL` shapes.
- Both keep the established `*:unmatched` fallback + deduped-sample/WARNING behavior.

**`text.py:_get_with_retry`**
- Accumulates attempts across the retry loop and records bucketed successes + per-request error outcomes with retry resolution. Per ADR 0021, **403/429 throttle hits are recorded as errors** (retry behavior unchanged).
- `fetch_text` records the "no `<pre>` content" **structural failure** as a `failed` event (synthetic `NoPreContent` marker) after the HTTP-layer success — so "fetched but unparseable" is visible, not silently dropped.

**`senate_xml.py:_get_xml`**
- Same chokepoint treatment (transport / 5xx / non-200 terminal).
- The **HTML-as-200 trap** is recorded as a `failed` event with an `html-not-xml` marker (status 200).
- Its `observability` import is lazy / `TYPE_CHECKING` to break a `models ↔ senate_xml ↔ observability` import cycle (senate_xml is pulled into the models graph; `observability` stays a leaf).

**Scrapers wrapped in `scrape_run(...)`** — Proceedings, Members, Votes
- Each Stage-0 helper (used by both `scrape <entity>` and `run <entity>`) now wraps its body in `scrape_run(entity=…, command=…)`, threading a `--db` ledger path.
- Clients are constructed *before* the scrape seam so a pure config error (missing key) mints no run — matching the Bills wiring.
- A Proceedings run carries both `api:*` and `text:*` buckets; a Votes run carries `api:*` and/or `senate:*` depending on `--chambers`.

## Tests
- Route-shape tests for `text:`/`senate:` URLs.
- `httpx.MockTransport` recording tests for both clients: clean / resolved-on-retry / terminal-failed / structural-failure / html-trap.
- End-to-end integration test: a flushed `scrape_run` carries the expected cross-source buckets with **no** `*:unmatched`.

## Verification
`uv run ruff check`, `uv run ruff format --check`, `uv run mypy src`, `uv run pytest` all green — **806 passed**. PR 1's tests pass unchanged; `observability.py`'s public behavior is untouched (additive route-table extension only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)