### PR TITLE
Tighten NOT NULL on ten derived SQLite columns (#90)

### DIFF
--- a/docs/adr/0024-constraint-tightening-on-rebuildable-mirror-columns.md
+++ b/docs/adr/0024-constraint-tightening-on-rebuildable-mirror-columns.md
@@ -41,13 +41,33 @@ rebuildable — will reasonably ask "why bother?"
 ## Decision
 
 **Tighten via a guarded table-rebuild migration, not a bare `_BASE_SCHEMA` edit.**
-We converge existing DBs so `user_version` stays an honest identity of the schema,
-upholding ADR 0017 rather than carving an exception into it. Concretely, issue #90
-edits `_BASE_SCHEMA` (the head snapshot) *and* adds three append-only migrations —
-`m005` (`member_terms`), `m006` (the three `bill_*` child tables), `m007`
-(`vote_positions`) — bumping `_HEAD` 4 → 7. Three module-local entries preserve the
-"each domain module owns its tables' migrations" convention; all delegate to one
-shared helper, `concord.storage._ddl.rebuild_table_add_not_null`.
+We converge existing DBs so `user_version` stays an honest identity of the schema.
+Concretely, issue #90 edits `_BASE_SCHEMA` (the head snapshot) *and* adds three
+append-only migrations — `m005` (`member_terms`), `m006` (the three `bill_*` child
+tables), `m007` (`vote_positions`) — bumping `_HEAD` 4 → 7. Three module-local
+entries preserve the "each domain module owns its tables' migrations" convention;
+all delegate to one shared helper, `concord.storage._ddl.rebuild_table_add_not_null`.
+
+**Why convergence is worth it here — and why it's a judgment, not a commandment.**
+The honest case for converging rather than a bare `_BASE_SCHEMA` edit is *not* that
+`user_version` honesty is inviolable. This `NOT NULL` is defense-in-depth over a
+contract the post-#89 models already enforce: the ten fields are non-optional `str`,
+so Pydantic validation prevents a NULL from ever reaching these columns on a normal
+`concord load`. The cross-install divergence a bare edit would create is therefore
+latent — a nullable-but-NULL-free column reads and writes identically to a `NOT NULL`
+one, and nothing in the codebase can write a violating row. (`user_version` is itself
+only a *fingerprint* identity, not byte-identical-schema: ADR 0017 drops `cid` and the
+fingerprint is blind to CHECK/FK. We're protecting a fingerprint this change happens
+to be visible to, not a pristine invariant.) We converge for two concrete reasons:
+(1) `rebuild_table_add_not_null` is reusable infrastructure for the SQLite gap
+(`ALTER COLUMN … SET NOT NULL`), and constraint-tightening is recurring here — PR #89
+was a ten-field audit, and this PR's own per-field policy anticipates more — so the
+helper amortizes across future tightenings; (2) it keeps the just-established ADR 0017
+precedent intact at a maintenance cost we judge affordable. This is a cost-benefit
+call, and it is reversible: if the rebuild helper stops paying rent (e.g. the derived
+schema effectively freezes), tightening via a bare base edit plus a one-paragraph ADR
+— existing DBs reconverge on the next full load per ADR 0002 — is a legitimate future
+position, not a violation of this one.
 
 The pattern for any future constraint-tightening on a rebuildable mirror column is:
 
@@ -111,11 +131,12 @@ prior failed, un-versioned attempt.
 ## Rejected: bare `_BASE_SCHEMA` edit, lean on ADR 0002
 
 Edit the DDL, add no migration, let the one wild demo DB get rebuilt from JSONL. The
-schema-equivalence test would even stay green (both sides run the edited base).
-Rejected because it reintroduces the silent fresh-vs-migrated divergence at equal
-`user_version` that ADR 0017 was created to eliminate — trading a one-time rebuild
-cost for a standing correctness gap. Viable for a throwaway store; not worth the
-erosion of the versioning invariant now that one exists.
+schema-equivalence test would even stay green (both sides run the edited base). The
+divergence it reintroduces at equal `user_version` is latent rather than dangerous
+(see the Decision — the model contract already prevents a violating row), so this is
+a defensible position, not a wrong one. Not chosen here because converging amortizes
+the reusable rebuild helper and keeps the fresh ADR 0017 precedent intact at a cost we
+judge affordable — but it remains the right call the day that cost stops paying rent.
 
 ## Rejected: `writable_schema` hack to rewrite the stored DDL in place
 

--- a/docs/adr/0024-constraint-tightening-on-rebuildable-mirror-columns.md
+++ b/docs/adr/0024-constraint-tightening-on-rebuildable-mirror-columns.md
@@ -1,0 +1,126 @@
+# 0024 — Constraint-tightening on rebuildable mirror columns
+
+**Status**: Accepted, 2026-06-08.
+
+## Context
+
+[PR #89](https://github.com/johnmarcampbell/concord/pull/89) tightened ten Pydantic
+model fields from `T | None` to `T` after auditing the API fixtures — `Term.party
+/ start_date / end_date`, `BillCosponsor.sponsorship_date`, `BillAction.action_code
+/ source_system`, `BillSummary.action_date / action_desc`, `VotePosition.vote_party
+/ vote_state`. [Issue #90](https://github.com/johnmarcampbell/concord/issues/90)
+is the follow-up that brings the corresponding SQLite mirror columns into
+agreement: declare them `NOT NULL`.
+
+The issue text proposed *"a straight schema change — per [ADR 0002](0002-jsonl-as-canonical-raw-store.md)
+there's no migration story, SQLite is rebuildable from JSONL."* But the issue was
+filed one day after [ADR 0017](0017-sqlite-schema-versioning.md) landed the
+`PRAGMA user_version` migration runner, which changed the calculus. Under ADR 0017:
+
+- `_BASE_SCHEMA` is the *head snapshot*; fresh DBs get the current shape from it.
+- Existing on-disk DBs only converge through migrations, because `CREATE TABLE IF
+  NOT EXISTS` no-ops against a pre-existing table. A bare `_BASE_SCHEMA` edit would
+  leave a live DB nullable while a fresh install is `NOT NULL` — *both reporting
+  the same `user_version`*. That silent divergence is exactly what ADR 0017 exists
+  to prevent.
+
+So the question issue #90 forces is: lean on ADR 0002's rebuildability (edit the
+DDL, let the one wild demo DB get nuked-and-rebuilt), or honor ADR 0017's
+convergence guarantee with a real migration? Two facts make the second non-trivial:
+
+1. **SQLite has no `ALTER COLUMN … SET NOT NULL`.** Tightening an existing column
+   requires the 12-step table rebuild: create a new table carrying the constraint,
+   copy the rows, drop the original, rename the copy back, recreate indexes.
+2. **A rebuild must decide what to do with a legacy row that holds a `NULL`** in a
+   now-`NOT NULL` column — it would violate the constraint on copy.
+
+This ADR records the choices, because a future reader who sees a full table-rebuild
+migration added merely to tighten a constraint — when ADR 0002 says the store is
+rebuildable — will reasonably ask "why bother?"
+
+## Decision
+
+**Tighten via a guarded table-rebuild migration, not a bare `_BASE_SCHEMA` edit.**
+We converge existing DBs so `user_version` stays an honest identity of the schema,
+upholding ADR 0017 rather than carving an exception into it. Concretely, issue #90
+edits `_BASE_SCHEMA` (the head snapshot) *and* adds three append-only migrations —
+`m005` (`member_terms`), `m006` (the three `bill_*` child tables), `m007`
+(`vote_positions`) — bumping `_HEAD` 4 → 7. Three module-local entries preserve the
+"each domain module owns its tables' migrations" convention; all delegate to one
+shared helper, `concord.storage._ddl.rebuild_table_add_not_null`.
+
+The pattern for any future constraint-tightening on a rebuildable mirror column is:
+
+**1. Drop rows that violate the new constraint; log the count.** The rebuild copies
+with `INSERT … SELECT … WHERE <every tightened col> IS NOT NULL`. A DB loaded under
+the strict post-#89 models has no such rows, so this only bites a DB loaded under
+the old nullable models; those dropped rows are derived state and reappear on the
+next `concord load` from JSONL (ADR 0002). Fail-loud was rejected — it bricks
+`concord serve` against a legacy DB and defeats the convergence goal. Coalesce-to-`''`
+was rejected — it fabricates empty data the strict model silently accepts as a valid
+(empty) `str`, masking the very contract violation #89 set out to surface.
+
+**2. Inject `NOT NULL` into the *live* DDL read from `sqlite_master`, never
+hand-write the new table.** The schema-equivalence fingerprint (ADR 0017) compares
+`PRAGMA table_info` + `index_list`, which capture *neither* CHECK nor FK
+constraints. A hand-copied `CREATE TABLE` that accidentally dropped `member_terms`'s
+chamber CHECK or a `bill_*` foreign key would pass every fingerprint test. Reading
+the live statement and adding `NOT NULL` only to the named columns preserves CHECK /
+FK / DEFAULT / PRIMARY KEY by construction. A dedicated test additionally asserts the
+CHECK and FK *behaviour* survives, as a backstop against a bad string transform.
+
+**3. Guard on the precondition; rebuild only when a target column is still
+nullable.** The helper inspects `PRAGMA table_info` and returns early (a no-op) when
+every target column is already `NOT NULL`. On a fresh install — where `_BASE_SCHEMA`
+already declares the constraint — the migration does nothing, so the existing
+`test_base_schema_matches_replayed_migrations` passes trivially. The rebuild's
+structural correctness is pinned instead by a dedicated test that starts from a
+legacy nullable DB and asserts the converged schema fingerprint equals a fresh one.
+
+**Foreign keys stay ON through the rebuild — no toggle.** The 12-step recipe
+normally calls for `PRAGMA foreign_keys=OFF`, which is a no-op inside a transaction
+(and the runner wraps each migration in one). It is unnecessary here because none of
+the five tightened tables is a foreign-key *target*; their only FKs are outgoing and
+are re-checked against still-present parents during the copy. A leading `DROP TABLE
+IF EXISTS <tmp>` makes the helper retry-safe against an orphan temp table from a
+prior failed, un-versioned attempt.
+
+## Consequences
+
+**Trade-offs accepted:**
+
+- **A rebuild migration is heavier than a DDL edit.** Every existing DB drops and
+  recreates the affected tables once on upgrade. Accepted to keep `user_version` an
+  honest schema identity (ADR 0017) rather than relying on operators to rebuild.
+- **Row drops are silent except for a log line.** A legacy DB with real NULLs loses
+  those rows on migrate. Acceptable: the store is derived (ADR 0002) and the rows
+  return on the next load; a `WARNING` with the per-table count surfaces it.
+- **The `NOT NULL`-injection transform is a regex over the project's own DDL.** It
+  assumes unquoted identifiers and a `<name> <TYPE>` column shape, and raises if it
+  can't make exactly one substitution per column. Brittle in the abstract, but bounded
+  by the dedicated rebuild test and the fail-fast assertions.
+
+**Things this buys:**
+
+- Fresh and migrated installs converge on the same `(schema, user_version)` for a
+  constraint change, closing the gap ADR 0017's "What stays open" flagged between it
+  and ADR 0002.
+- A reusable `rebuild_table_add_not_null` helper and a documented pattern for the
+  next constraint-tightening, so it isn't re-derived from scratch.
+
+## Rejected: bare `_BASE_SCHEMA` edit, lean on ADR 0002
+
+Edit the DDL, add no migration, let the one wild demo DB get rebuilt from JSONL. The
+schema-equivalence test would even stay green (both sides run the edited base).
+Rejected because it reintroduces the silent fresh-vs-migrated divergence at equal
+`user_version` that ADR 0017 was created to eliminate — trading a one-time rebuild
+cost for a standing correctness gap. Viable for a throwaway store; not worth the
+erosion of the versioning invariant now that one exists.
+
+## Rejected: `writable_schema` hack to rewrite the stored DDL in place
+
+`PRAGMA writable_schema=ON` + `UPDATE sqlite_master SET sql=…` can add `NOT NULL` to
+the stored `CREATE` text without copying data. Rejected: it does not validate or
+clean existing NULL rows (the constraint simply starts applying to future writes,
+leaving latent violations), and SQLite documents it as dangerous. The table rebuild
+is slower but honest.

--- a/src/concord/storage/_ddl.py
+++ b/src/concord/storage/_ddl.py
@@ -21,8 +21,11 @@ The helper assumes the unquoted-identifier DDL this project writes (no
 it cannot locate the table declaration or a column definition.
 """
 
+import logging
 import re
 import sqlite3
+
+_log = logging.getLogger(__name__)
 
 # SQLite's storage-class keywords, enough to anchor the end of a column's type
 # token so ``NOT NULL`` is appended right after it.
@@ -42,7 +45,19 @@ def _swap_table_name(create_sql: str, old: str, new: str) -> str:
 
 
 def _inject_not_null(create_sql: str, column: str) -> str:
-    """Append ``NOT NULL`` to ``column``'s definition (after its type token)."""
+    """Ensure ``column``'s definition carries ``NOT NULL`` (idempotent).
+
+    Appends ``NOT NULL`` immediately after the column's type token. If the column
+    is already ``NOT NULL`` (the constraint already follows its type), returns the
+    DDL unchanged — so the helper is safe to call regardless of the column's
+    current state. Assumes this project's DDL shape, where ``NOT NULL`` directly
+    follows the type token.
+    """
+    already = re.compile(
+        r"\b" + re.escape(column) + r"\b\s+" + _TYPE + r"\s+NOT\s+NULL\b", re.IGNORECASE
+    )
+    if already.search(create_sql):
+        return create_sql
     pattern = re.compile(r"(\b" + re.escape(column) + r"\b\s+" + _TYPE + r")\b", re.IGNORECASE)
     injected, n = pattern.subn(r"\1 NOT NULL", create_sql, count=1)
     if n != 1:
@@ -62,8 +77,8 @@ def rebuild_table_add_not_null(
     already ``NOT NULL`` — the fresh-install case, where ``_BASE_SCHEMA`` already
     declares them — this is a no-op returning ``0``. Otherwise the table is
     rebuilt and any row holding a ``NULL`` in a target column is dropped (derived
-    state, rebuildable from JSONL per ADR 0002); the dropped-row count is returned
-    so the caller can log it.
+    state, rebuildable from JSONL per ADR 0002) and logged at ``WARNING``; the
+    dropped-row count is also returned.
 
     Runs inside the migration runner's transaction with ``foreign_keys`` left ON.
     That is safe because none of the tightened tables is a foreign-key *target* —
@@ -99,8 +114,7 @@ def rebuild_table_add_not_null(
     tmp = f"{table}__new"
     new_sql = _swap_table_name(create_sql, table, tmp)
     for col in not_null_columns:
-        if notnull_by_name[col] != 1:
-            new_sql = _inject_not_null(new_sql, col)
+        new_sql = _inject_not_null(new_sql, col)
 
     columns = ", ".join(str(row[1]) for row in info)
     not_null_filter = " AND ".join(f"{c} IS NOT NULL" for c in not_null_columns)
@@ -119,4 +133,12 @@ def rebuild_table_add_not_null(
     for idx_sql in index_sqls:
         conn.execute(idx_sql)
 
-    return rows_before - inserted
+    dropped = rows_before - inserted
+    if dropped:
+        _log.warning(
+            "rebuild_table_add_not_null: dropped %d row(s) from %s with NULL in %s",
+            dropped,
+            table,
+            not_null_columns,
+        )
+    return dropped

--- a/src/concord/storage/_ddl.py
+++ b/src/concord/storage/_ddl.py
@@ -1,0 +1,122 @@
+"""Schema-rebuild helpers for migrations (ADR 0017 / ADR 0024).
+
+SQLite has no ``ALTER COLUMN … SET NOT NULL``, so a migration that tightens a
+column to ``NOT NULL`` must rebuild the table: copy the rows into a new table
+whose DDL carries the constraint, drop the original, and rename the copy back.
+
+This leaf lives beside :mod:`concord.storage._sql` — *not* in
+:mod:`concord.storage.sqlite` — so the per-domain storage modules can import it
+from their migration callables without the import cycle ``sqlite`` → domain →
+``sqlite`` (``sqlite`` imports the domain modules, never the reverse).
+
+The new table's DDL is produced by injecting ``NOT NULL`` into the *live*
+``CREATE`` statement read from ``sqlite_master``, never hand-written. That keeps
+CHECK / FK / DEFAULT / PRIMARY KEY clauses byte-identical by construction — the
+schema-equivalence fingerprint (ADR 0017) compares ``PRAGMA table_info`` +
+``index_list``, which capture *neither* CHECK nor FK, so structural preservation
+must not depend on a hand-copied DDL staying in sync. See ADR 0024.
+
+The helper assumes the unquoted-identifier DDL this project writes (no
+``"quoted"`` table or column names); it raises rather than silently mis-edit if
+it cannot locate the table declaration or a column definition.
+"""
+
+import re
+import sqlite3
+
+# SQLite's storage-class keywords, enough to anchor the end of a column's type
+# token so ``NOT NULL`` is appended right after it.
+_TYPE = r"(?:TEXT|INTEGER|REAL|BLOB|NUMERIC)"
+
+
+def _swap_table_name(create_sql: str, old: str, new: str) -> str:
+    """Rename only the table in a ``CREATE TABLE`` statement's declaration."""
+    pattern = re.compile(
+        r"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?)" + re.escape(old) + r"\b",
+        re.IGNORECASE,
+    )
+    swapped, n = pattern.subn(rf"\g<1>{new}", create_sql, count=1)
+    if n != 1:
+        raise ValueError(f"could not locate the table declaration for {old!r} in its DDL")
+    return swapped
+
+
+def _inject_not_null(create_sql: str, column: str) -> str:
+    """Append ``NOT NULL`` to ``column``'s definition (after its type token)."""
+    pattern = re.compile(r"(\b" + re.escape(column) + r"\b\s+" + _TYPE + r")\b", re.IGNORECASE)
+    injected, n = pattern.subn(r"\1 NOT NULL", create_sql, count=1)
+    if n != 1:
+        raise ValueError(f"expected exactly one definition of column {column!r}, found {n}")
+    return injected
+
+
+def rebuild_table_add_not_null(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+    not_null_columns: tuple[str, ...],
+) -> int:
+    """Rebuild ``table`` so ``not_null_columns`` become ``NOT NULL``; return rows dropped.
+
+    Idempotent on its precondition (ADR 0017): when every target column is
+    already ``NOT NULL`` — the fresh-install case, where ``_BASE_SCHEMA`` already
+    declares them — this is a no-op returning ``0``. Otherwise the table is
+    rebuilt and any row holding a ``NULL`` in a target column is dropped (derived
+    state, rebuildable from JSONL per ADR 0002); the dropped-row count is returned
+    so the caller can log it.
+
+    Runs inside the migration runner's transaction with ``foreign_keys`` left ON.
+    That is safe because none of the tightened tables is a foreign-key *target* —
+    their only FKs are outgoing, re-checked against still-present parents during
+    the copy — so the 12-step rebuild needs no ``PRAGMA foreign_keys`` toggle
+    (which would be a no-op inside a transaction anyway). The leading
+    ``DROP TABLE IF EXISTS`` clears any orphan temp table left by a prior failed,
+    un-versioned attempt.
+    """
+    info = list(conn.execute(f"PRAGMA table_info({table})"))
+    notnull_by_name: dict[str, int] = {str(row[1]): int(row[3]) for row in info}
+    missing = [c for c in not_null_columns if c not in notnull_by_name]
+    if missing:
+        raise ValueError(f"{table!r} has no column(s): {missing}")
+    if all(notnull_by_name[c] == 1 for c in not_null_columns):
+        return 0
+
+    create_row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)
+    ).fetchone()
+    if create_row is None:
+        raise ValueError(f"table {table!r} not found")
+    create_sql = str(create_row[0])
+    index_sqls: list[str] = [
+        str(r[0])
+        for r in conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'index' AND tbl_name = ? AND sql IS NOT NULL",
+            (table,),
+        )
+    ]
+
+    tmp = f"{table}__new"
+    new_sql = _swap_table_name(create_sql, table, tmp)
+    for col in not_null_columns:
+        if notnull_by_name[col] != 1:
+            new_sql = _inject_not_null(new_sql, col)
+
+    columns = ", ".join(str(row[1]) for row in info)
+    not_null_filter = " AND ".join(f"{c} IS NOT NULL" for c in not_null_columns)
+    count_sql = f"SELECT COUNT(*) FROM {table}"  # noqa: S608 - table identifier, never user input
+    insert_sql = (
+        f"INSERT INTO {tmp} ({columns}) "  # noqa: S608 - schema identifiers, never user input
+        f"SELECT {columns} FROM {table} WHERE {not_null_filter}"
+    )
+
+    rows_before = int(conn.execute(count_sql).fetchone()[0])
+    conn.execute(f"DROP TABLE IF EXISTS {tmp}")
+    conn.execute(new_sql)
+    inserted = conn.execute(insert_sql).rowcount
+    conn.execute(f"DROP TABLE {table}")
+    conn.execute(f"ALTER TABLE {tmp} RENAME TO {table}")
+    for idx_sql in index_sqls:
+        conn.execute(idx_sql)
+
+    return rows_before - inserted

--- a/src/concord/storage/bills.py
+++ b/src/concord/storage/bills.py
@@ -10,7 +10,6 @@ transaction boundary; the helpers here are pure SQL over a connection, except
 :func:`upsert_bill`, whose single-row write owns its own commit.
 """
 
-import logging
 import sqlite3
 from collections.abc import Sequence
 from typing import Any
@@ -25,8 +24,6 @@ from concord.models.bills import (
 )
 from concord.storage._ddl import rebuild_table_add_not_null
 from concord.storage._sql import insert_sql, upsert_sql
-
-_log = logging.getLogger(__name__)
 
 BILLS_SCHEMA = """
 -- Bills (Phase 2a). Identity record per Bill — sponsor goes here too
@@ -299,18 +296,15 @@ def m006_bill_children_not_null(conn: sqlite3.Connection) -> None:
     already declares the constraints. Covers ``bill_cosponsors.sponsorship_date``,
     ``bill_actions.{action_code,source_system}`` and
     ``bill_summaries.{action_date,action_desc}``. Legacy rows holding a ``NULL`` in
-    any tightened column are dropped (derived state, rebuildable per ADR 0002) and
-    the count logged; each rebuild preserves the FK to ``bills``.
+    any tightened column are dropped (derived state, rebuildable per ADR 0002);
+    each rebuild preserves the FK to ``bills``.
     """
-    targets: tuple[tuple[str, tuple[str, ...]], ...] = (
+    for table, columns in (
         ("bill_cosponsors", ("sponsorship_date",)),
         ("bill_actions", ("action_code", "source_system")),
         ("bill_summaries", ("action_date", "action_desc")),
-    )
-    for table, columns in targets:
-        dropped = rebuild_table_add_not_null(conn, table=table, not_null_columns=columns)
-        if dropped:
-            _log.warning("m006: dropped %d %s row(s) with NULL in %s", dropped, table, columns)
+    ):
+        rebuild_table_add_not_null(conn, table=table, not_null_columns=columns)
 
 
 def upsert_bill(conn: sqlite3.Connection, bill: BillDetail, *, fetched_at: str) -> None:

--- a/src/concord/storage/bills.py
+++ b/src/concord/storage/bills.py
@@ -10,6 +10,7 @@ transaction boundary; the helpers here are pure SQL over a connection, except
 :func:`upsert_bill`, whose single-row write owns its own commit.
 """
 
+import logging
 import sqlite3
 from collections.abc import Sequence
 from typing import Any
@@ -22,7 +23,10 @@ from concord.models.bills import (
     BillSummary,
     BillTitle,
 )
+from concord.storage._ddl import rebuild_table_add_not_null
 from concord.storage._sql import insert_sql, upsert_sql
+
+_log = logging.getLogger(__name__)
 
 BILLS_SCHEMA = """
 -- Bills (Phase 2a). Identity record per Bill — sponsor goes here too
@@ -74,7 +78,7 @@ CREATE INDEX IF NOT EXISTS idx_bills_congress
 CREATE TABLE IF NOT EXISTS bill_cosponsors (
     bill_id                     TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
     bioguide_id                 TEXT NOT NULL,
-    sponsorship_date            TEXT,
+    sponsorship_date            TEXT NOT NULL,
     sponsorship_withdrawn_date  TEXT,
     is_original_cosponsor       INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (bill_id, bioguide_id)
@@ -87,8 +91,8 @@ CREATE TABLE IF NOT EXISTS bill_actions (
     ord            INTEGER NOT NULL,
     action_date    TEXT NOT NULL,
     action_text    TEXT NOT NULL,
-    action_code    TEXT,
-    source_system  TEXT,
+    action_code    TEXT NOT NULL,
+    source_system  TEXT NOT NULL,
     PRIMARY KEY (bill_id, ord)
 );
 CREATE INDEX IF NOT EXISTS idx_bill_actions_date
@@ -112,8 +116,8 @@ CREATE TABLE IF NOT EXISTS bill_titles (
 CREATE TABLE IF NOT EXISTS bill_summaries (
     bill_id        TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
     version_code   TEXT NOT NULL,
-    action_date    TEXT,
-    action_desc    TEXT,
+    action_date    TEXT NOT NULL,
+    action_desc    TEXT NOT NULL,
     summary_text   TEXT NOT NULL,
     PRIMARY KEY (bill_id, version_code)
 );
@@ -286,6 +290,27 @@ def m002_add_bill_briefs(conn: sqlite3.Connection) -> None:
         );
         """
     )
+
+
+def m006_bill_children_not_null(conn: sqlite3.Connection) -> None:
+    """ADR 0024: tighten the bill child tables' columns to ``NOT NULL``.
+
+    Guarded table rebuilds — no-ops on fresh installs whose ``_BASE_SCHEMA``
+    already declares the constraints. Covers ``bill_cosponsors.sponsorship_date``,
+    ``bill_actions.{action_code,source_system}`` and
+    ``bill_summaries.{action_date,action_desc}``. Legacy rows holding a ``NULL`` in
+    any tightened column are dropped (derived state, rebuildable per ADR 0002) and
+    the count logged; each rebuild preserves the FK to ``bills``.
+    """
+    targets: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("bill_cosponsors", ("sponsorship_date",)),
+        ("bill_actions", ("action_code", "source_system")),
+        ("bill_summaries", ("action_date", "action_desc")),
+    )
+    for table, columns in targets:
+        dropped = rebuild_table_add_not_null(conn, table=table, not_null_columns=columns)
+        if dropped:
+            _log.warning("m006: dropped %d %s row(s) with NULL in %s", dropped, table, columns)
 
 
 def upsert_bill(conn: sqlite3.Connection, bill: BillDetail, *, fetched_at: str) -> None:

