### PR TITLE
Bump to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "congress-concord"
-version = "0.7.0rc1"
+version = "0.7.0"
 description = "Collect, index, and search U.S. Congress data — Congressional Record, Members, Bills, Votes — via api.congress.gov."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,7 @@ wheels = [
 
 [[package]]
 name = "congress-concord"
-version = "0.7.0rc1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Promotes `0.7.0rc1` to the real **0.7.0** release after a clean TestPyPI dry-run (smoke test passed: install + `concord --help` + `__version__` + a functional `ensure_schema` check showing `user_version=7` with the tightened columns `NOT NULL`).

One-line `pyproject.toml` change (+ matching `uv.lock`), per [docs/releases.md](docs/releases.md). After merge, I'll cut a GitHub Release tagged `v0.7.0` with **pre-release ❌ unchecked** → fires `publish-pypi` + Docker→GHCR.

## What 0.7.0 ships
- `NOT NULL` tightening of the ten derived SQLite mirror columns (#90), converged on existing DBs via three append-only table-rebuild migrations (`_HEAD` 4→7).
- New `ADR 0024` and the reusable `rebuild_table_add_not_null` helper.

No CLI/API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)