### PR TITLE
Bump to 0.7.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "congress-concord"
-version = "0.6.0"
+version = "0.7.0rc1"
 description = "Collect, index, and search U.S. Congress data — Congressional Record, Members, Bills, Votes — via api.congress.gov."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,7 @@ wheels = [
 
 [[package]]
 name = "congress-concord"
-version = "0.6.0"
+version = "0.7.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Release-candidate version bump for **0.7.0** — the TestPyPI dry-run before the real release.

One-line `pyproject.toml` change (+ matching `uv.lock`), per [docs/releases.md](docs/releases.md). After merge, I'll cut a GitHub pre-release tagged `v0.7.0rc1` (**"Set as a pre-release" ✅**) to fire `publish-testpypi`, then run the TestPyPI smoke test.

## What 0.7.0 ships
- `NOT NULL` tightening of the ten derived SQLite mirror columns (#90), converged on existing DBs via three append-only table-rebuild migrations (`_HEAD` 4→7).
- New `ADR 0024` and the reusable `rebuild_table_add_not_null` helper.

No CLI/API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)