--- a/src/concord/storage/members.py
+++ b/src/concord/storage/members.py
@@ -7,7 +7,6 @@ these and owns the transaction boundary; the write helper here that needs
 member+terms atomicity manages its own self-contained BEGIN/COMMIT.
 """
 
-import logging
 import sqlite3
 from collections.abc import Sequence
 from typing import Any
@@ -15,8 +14,6 @@ from typing import Any
 from concord.models.members import Member, Term
 from concord.storage._ddl import rebuild_table_add_not_null
 from concord.storage._sql import insert_sql, upsert_sql
-
-_log = logging.getLogger(__name__)
 
 MEMBERS_SCHEMA = """
 -- Members (Phase 1). Per-person identity fields; per-Term records the
@@ -97,17 +94,13 @@ def m005_member_terms_not_null(conn: sqlite3.Connection) -> None:
 
     Guarded table rebuild — a no-op on fresh installs whose ``_BASE_SCHEMA``
     already declares the constraint. Any legacy row holding a ``NULL`` in these
-    columns is dropped (derived state, rebuildable from JSONL per ADR 0002) and
-    the count logged. The rebuild preserves the chamber CHECK and the FK to
-    ``members`` by injecting ``NOT NULL`` into the live DDL.
+    columns is dropped (derived state, rebuildable from JSONL per ADR 0002). The
+    rebuild preserves the chamber CHECK and the FK to ``members`` by injecting
+    ``NOT NULL`` into the live DDL.
     """
-    dropped = rebuild_table_add_not_null(
+    rebuild_table_add_not_null(
         conn, table="member_terms", not_null_columns=("party", "start_date", "end_date")
     )
-    if dropped:
-        _log.warning(
-            "m005: dropped %d member_terms row(s) with NULL party/start_date/end_date", dropped
-        )
 
 
 def upsert_member(

--- a/src/concord/storage/members.py
+++ b/src/concord/storage/members.py
@@ -7,12 +7,16 @@ these and owns the transaction boundary; the write helper here that needs
 member+terms atomicity manages its own self-contained BEGIN/COMMIT.
 """
 
