### PR TITLE
Untangle concord.models from the senate_xml client (layering fix)

### DIFF
--- a/docs/plans/untangle-models-senate-xml.md
+++ b/docs/plans/untangle-models-senate-xml.md
@@ -1,0 +1,117 @@
+# Untangle `concord.models` from the `senate_xml` client (layering fix)
+
+> Give the Senate-vote parse path a dependency-free error type in a new `concord/errors.py` leaf, so the data layer (`concord.models.votes`) stops importing a network client (`concord.senate_xml`) — removing the lazy-import workaround that PR #122 used to paper over the cycle.
+
+## Source
+
+- GitHub issue: [#123 — Untangle concord.models from the senate_xml client (layering + façade follow-up)](https://github.com/johnmarcampbell/concord/issues/123)
+- Originating PR: [#122 — fan out the Scrape Run ledger](https://github.com/johnmarcampbell/concord/pull/122) (introduced the lazy-import workaround this plan removes)
+- This is **plan 1 of 2** for issue #123. Plan 2 (the codebase-wide import-convention sweep) is [internal-import-convention.md](internal-import-convention.md) and is **sequenced after** this one.
+
+## Context
+
+PR #122 instrumented `senate_xml.py` to record into the observability ledger (ADR 0021), which made it import `concord.observability` → `concord.models`. But `concord.models.votes` already imported `concord.senate_xml` to borrow the `SenateXmlError` exception type inside `SenateVoteDetail.from_senate_xml`. That closed the cycle `models → votes → senate_xml → observability → models`.
+
+#122 unblocked itself by **lazy-importing** `SenateXmlError` inside the method ([votes.py:368](../../src/concord/models/votes.py)) plus a regression guard in [tests/test_import_cycles.py](../../tests/test_import_cycles.py). That works, but it papers over the real smell: a **layering inversion**. `concord.models.votes` is a domain/data-layer module; `concord.senate_xml` is an HTTP client. The data layer should not depend on a network client — and it only does so to reuse one exception class. ADR 0018 deliberately put the senate.gov XML parsing *on the model* (Rule 2 — the `from_<source>` factory owns the parse in one place); the parser borrowed the client's error class instead of owning a dependency-free one.
+
+This plan fixes that edge structurally. It is the higher-payoff, smaller half of issue #123. The façade question (issue smell #2) is handled separately in plan 2.
+
+Domain terms (Vote, `SenateVoteDetail`, wire-shape/domain model, snapshot envelope) are defined in [CONTEXT.md](../../CONTEXT.md) and [ADR 0018](../adr/0018-pydantic-at-the-load-boundary.md).
+
+## Goals
+
+1. `concord.models` and all its submodules import **no** network client (`api`, `text`, `senate_xml`) at module load time.
+2. `SenateXmlError` lives in a dependency-free leaf module that both the client and the model can import top-level.
+3. The lazy `from concord.senate_xml import SenateXmlError` inside `SenateVoteDetail.from_senate_xml` reverts to a clean top-level import; the `# noqa: PLC0415` is gone.
+4. `tests/test_import_cycles.py` still passes — and the workaround it was guarding no longer exists.
+5. `ruff` / `mypy src` / `pytest` all green.
+
+## Non-goals
+
+1. **Touching the `concord.models/__init__.py` façade or rewriting any `from concord.models import …` call sites.** That is plan 2 ([internal-import-convention.md](internal-import-convention.md)). This plan changes the *definition site* of one exception, not the import convention.
+2. **Renaming `SenateXmlError`.** The client still raises it for network/HTTP/HTML-trap failures and the model raises it for XML-parse failures; one shared type for "something went wrong getting or parsing Senate XML" is intentional. Keep the name.
+3. **Flipping ruff's relative-import setting** or autofixing relative imports. Also plan 2.
+4. **Any behaviour change.** Same exceptions raised at the same call sites; this is a pure move + import-path change.
+
+## Relevant prior decisions
+
+- [ADR 0018 — Pydantic validation at the load boundary](../adr/0018-pydantic-at-the-load-boundary.md). Rule 2 collocates `SenateVoteDetail.from_senate_xml` on the model; this plan keeps that, it only changes which module the error class comes from. The issue flags ADR 0018 as the "model/error ownership" anchor — no amendment is required (the model still owns the parse; the error simply moves to a neutral leaf), but note it in the PR description.
+- [ADR 0021 — Scrape-run observability](../adr/0021-scrape-run-observability.md). The ledger edges (`senate_xml → observability → models`) are the second half of the cycle and are correct; this plan does not touch them.
+- [ADR 0014 — Publish to PyPI as `congress-concord`, CLI-first](../adr/0014-publish-to-pypi-cli-first.md). Python imports are best-effort, not the stable contract — so repointing an internal import path (incl. in tests) needs no deprecation dance.
+
+No new ADRs for this plan.
+
+## Relevant files and code
+
+- `src/concord/senate_xml.py:71` — current definition site of `class SenateXmlError(Exception)`. Also raises it at lines 175/187/195/204/211/337, and lists it in `__all__` (line 347).
+- [src/concord/models/votes.py:344](../../src/concord/models/votes.py) — `SenateVoteDetail.from_senate_xml`; the lazy import is at line 368 (`# noqa: PLC0415`), the docstring reference at lines 359–361, and the raises at 373/382.
+- `src/concord/models/_common.py` — dependency-free model leaf (stdlib + pydantic only). **Considered and rejected** as the error's home (see Approach).
+- [tests/test_import_cycles.py](../../tests/test_import_cycles.py) — the regression guard; must still pass.
+- `tests/test_scraper_votes.py:21` — `from concord.senate_xml import SenateClient, SenateXmlError`.
+- `tests/test_senate_xml_recording.py:19` — `from concord.senate_xml import _HTML_TRAP_MARKER, SenateClient, SenateXmlError`.
+- `src/concord/errors.py` — **new file** this plan creates.
+
+## Approach
+
+Create a new top-level leaf module `concord/errors.py` holding `SenateXmlError`. Both `concord.senate_xml` (which raises it for network/HTTP/HTML-trap failures) and `concord.models.votes` (which raises it for XML-parse failures) import it from there. The `models → senate_xml` edge disappears structurally, and the lazy import reverts to a normal top-level one.
+
+**Why `concord/errors.py` and not `concord/models/_common.py`?** Both are dependency-free leaves, and the issue offers either. But `_common.py` holds model utility *types* (`Chamber`, `SessionNumber`, `Snapshot`) — a network/parse error is out of place there. More importantly, putting the error under the `models` package would force the network client to do `from concord.models._common import SenateXmlError` — a client reaching into the domain layer's private module for its own exception. That just inverts the smell in the other direction. A neutral top-level `concord/errors.py` is a foundational leaf that *both* layers sit above, importing downward. It's also the obvious home for any future shared exception.
+
+**Why keep one shared `SenateXmlError` rather than give the model its own type?** The Senate-vote loader fetches via the client (raises `SenateXmlError` on HTTP/HTML failures) and parses via the model (raises `SenateXmlError` on malformed XML). A single exception class lets the loader's `except SenateXmlError` cover "anything wrong with a Senate vote from senate.gov" in one clause. Splitting into two types would be churn for negative value.
+
+**Cycle check after the change.** `concord.errors` imports nothing but `Exception`. So `models.votes → errors` and `senate_xml → errors` both terminate at a leaf. The old cycle is cut at the `votes → senate_xml` edge. The `senate_xml → observability → models` edges remain (correct and unchanged).
+
+```mermaid
+graph LR
+  subgraph before
+    M1[models.votes] -->|borrows SenateXmlError| SX1[senate_xml]
+    SX1 --> OB1[observability] --> M1
+  end
+  subgraph after
+    M2[models.votes] --> E[errors leaf]
+    SX2[senate_xml] --> E
+    SX2 --> OB2[observability] --> M2
+  end
+```
+
+## Step-by-step plan
+
+1. **Create the leaf module.** Add `src/concord/errors.py` containing `class SenateXmlError(Exception)` — move the class body (and its docstring) verbatim from `senate_xml.py:71`. Give the module a short docstring: dependency-free home for cross-layer exceptions; importing it must pull in nothing but the stdlib. Add `__all__ = ["SenateXmlError"]`. Verify the file imports cleanly: `uv run python -c "import concord.errors"`.
+
+2. **Repoint the client.** In `src/concord/senate_xml.py`: delete the `class SenateXmlError` definition (line 71), add `from concord.errors import SenateXmlError` to the top-level imports, and remove `"SenateXmlError"` from the module's `__all__` (line 347). The six `raise SenateXmlError(...)` sites are unchanged. Verify: `uv run python -c "import concord.senate_xml"`.
+
+3. **Revert the lazy import in the model.** In `src/concord/models/votes.py`, delete the lazy import block at line 368 (including the `# noqa: PLC0415` and its explanatory comment, lines ~363–368) and add `from concord.errors import SenateXmlError` to the top-level imports. Update the `from_senate_xml` docstring reference (lines ~359–361) from `concord.senate_xml.SenateXmlError` to `concord.errors.SenateXmlError`. The two `raise SenateXmlError(...)` sites (lines 373, 382) are unchanged.
+
+4. **Repoint the two test imports.** In `tests/test_scraper_votes.py:21` and `tests/test_senate_xml_recording.py:19`, split the import so `SenateXmlError` comes from `concord.errors` while `SenateClient` / `_HTML_TRAP_MARKER` stay on `concord.senate_xml`. E.g. `from concord.senate_xml import SenateClient` + `from concord.errors import SenateXmlError`.
+
+5. **Verify no other models submodule imports a client.** Run `grep -rEn "import concord\.(api|text|senate_xml)|from concord\.(api|text|senate_xml)" src/concord/models/` and confirm it returns nothing. (Goal 1.)
+
+6. **Run the gates.** `uv run ruff check && uv run ruff format --check && uv run mypy src && uv run pytest` — all green. Confirm `tests/test_import_cycles.py` passes specifically with each module as a first import.
+
+## Demo seed data
+
+Not applicable — pure refactor, no new tables, columns, entities, or API capabilities.
+
+## Testing strategy
+
+- **Regression — import cycles:** `tests/test_import_cycles.py` must stay green; it imports each of `senate_xml`, `observability`, `models`, `text`, `api` first in a clean subprocess. This is the load-bearing check.
+- **Regression — Senate parse path:** `tests/test_scraper_votes.py` and `tests/test_senate_xml_recording.py` exercise `from_senate_xml` and the client's error raises; they must pass with the repointed import. Confirm a malformed-XML case still raises `SenateXmlError` (now from `concord.errors`).
+- **No new tests required** — behaviour is unchanged. Optionally add a one-line assertion that `concord.errors.SenateXmlError is concord.senate_xml.SenateXmlError` to pin the shared-identity contract, but it's not necessary.
+- **Manual:** none.
+
+## Acceptance criteria
+
+- [ ] `src/concord/errors.py` exists, defines `SenateXmlError`, and imports nothing outside the stdlib.
+- [ ] `grep` confirms no module under `src/concord/models/` imports `concord.api`, `concord.text`, or `concord.senate_xml`.
+- [ ] `votes.py`'s `from_senate_xml` has a top-level `from concord.errors import SenateXmlError` and no `# noqa: PLC0415`.
+- [ ] `senate_xml.py` raises the imported `SenateXmlError`; the class is no longer defined or `__all__`-exported there.
+- [ ] `tests/test_import_cycles.py` passes; the lazy-import workaround it guarded is gone.
+- [ ] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy src`, and `uv run pytest` are all green.
+
+## Open questions
+
+None — all design decisions resolved during grilling (leaf location, shared-vs-split error type, naming all decided above).
+
+## Out-of-band work
+
+- **Blocks plan 2.** [internal-import-convention.md](internal-import-convention.md) (the façade sweep) should land **after** this PR. Both plans touch `senate_xml.py` (this one changes the `SenateXmlError` import; plan 2 autofixes `senate_xml.py`'s relative imports and rewrites `from .models import Attempt`). Different lines, but sequencing this first avoids a rebase tangle and lets plan 2's new ADR reference the resolved layering rather than an open problem.

--- a/src/concord/errors.py
+++ b/src/concord/errors.py
@@ -1,0 +1,18 @@
+"""Dependency-free home for exceptions shared across Concord layers.
+
+This module must import nothing outside the standard library so that both
+the network clients (e.g. :mod:`concord.senate_xml`) and the domain models
+(e.g. :mod:`concord.models.votes`) can import from it without re-creating
+the ``models -> senate_xml`` import cycle that issue #123 untangles. See
+ADR 0018 for why the senate.gov XML parse lives on the model.
+"""
+
+
+class SenateXmlError(Exception):
+    """Raised on a senate.gov LIS failure.
+
+    Two call paths raise it: the client (:mod:`concord.senate_xml`) on a
+    non-XML response or transport error, and the model
+    (:meth:`concord.models.votes.SenateVoteDetail.from_senate_xml`) on
+    malformed or incomplete detail XML.
+    """

--- a/src/concord/models/votes.py
+++ b/src/concord/models/votes.py
@@ -27,6 +27,7 @@ from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, ConfigDict
 
+from concord.errors import SenateXmlError
 from concord.models._common import Chamber, SessionNumber, normalize_chamber
 from concord.models.bills import bill_id_from_components
 
@@ -356,17 +357,10 @@ class SenateVoteDetail(BaseModel):
         ``<en_bloc><matter>`` breakdown is preserved in the raw XML payload
         but not surfaced on the SQLite row in this phase.
 
-        Raises :exc:`concord.senate_xml.SenateXmlError` for malformed XML
+        Raises :exc:`concord.errors.SenateXmlError` for malformed XML
         or missing required date fields; raises ``pydantic.ValidationError``
         for any field that doesn't match the model's schema.
         """
-        # Lazy import: ``concord.senate_xml`` now records into the observability
-        # ledger, which imports ``concord.models`` — so a top-level import here
-        # would close a models<->senate_xml cycle. ``SenateXmlError`` lives with
-        # its client (project convention), and it's only needed inside this one
-        # parse path, so importing it lazily keeps senate_xml a clean dependency.
-        from concord.senate_xml import SenateXmlError  # noqa: PLC0415 - breaks an import cycle
-
         try:
             root = ET.fromstring(xml_bytes)  # noqa: S314 — senate.gov XML is trusted (no DTD, no external entities)
         except ET.ParseError as exc:

--- a/src/concord/senate_xml.py
+++ b/src/concord/senate_xml.py
@@ -30,6 +30,8 @@ from types import TracebackType
 
 import httpx
 
+from concord.errors import SenateXmlError
+
 from . import __version__
 from .models import Attempt
 from .observability import Recorder, active_recorder
@@ -66,10 +68,6 @@ DETAIL_REQUEST_SLEEP_SECONDS = 0.1
 HTTP_OK = 200
 HTTP_SERVER_ERROR_MIN = 500
 HTTP_SERVER_ERROR_MAX = 600  # exclusive upper bound
-
-
-class SenateXmlError(Exception):
-    """Raised when senate.gov returns a non-XML response or a transport error."""
 
 
 class SenateClient:
@@ -344,7 +342,6 @@ __all__ = [
     "ROSTER_URL",
     "USER_AGENT",
     "SenateClient",
-    "SenateXmlError",
     "parse_senate_roster",
     "parse_vote_menu",
 ]

--- a/tests/test_scraper_votes.py
+++ b/tests/test_scraper_votes.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 from concord.api import Client
+from concord.errors import SenateXmlError
 from concord.scraper.votes import (
     HOUSE_VOTE_POSITIONS_JSONL_NAME,
     HOUSE_VOTES_JSONL_NAME,
@@ -18,7 +19,7 @@ from concord.scraper.votes import (
     scrape_house,
     scrape_senate,
 )
-from concord.senate_xml import SenateClient, SenateXmlError
+from concord.senate_xml import SenateClient
 
 FIXED_FETCHED_AT = datetime(2026, 5, 26, 14, 2, 11, tzinfo=UTC)
 VOTES_DIR = Path(__file__).parent / "fixtures" / "api" / "votes"

--- a/tests/test_senate_xml_recording.py
+++ b/tests/test_senate_xml_recording.py
@@ -15,8 +15,9 @@ from datetime import UTC, datetime
 import httpx
 import pytest
 
+from concord.errors import SenateXmlError
 from concord.observability import Recorder, _recorder
-from concord.senate_xml import _HTML_TRAP_MARKER, SenateClient, SenateXmlError
+from concord.senate_xml import _HTML_TRAP_MARKER, SenateClient
 
 #: Minimal well-formed XML that the roster/menu parsers accept (empty result).
 _XML_BODY = b"<doc></doc>"


### PR DESCRIPTION
## What

Move `SenateXmlError` to a new dependency-free `concord/errors.py` leaf so the data layer (`concord.models.votes`) stops importing the `senate_xml` network client.

## Why

`concord.models.votes` borrowed `SenateXmlError` from `concord.senate_xml` purely to raise it inside `SenateVoteDetail.from_senate_xml` — a layering inversion (the data layer depending on an HTTP client). Once #122 wired `senate_xml` into the observability ledger, that edge closed an import cycle `models → votes → senate_xml → observability → models`, which #122 worked around with a lazy import plus a regression guard in `tests/test_import_cycles.py`.

This removes the root cause: a neutral top-level `concord/errors.py` leaf that both the client and the model import. The `models → senate_xml` edge disappears structurally and the lazy import reverts to a clean top-level one. The error keeps one shared identity — raised by the client (network/HTML-trap failures) and by the model (XML-parse failures) — so the loader's `except SenateXmlError` still covers both.

(Chose a neutral top-level leaf over `models/_common.py`: putting a *client* error under the *models* package would just invert the smell in the other direction.)

## Scope

This is **plan 1 of 2** for #123 — smell #1, the layering inversion. It satisfies the issue's acceptance criteria on its own. The façade cleanup (smell #2 — drop the re-export façades, establish a submodule-direct/absolute-only import convention + new ADR) is a separate follow-up PR; see `docs/plans/internal-import-convention.md`.

Part of #123 (intentionally **not** "Closes" — the follow-up PR finishes the issue).

## Changes

- New `src/concord/errors.py` defining `SenateXmlError` (stdlib-only leaf).
- `senate_xml.py` imports the error instead of defining it; removed from its `__all__`.
- `models/votes.py`: top-level `from concord.errors import SenateXmlError`; the lazy-import workaround + `# noqa: PLC0415` deleted; docstring reference updated.
- `tests/test_scraper_votes.py`, `tests/test_senate_xml_recording.py`: repointed to import `SenateXmlError` from `concord.errors`.
- Plan doc: `docs/plans/untangle-models-senate-xml.md`.

Net diff is **negative** in the source (+8/−15 across the four edited files) — the fix is smaller than the workaround it removes.

## Verification

- `ruff check`, `ruff format --check`, `mypy src`, `pytest` (**811 passed**) all green.
- `tests/test_import_cycles.py` passes; each cycle module imports cleanly as a first import, and the lazy-import workaround it guarded is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
