### PR TITLE
chore(models): drop __all__ from every models module

### DIFF
--- a/src/concord/models/_common.py
+++ b/src/concord/models/_common.py
@@ -54,6 +54,3 @@ class Snapshot[PayloadT](BaseModel):
     fetched_at: datetime
     key: dict[str, str | int]
     payload: PayloadT
-
-
-__all__ = ["Chamber", "SessionNumber", "Snapshot", "normalize_chamber"]

--- a/src/concord/models/bills.py
+++ b/src/concord/models/bills.py
@@ -229,14 +229,3 @@ class BillSummary(BaseModel):
             action_desc=payload["actionDesc"],
             summary_text=text,
         )
-
-
-__all__ = [
-    "BillAction",
-    "BillCosponsor",
-    "BillDetail",
-    "BillSubject",
-    "BillSummary",
-    "BillTitle",
-    "bill_id_from_components",
-]

--- a/src/concord/models/members.py
+++ b/src/concord/models/members.py
@@ -242,6 +242,3 @@ def _term_item_for_congress(items: list[dict[str, Any]], congress: int) -> dict[
             continue
         match = item
     return match
-
-
-__all__ = ["Member", "Term", "normalize_state"]

--- a/src/concord/models/proceedings.py
+++ b/src/concord/models/proceedings.py
@@ -209,6 +209,3 @@ class Proceeding(BaseModel):
             text=text,
             fetched_at=fetched_at,
         )
-
-
-__all__ = ["Article", "Issue", "Proceeding", "parse_granule_id"]

--- a/src/concord/models/runs.py
+++ b/src/concord/models/runs.py
@@ -78,6 +78,3 @@ class RunRecord(BaseModel):
     unmatched_sample: list[str]
     error_event_count: int
     events: list[RunEvent]
-
-
-__all__ = ["Attempt", "RunEvent", "RunRecord"]

--- a/src/concord/models/validation.py
+++ b/src/concord/models/validation.py
@@ -52,6 +52,3 @@ class ValidationFailure(BaseModel):
             field_path=field_path,
             payload=payload,
         )
-
-
-__all__ = ["ValidationFailure"]

--- a/src/concord/models/votes.py
+++ b/src/concord/models/votes.py
@@ -622,17 +622,3 @@ def _extract_vote_party_totals(payload: dict[str, Any]) -> list[dict[str, Any]]:
 def _is_election_vote(party_totals: list[dict[str, Any]]) -> bool:
     """Detect election-vote shape: any party-total entry carries `candidate`."""
     return any("candidate" in entry for entry in party_totals)
-
-
-__all__ = [
-    "HouseVoteMembers",
-    "SenateVoteDetail",
-    "SenateVotePosition",
-    "Vote",
-    "VoteKind",
-    "VotePosition",
-    "VoteThreshold",
-    "amendment_id_from_components",
-    "parse_vote_threshold",
-    "vote_id_from_components",
-]


### PR DESCRIPTION
Removes `__all__` from every module in `src/concord/models/` — `_common.py`, `bills.py`, `members.py`, `proceedings.py`, `runs.py`, `validation.py`, `votes.py`.

## Why

`__all__` only controls `from module import *`. This codebase never does wildcard imports — absolute, submodule-direct imports are enforced ([#125](https://github.com/johnmarcampbell/concord/pull/125)) — so on these modules `__all__` was an unmaintained re-statement of the public names with **no behavioral effect**. It's the kind of boilerplate that drifts out of sync with the actual definitions and earns its keep nowhere.

This started as a one-line cleanup of a pointless `__all__` I'd added to a private helper; auditing the convention showed `models/` was the only package applying it (7/7 modules), so rather than leave one outlier we drop it across the package.

## Safety

Behavior-neutral, verified before removing:
- `grep` for `from concord.models… import *` → none anywhere in `src/` or `tests/`.
- No test asserts on any module's `__all__` contents.
- Every removed entry was a locally-defined name used internally, so no import becomes unused (ruff clean — no F401).

## Testing

`ruff format --check && ruff check && mypy src && pytest` — all green, 832 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