+import logging
 import sqlite3
 from collections.abc import Sequence
 from typing import Any
 
 from concord.models.members import Member, Term
+from concord.storage._ddl import rebuild_table_add_not_null
 from concord.storage._sql import insert_sql, upsert_sql
+
+_log = logging.getLogger(__name__)
 
 MEMBERS_SCHEMA = """
 -- Members (Phase 1). Per-person identity fields; per-Term records the
@@ -35,11 +39,11 @@ CREATE TABLE IF NOT EXISTS member_terms (
     bioguide_id TEXT NOT NULL REFERENCES members(bioguide_id) ON DELETE CASCADE,
     congress    INTEGER NOT NULL,
     chamber     TEXT NOT NULL CHECK (chamber IN ('house', 'senate')),
-    party       TEXT,
+    party       TEXT NOT NULL,
     state       TEXT NOT NULL,
     district    INTEGER,
-    start_date  TEXT,
-    end_date    TEXT,
+    start_date  TEXT NOT NULL,
+    end_date    TEXT NOT NULL,
     PRIMARY KEY (bioguide_id, congress, chamber)
 );
 
@@ -86,6 +90,24 @@ _TERM_COLUMNS: tuple[str, ...] = (
 
 _MEMBER_UPSERT_SQL = upsert_sql("members", _MEMBER_COLUMNS, conflict=("bioguide_id",))
 _TERM_INSERT_SQL = insert_sql("member_terms", _TERM_COLUMNS)
+
+
+def m005_member_terms_not_null(conn: sqlite3.Connection) -> None:
+    """ADR 0024: tighten ``member_terms.{party,start_date,end_date}`` to ``NOT NULL``.
+
+    Guarded table rebuild — a no-op on fresh installs whose ``_BASE_SCHEMA``
+    already declares the constraint. Any legacy row holding a ``NULL`` in these
+    columns is dropped (derived state, rebuildable from JSONL per ADR 0002) and
+    the count logged. The rebuild preserves the chamber CHECK and the FK to
+    ``members`` by injecting ``NOT NULL`` into the live DDL.
+    """
+    dropped = rebuild_table_add_not_null(
+        conn, table="member_terms", not_null_columns=("party", "start_date", "end_date")
+    )
+    if dropped:
+        _log.warning(
+            "m005: dropped %d member_terms row(s) with NULL party/start_date/end_date", dropped
+        )
 
 
 def upsert_member(

--- a/src/concord/storage/sqlite.py
+++ b/src/concord/storage/sqlite.py
@@ -215,6 +215,9 @@ _MIGRATIONS: tuple[tuple[int, Callable[[sqlite3.Connection], None]], ...] = (
     (2, bills_storage.m002_add_bill_briefs),
     (3, runs_storage.m003_add_runs_tables),
     (4, validation_storage.m004_add_validation_failures),
+    (5, members_storage.m005_member_terms_not_null),
+    (6, bills_storage.m006_bill_children_not_null),
+    (7, votes_storage.m007_vote_positions_not_null),
 )
 _HEAD: int = _MIGRATIONS[-1][0] if _MIGRATIONS else 0
 

--- a/src/concord/storage/votes.py
+++ b/src/concord/storage/votes.py
@@ -7,12 +7,16 @@ persistence/query helpers. ``SqliteStorage`` composes these and owns the
 transaction boundary; the helpers here are pure SQL over a connection.
 """
 
