### PR TITLE
chore(release): add scripts/smoke-test-release.sh

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,7 +8,7 @@ This document covers the **recurring** release workflow — what to do every tim
 | ---- | ----- | ------ |
 | 1. Bump `[project].version` in `pyproject.toml` to e.g. `0.3.0rc1` | PR + merge | Pyproject now reflects the next dry-run version |
 | 2. Create a GitHub Release tagged `v0.3.0rc1`, **"Set as a pre-release" ✅** | GitHub UI | Fires `publish-testpypi` only — TestPyPI gets the wheel |
-| 3. Smoke-test the TestPyPI wheel (see [recipe](#testpypi-smoke-test-recipe)) | Your machine | Confirms install + import + CLI work |
+| 3. Smoke-test the TestPyPI wheel — run [`scripts/smoke-test-release.sh`](../scripts/smoke-test-release.sh) (or the [manual recipe](#testpypi-smoke-test-recipe)) | Your machine | Confirms install + import + CLI work |
 | 4. Bump `[project].version` to the real version, e.g. `0.3.0` | PR + merge | Drops the `rc1` suffix |
 | 5. Create a GitHub Release tagged `v0.3.0`, pre-release **❌ unchecked** | GitHub UI | Fires `publish-pypi` + Docker→GHCR; real PyPI gets the wheel |
 | 6. Verify on https://pypi.org/project/congress-concord/ | PyPI page | Eyeball the release page, README rendering, classifiers |
@@ -31,6 +31,8 @@ If you forget to bump `pyproject.toml`, the symptoms depend on the situation:
 Easiest discipline: the bump-PR's title should match the GitHub release's tag (e.g. PR titled "Bump to 0.3.0" pairs with release `v0.3.0`).
 
 ## TestPyPI smoke-test recipe
+
+> **Shortcut:** [`scripts/smoke-test-release.sh`](../scripts/smoke-test-release.sh) runs this whole recipe for you in a throwaway venv — `scripts/smoke-test-release.sh [version] [testpypi|pypi]`, where `version` defaults to `pyproject.toml`'s and the index defaults to TestPyPI. Use it for step 3 (`scripts/smoke-test-release.sh`) and as a final check after step 5 (`scripts/smoke-test-release.sh X.Y.Z pypi`). It is scoped to the smoke test only — it does not bump, tag, or release, since those steps are human-gated by design (see the footgun and checkbox sections). The manual recipe below explains *why* it works the way it does.
 
 The pattern most tutorials suggest — `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ <package>` — **is unsafe** for our use case. Here's why, and what to do instead.
 

--- a/scripts/smoke-test-release.sh
+++ b/scripts/smoke-test-release.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Smoke-test a published congress-concord wheel — the executable form of the
+# "TestPyPI smoke-test recipe" in docs/releases.md (release step 3, and a final
+# check for step 6). Deliberately scoped to the smoke test: it does NOT bump
+# versions, tag, or cut releases — those steps are human-gated by design (see
+# the "big footgun" and pre-release-checkbox sections of the doc).
+#
+# It downloads ONLY our wheel from the chosen index, then installs it from the
+# local file so dependencies resolve from real PyPI — sidestepping the
+# --extra-index-url footgun where a TestPyPI typosquat outranks a real dep. It
+# runs in a throwaway venv that is removed on exit; it never touches the
+# project's own environment.
+#
+# Usage:
+#   scripts/smoke-test-release.sh                 # version from pyproject.toml, TestPyPI
+#   scripts/smoke-test-release.sh 0.7.0rc1        # explicit version, TestPyPI
+#   scripts/smoke-test-release.sh 0.7.0 pypi      # explicit version, real PyPI
+#
+# Env:
+#   PYTHON   interpreter for the throwaway venv (default: python3.12)
+#
+set -euo pipefail
+
+VERSION="${1:-}"
+INDEX="${2:-testpypi}"
+PYTHON="${PYTHON:-python3.12}"
+PACKAGE="congress-concord"
+
+# Default the version to [project].version in pyproject.toml (resolved relative
+# to the repo root, so the script works from any CWD).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -z "$VERSION" ]; then
+  VERSION="$("$PYTHON" - "$REPO_ROOT/pyproject.toml" <<'PY'
+import sys, tomllib, pathlib
+print(tomllib.loads(pathlib.Path(sys.argv[1]).read_text())["project"]["version"])
+PY
+)"
+fi
+
+case "$INDEX" in
+  testpypi) INDEX_URL="https://test.pypi.org/simple/" ;;
+  pypi)     INDEX_URL="https://pypi.org/simple/" ;;
+  *) echo "error: unknown index '$INDEX' (use 'testpypi' or 'pypi')" >&2; exit 2 ;;
+esac
+
+echo ">> smoke-testing ${PACKAGE}==${VERSION} from ${INDEX} (${INDEX_URL})"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+VENV="$WORK/venv"
+DL="$WORK/dl"
+
+"$PYTHON" -m venv "$VENV"
+"$VENV/bin/pip" install --quiet --upgrade pip
+
+# Download ONLY our wheel (no deps) from the chosen index.
+"$VENV/bin/pip" download --index-url "$INDEX_URL" --no-deps --dest "$DL" \
+  "${PACKAGE}==${VERSION}"
+
+WHEEL="$(find "$DL" -name 'congress_concord-*.whl' | head -1)"
+if [ -z "$WHEEL" ]; then
+  echo "FAIL: no wheel downloaded for ${PACKAGE}==${VERSION}" >&2
+  exit 1
+fi
+echo ">> downloaded $(basename "$WHEEL")"
+
+# Install from the local file; deps come from the default index (real PyPI).
+"$VENV/bin/pip" install --quiet "$WHEEL"
+
+# 1. CLI entry point runs.
+"$VENV/bin/concord" --help >/dev/null
+echo ">> concord --help: ok"
+
+# 2. Declared version matches what we asked for.
+GOT="$("$VENV/bin/python" -c 'import concord; print(concord.__version__)')"
+if [ "$GOT" != "$VERSION" ]; then
+  echo "FAIL: installed __version__=${GOT}, expected ${VERSION}" >&2
+  exit 1
+fi
+echo ">> __version__ == ${VERSION}: ok"
+
+# 3. The packaged store actually bootstraps: schema applies and stamps to head.
+"$VENV/bin/python" - <<'PY'
+import sqlite3
+import tempfile
+
+from concord.storage.sqlite import _HEAD, ensure_schema
+
+db = tempfile.mktemp(suffix=".db")
+ensure_schema(db)
+conn = sqlite3.connect(db)
+version = conn.execute("PRAGMA user_version").fetchone()[0]
+conn.close()
+assert version == _HEAD, f"user_version {version} != _HEAD {_HEAD}"
+print(f">> ensure_schema bootstraps to user_version={version}: ok")
+PY
+
+echo ">> PASS: ${PACKAGE}==${VERSION} installs cleanly, CLI runs, version matches, schema bootstraps."
+echo ">> also eyeball the project page: ${INDEX_URL%simple/}project/${PACKAGE}/"