+import logging
 import sqlite3
 from collections.abc import Sequence
 from typing import Any
 
 from concord.models.votes import Vote, VotePosition
+from concord.storage._ddl import rebuild_table_add_not_null
 from concord.storage._sql import upsert_sql
+
+_log = logging.getLogger(__name__)
 
 VOTES_SCHEMA = """
 -- Votes (Phase 3a). One row per recorded roll-call decision in a chamber.
@@ -59,8 +63,8 @@ CREATE TABLE IF NOT EXISTS vote_positions (
     vote_id      TEXT NOT NULL,
     bioguide_id  TEXT NOT NULL,
     position     TEXT NOT NULL,
-    vote_party   TEXT,
-    vote_state   TEXT,
+    vote_party   TEXT NOT NULL,
+    vote_state   TEXT NOT NULL,
     PRIMARY KEY (vote_id, bioguide_id)
 );
 
@@ -125,6 +129,24 @@ _VOTE_POSITION_INSERT_SQL = (
     + ", ".join("?" for _ in _VOTE_POSITION_COLUMNS)
     + ")"
 )
+
+
+def m007_vote_positions_not_null(conn: sqlite3.Connection) -> None:
+    """ADR 0024: tighten ``vote_positions.{vote_party,vote_state}`` to ``NOT NULL``.
+
+    Guarded table rebuild — a no-op on fresh installs whose ``_BASE_SCHEMA``
+    already declares the constraint. Any legacy row holding a ``NULL`` in these
+    columns is dropped (derived state, rebuildable from JSONL per ADR 0002) and the
+    count logged. ``vote_positions`` has no FK or CHECK, so the rebuild is a plain
+    structural copy.
+    """
+    dropped = rebuild_table_add_not_null(
+        conn, table="vote_positions", not_null_columns=("vote_party", "vote_state")
+    )
+    if dropped:
+        _log.warning(
+            "m007: dropped %d vote_positions row(s) with NULL vote_party/vote_state", dropped
+        )
 
 
 def upsert_vote(conn: sqlite3.Connection, vote: Vote, *, fetched_at: str) -> None:

--- a/src/concord/storage/votes.py
+++ b/src/concord/storage/votes.py
@@ -7,7 +7,6 @@ persistence/query helpers. ``SqliteStorage`` composes these and owns the
 transaction boundary; the helpers here are pure SQL over a connection.
 """
 
-import logging
 import sqlite3
 from collections.abc import Sequence
 from typing import Any
@@ -15,8 +14,6 @@ from typing import Any
 from concord.models.votes import Vote, VotePosition
 from concord.storage._ddl import rebuild_table_add_not_null
 from concord.storage._sql import upsert_sql
-
-_log = logging.getLogger(__name__)
 
 VOTES_SCHEMA = """
 -- Votes (Phase 3a). One row per recorded roll-call decision in a chamber.
@@ -136,17 +133,13 @@ def m007_vote_positions_not_null(conn: sqlite3.Connection) -> None:
 
     Guarded table rebuild — a no-op on fresh installs whose ``_BASE_SCHEMA``
     already declares the constraint. Any legacy row holding a ``NULL`` in these
-    columns is dropped (derived state, rebuildable from JSONL per ADR 0002) and the
-    count logged. ``vote_positions`` has no FK or CHECK, so the rebuild is a plain
-    structural copy.
+    columns is dropped (derived state, rebuildable from JSONL per ADR 0002).
+    ``vote_positions`` has no FK or CHECK, so the rebuild is a plain structural
+    copy.
     """
-    dropped = rebuild_table_add_not_null(
+    rebuild_table_add_not_null(
         conn, table="vote_positions", not_null_columns=("vote_party", "vote_state")
     )
-    if dropped:
-        _log.warning(
-            "m007: dropped %d vote_positions row(s) with NULL vote_party/vote_state", dropped
-        )
 
 
 def upsert_vote(conn: sqlite3.Connection, vote: Vote, *, fetched_at: str) -> None:

--- a/tests/test_pipeline_votes.py
+++ b/tests/test_pipeline_votes.py
@@ -236,7 +236,7 @@ def _seed_member(
     *,
     chamber: str = "senate",
     start_date: str = "2023-01-03",
-    end_date: str | None = None,
+    end_date: str = "2027-01-03",
 ) -> None:
     storage = SqliteStorage(db, load_vec=False)
     try:

--- a/tests/test_sqlite_runs.py
+++ b/tests/test_sqlite_runs.py
@@ -115,8 +115,8 @@ class TestRunsRoundTrip:
 
 
 class TestSchemaVersion:
-    def test_head_is_four(self) -> None:
-        assert _HEAD == 4
+    def test_head_is_seven(self) -> None:
+        assert _HEAD == 7
 
     def test_fresh_db_has_runs_tables_at_head(self, tmp_path: Path) -> None:
         db_path = tmp_path / "ledger.db"
@@ -131,4 +131,4 @@ class TestSchemaVersion:
         finally:
             conn.close()
         assert {"runs", "run_events", "validation_failures"} <= tables
-        assert version == 4
+        assert version == _HEAD

--- a/tests/test_storage_members_sqlite.py
+++ b/tests/test_storage_members_sqlite.py
@@ -133,11 +133,15 @@ class TestUpsertMember:
             "VALUES (?, ?, ?, ?, ?)",
             ("X000001", "X", "Y", "X Y", "2026-05-25T00:00:00+00:00"),
         )