### PR DESCRIPTION
Codifies the **"TestPyPI smoke-test recipe"** from [docs/releases.md](docs/releases.md) as a runnable script, so release step 3 (and a final check after step 5) isn't a hand-typed sequence where the `--extra-index-url` footgun lurks.

### What it does
In a throwaway venv (removed on exit, never touches the project env):
1. Downloads **only** our wheel from the chosen index (`--no-deps`).
2. Installs it from the local file so dependencies resolve from **real PyPI**.
3. Asserts `concord --help` runs, `__version__` matches the requested version, and `ensure_schema` bootstraps a DB to `_HEAD`.

```sh
scripts/smoke-test-release.sh                 # version from pyproject.toml, TestPyPI
scripts/smoke-test-release.sh 0.7.0rc1         # explicit version, TestPyPI
scripts/smoke-test-release.sh 0.7.0 pypi       # explicit version, real PyPI
```

### Scope (deliberate)
Smoke test only. It does **not** bump versions, tag, or cut releases — those are human-gated by design (the doc's "big footgun" and pre-release-checkbox discipline depend on a person deciding each one). The recipe section and the step-3 table row now point at the script; the manual recipe stays as the explanation of *why*.

### Validated
Ran green against both indexes during review:
- `scripts/smoke-test-release.sh 0.7.0 pypi` → PASS
- `scripts/smoke-test-release.sh 0.7.0rc1 testpypi` → PASS

`bash -n` clean (no shellcheck in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)