-        with pytest.raises(sqlite3.IntegrityError):
+        # Supply the NOT NULL columns (party/start_date/end_date) so the *only*
+        # constraint this row violates is the chamber CHECK — otherwise a NOT NULL
+        # trip could mask it and the test would pass for the wrong reason.
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK"):
             storage.connection.execute(
-                "INSERT INTO member_terms (bioguide_id, congress, chamber, state) "
-                "VALUES (?, ?, ?, ?)",
-                ("X000001", 119, "bogus", "VT"),
+                "INSERT INTO member_terms "
+                "(bioguide_id, congress, chamber, party, state, start_date, end_date) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("X000001", 119, "bogus", "D", "VT", "2025-01-03", "2027-01-03"),
             )
 
 

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from concord.models.proceedings import Article, Issue, Proceeding
+from concord.storage._ddl import _inject_not_null
 from concord.storage.base import Storage
 from concord.storage.sqlite import _BASE_SCHEMA, _HEAD, _MIGRATIONS, SqliteStorage, ensure_schema
 
@@ -863,7 +864,7 @@ class TestNotNullRebuildMigration:
                     "(bioguide_id, congress, chamber, party, state, start_date, end_date) "
                     "VALUES ('M1', 120, 'bogus', 'D', 'VT', '2025-01-03', '2027-01-03')"
                 )
-            with pytest.raises(sqlite3.IntegrityError):
+            with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
                 storage.connection.execute(
                     "INSERT INTO bill_cosponsors "
                     "(bill_id, bioguide_id, sponsorship_date, is_original_cosponsor) "
@@ -871,3 +872,16 @@ class TestNotNullRebuildMigration:
                 )
         finally:
             storage.close()
+
+
+class TestInjectNotNullIdempotent:
+    """ADR 0024: _inject_not_null is safe to call on an already-constrained column."""
+
+    def test_injects_once_then_is_a_no_op(self) -> None:
+        ddl = "CREATE TABLE t (\n    party TEXT,\n    state TEXT NOT NULL\n)"
+        once = _inject_not_null(ddl, "party")
+        assert "party TEXT NOT NULL" in once
+        # A second call on the now-constrained column must not double-inject.
+        twice = _inject_not_null(once, "party")
+        assert twice == once
+        assert "NOT NULL NOT NULL" not in twice

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -641,3 +641,233 @@ class TestSchemaMigrations:
             "  - _BASE_SCHEMA has something the migrations don't.\n"
             "Update _BASE_SCHEMA (or the migration) so they describe the same head."
         )
+
+
+# The ten derived mirror columns tightened to NOT NULL in issue #90 / ADR 0024.
+_NOT_NULL_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("member_terms", "party"),
+    ("member_terms", "start_date"),
+    ("member_terms", "end_date"),
+    ("bill_cosponsors", "sponsorship_date"),
+    ("bill_actions", "action_code"),
+    ("bill_actions", "source_system"),
+    ("bill_summaries", "action_date"),
+    ("bill_summaries", "action_desc"),
+    ("vote_positions", "vote_party"),
+    ("vote_positions", "vote_state"),
+)
+
+
+class TestDerivedColumnsNotNull:
+    """Issue #90 / ADR 0024: the ten derived mirror columns are NOT NULL on a fresh DB."""
+
+    @pytest.mark.parametrize(("table", "column"), _NOT_NULL_COLUMNS)
+    def test_column_is_not_null(self, tmp_path: Path, table: str, column: str) -> None:
+        db_path = tmp_path / "fresh.db"
+        ensure_schema(db_path)
+        conn = sqlite3.connect(db_path)
+        try:
+            notnull = {row[1]: row[3] for row in conn.execute(f"PRAGMA table_info({table})")}
+        finally:
+            conn.close()
+        assert notnull[column] == 1, f"{table}.{column} should be NOT NULL"
+
+
+# Pre-#90 nullable DDL for the five tightened tables — identical to the head
+# schema except the ten columns lack NOT NULL. Used to build a DB that predates
+# the constraint so migrations 5-7 have real work to do.
+_LEGACY_NULLABLE_SCHEMA = """
+CREATE TABLE member_terms (
+    bioguide_id TEXT NOT NULL REFERENCES members(bioguide_id) ON DELETE CASCADE,
+    congress    INTEGER NOT NULL,
+    chamber     TEXT NOT NULL CHECK (chamber IN ('house', 'senate')),
+    party       TEXT,
+    state       TEXT NOT NULL,
+    district    INTEGER,
+    start_date  TEXT,
+    end_date    TEXT,
+    PRIMARY KEY (bioguide_id, congress, chamber)
+);
+CREATE INDEX idx_member_terms_congress ON member_terms (congress);
+CREATE INDEX idx_member_terms_state ON member_terms (state);
+
+CREATE TABLE bill_cosponsors (
+    bill_id                     TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
+    bioguide_id                 TEXT NOT NULL,
+    sponsorship_date            TEXT,
+    sponsorship_withdrawn_date  TEXT,
+    is_original_cosponsor       INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (bill_id, bioguide_id)
+);
+CREATE INDEX idx_bill_cosponsors_bioguide ON bill_cosponsors (bioguide_id);
+
+CREATE TABLE bill_actions (
+    bill_id        TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
+    ord            INTEGER NOT NULL,
+    action_date    TEXT NOT NULL,
+    action_text    TEXT NOT NULL,
+    action_code    TEXT,
+    source_system  TEXT,
+    PRIMARY KEY (bill_id, ord)
+);
+CREATE INDEX idx_bill_actions_date ON bill_actions (action_date DESC);
+
+CREATE TABLE bill_summaries (
+    bill_id        TEXT NOT NULL REFERENCES bills(bill_id) ON DELETE CASCADE,
+    version_code   TEXT NOT NULL,
+    action_date    TEXT,
+    action_desc    TEXT,
+    summary_text   TEXT NOT NULL,
+    PRIMARY KEY (bill_id, version_code)
+);
+
+CREATE TABLE vote_positions (
+    vote_id      TEXT NOT NULL,
+    bioguide_id  TEXT NOT NULL,
+    position     TEXT NOT NULL,
+    vote_party   TEXT,
+    vote_state   TEXT,
+    PRIMARY KEY (vote_id, bioguide_id)
+);
+CREATE INDEX idx_vote_positions_member ON vote_positions (bioguide_id);
+"""
+
+# Seed rows for the legacy DB: one valid row per table plus one row that holds a
+# NULL in a now-tightened column (which the rebuild must drop). Parents (M1, the
+# bill) exist so the valid rows survive the rebuild's FK re-check; the NULL rows
+# are filtered out before that check.
+_LEGACY_SEED_SQL = """
+INSERT INTO members (bioguide_id, first_name, last_name, display_name, fetched_at)
+VALUES ('M1', 'F', 'L', 'F L', 't'), ('M2', 'G', 'H', 'G H', 't');
+
+INSERT INTO bills
+    (bill_id, congress, bill_type, bill_number, origin_chamber, title, update_date, fetched_at)
+VALUES ('119-hr-1', 119, 'hr', 1, 'House', 'A Bill', '2025-01-09', 't');
+
+INSERT INTO member_terms
+    (bioguide_id, congress, chamber, party, state, district, start_date, end_date)
+VALUES
+    ('M1', 119, 'house', 'D', 'VT', 1, '2025-01-03', '2027-01-03'),
+    ('M2', 119, 'senate', NULL, 'CA', NULL, '2025-01-03', '2027-01-03');
+
+INSERT INTO bill_cosponsors
+    (bill_id, bioguide_id, sponsorship_date, sponsorship_withdrawn_date, is_original_cosponsor)
+VALUES
+    ('119-hr-1', 'M1', '2025-01-09', NULL, 1),
+    ('119-hr-1', 'M2', NULL, NULL, 0);
+
+INSERT INTO bill_actions
+    (bill_id, ord, action_date, action_text, action_code, source_system)
+VALUES
+    ('119-hr-1', 0, '2025-01-09', 'Introduced', 'E40000', 'House'),
+    ('119-hr-1', 1, '2025-01-10', 'Referred', NULL, NULL);
+
+INSERT INTO bill_summaries
+    (bill_id, version_code, action_date, action_desc, summary_text)
+VALUES
+    ('119-hr-1', '00', '2025-01-09', 'Introduced in House', 'Summary'),
+    ('119-hr-1', '01', NULL, NULL, 'Other');
+
+INSERT INTO vote_positions
+    (vote_id, bioguide_id, position, vote_party, vote_state)
+VALUES
+    ('senate-119-1-1', 'M1', 'Yea', 'D', 'VT'),
+    ('senate-119-1-1', 'M2', 'Nay', NULL, NULL);
+"""
+
+
+_LEGACY_TABLES: tuple[str, ...] = (
+    "member_terms",
+    "bill_cosponsors",
+    "bill_actions",
+    "bill_summaries",
+    "vote_positions",
+)
+
+
+def _build_legacy_nullable_db(db_path: Path) -> None:
+    """Write a pre-#90 DB: the head schema but the five tightened tables nullable, at version 4."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(_BASE_SCHEMA)  # full head schema (target tables NOT NULL)
+        for table in _LEGACY_TABLES:
+            conn.execute(f"DROP TABLE {table}")
+        conn.executescript(_LEGACY_NULLABLE_SCHEMA)  # recreate the five nullable
+        conn.executescript(_LEGACY_SEED_SQL)
+        conn.execute("PRAGMA user_version = 4")  # the pre-#90 _HEAD
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestNotNullRebuildMigration:
+    """ADR 0024: migrations 5-7 converge a legacy nullable DB to the NOT NULL head."""
+
+    def test_legacy_db_converges_and_drops_null_rows(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "legacy.db"
+        _build_legacy_nullable_db(db_path)
+
+        ensure_schema(db_path)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == _HEAD
+            # Every tightened column is now NOT NULL.
+            for table, column in _NOT_NULL_COLUMNS:
+                notnull = {r[1]: r[3] for r in conn.execute(f"PRAGMA table_info({table})")}
+                assert notnull[column] == 1, f"{table}.{column} not tightened"
+            # The NULL-violating row was dropped; the valid row survived.
+            for table in _LEGACY_TABLES:
+                rows = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+                assert rows == 1, f"{table} should have exactly the one valid row"
+            assert conn.execute("SELECT bioguide_id FROM member_terms").fetchone()[0] == "M1"
+        finally:
+            conn.close()
+
+    def test_rebuilt_schema_matches_fresh(self, tmp_path: Path) -> None:
+        """The converged DB is structurally identical to a fresh head DB.
+
+        Pins what the schema-equivalence fingerprint *can* see (columns,
+        notnull, pk, indexes); CHECK/FK preservation is covered separately
+        below since the fingerprint is blind to them.
+        """
+        legacy = tmp_path / "legacy.db"
+        _build_legacy_nullable_db(legacy)
+        ensure_schema(legacy)
+
+        # Build the reference the same way (ensure_schema, not bare _BASE_SCHEMA) so
+        # both carry sqlite-vec's chunks_vec shadow tables and the comparison is
+        # apples-to-apples.
+        fresh = tmp_path / "fresh.db"
+        ensure_schema(fresh)
+
+        fresh_conn = sqlite3.connect(fresh)
+        migrated_conn = sqlite3.connect(legacy)
+        try:
+            assert _schema_fingerprint(migrated_conn) == _schema_fingerprint(fresh_conn)
+        finally:
+            fresh_conn.close()
+            migrated_conn.close()
+
+    def test_rebuild_preserves_check_and_fk(self, tmp_path: Path) -> None:
+        """The rebuild keeps member_terms' chamber CHECK and the bill_* FK alive."""
+        db_path = tmp_path / "legacy.db"
+        _build_legacy_nullable_db(db_path)
+        ensure_schema(db_path)
+
+        storage = SqliteStorage(db_path, load_vec=False)  # connection has foreign_keys ON
+        try:
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK"):
+                storage.connection.execute(
+                    "INSERT INTO member_terms "
+                    "(bioguide_id, congress, chamber, party, state, start_date, end_date) "
+                    "VALUES ('M1', 120, 'bogus', 'D', 'VT', '2025-01-03', '2027-01-03')"
+                )
+            with pytest.raises(sqlite3.IntegrityError):
+                storage.connection.execute(
+                    "INSERT INTO bill_cosponsors "
+                    "(bill_id, bioguide_id, sponsorship_date, is_original_cosponsor) "
+                    "VALUES ('no-such-bill', 'M1', '2025-01-09', 0)"
+                )
+        finally:
+            storage.close()


### PR DESCRIPTION
Closes #90.

## Summary

PR #89 tightened ten Pydantic fields from `T | None` to `T`. This brings the SQLite mirror columns into agreement by declaring them `NOT NULL`:

- `member_terms.{party, start_date, end_date}`
- `bill_cosponsors.sponsorship_date`
- `bill_actions.{action_code, source_system}`
- `bill_summaries.{action_date, action_desc}`
- `vote_positions.{vote_party, vote_state}`

## Why a migration, not a straight schema edit

The issue proposed a bare `_BASE_SCHEMA` edit (citing ADR 0002's rebuildability). But ADR 0017 — accepted one day before the issue — made migrations the convergence mechanism: `CREATE TABLE IF NOT EXISTS` no-ops against a pre-existing table, so a bare edit would leave existing on-disk DBs nullable while fresh installs are `NOT NULL`, **both reporting the same `user_version`**. This PR instead converges existing DBs with three append-only table-rebuild migrations (`m005`/`m006`/`m007`; `_HEAD` 4→7), keeping `user_version` an honest schema identity. New **ADR 0024** records the decision.

## How the rebuild works

SQLite has no `ALTER COLUMN … SET NOT NULL`, so a shared helper (`storage/_ddl.py`) rebuilds each table:

- **Injects `NOT NULL` into the live `sqlite_master` DDL** rather than hand-writing it, preserving CHECK / FK / DEFAULT / PK by construction — the schema-equivalence fingerprint (ADR 0017) can't see CHECK or FK, so structural preservation can't depend on a hand-copied DDL staying in sync.
- **Drops rows that violate the constraint** (`WHERE … IS NOT NULL`) with a logged count. None exist on a DB loaded under the strict post-#89 models; legacy NULL rows are derived and return on the next `concord load` (ADR 0002). Fail-loud and coalesce-to-`''` were both rejected (see ADR 0024).
- **Guards on already-`NOT NULL`**, so it's a no-op on fresh installs; `foreign_keys` stays ON (none of the five tables is an FK *target*).

## Tests

- Parametrized `NOT NULL`-flag regression over all ten columns.
- `TestNotNullRebuildMigration`: builds a pre-#90 nullable DB at `user_version=4`, runs `ensure_schema`, and asserts it converges to `_HEAD`, drops only the NULL-violating rows, keeps the valid rows, **matches a fresh DB's schema fingerprint**, and still enforces the chamber CHECK and the `bill_*` FK.
- Updated the two raw-insert sites and the `_HEAD` sentinel that assumed the old schema/version.

## Acceptance prerequisite (not automatable here)

The "zero parse-failure warnings against current Stage 0 data" gate needs real API data and is human-owned. A production NULL check across the ten columns is the direct form of it. If any column shows NULLs, that field's #89 tightening is suspect — exclude that column and re-loosen its model (escalate), per the plan's per-field policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)