### PR TITLE
fix(text): replace reactive 429 backoff with AIMD pacing and window-aware cooldowns

### DIFF
--- a/src/concord/text.py
+++ b/src/concord/text.py
@@ -9,36 +9,50 @@ dropped but their inner text preserved.
 No bs4, no lxml — the format is stable enough that one stdlib parser does the
 job and removes a dependency the rest of the project doesn't need.
 
-Retry policy
-------------
+Pacing and retry policy
+-----------------------
 
 The ``www.congress.gov`` HTML tier is a separate service from
 ``api.congress.gov``: it sits behind Cloudflare and has its own (undocumented)
-rate limit. A bulk pull of many articles trips two distinct Cloudflare signals,
-and the limit is enforced **per client across every URL**, not per request —
-so the backoff state lives on a single :class:`AdaptiveThrottle` shared by all
-fetches in a run, not inside one URL's retry loop (see ADR 0002's "JSONL is
-canonical, re-runs are cheap" — being throttled is a wait, never a data loss):
+rate limit, enforced **per client across every URL**, not per request — so the
+pacing state lives on a single :class:`AdaptiveThrottle` shared by all fetches
+in a run, not inside one URL's retry loop (see ADR 0002's "JSONL is canonical,
+re-runs are cheap" — being throttled is a wait, never a data loss).
 
-* HTTP 429 (Cloudflare rate-limit rule): typically carries a ``Retry-After``;
-  we honor it. Retry **indefinitely**.
-* HTTP 403 (Cloudflare bot/WAF block): a block page with **no** ``Retry-After``,
-  so there is no server hint to honor. Treated as the same throttle signal as
-  429 and retried **indefinitely**, but the wait comes from our own adaptive
-  backoff. This is the case a flat retry handles badly, which is why the
-  throttle escalates and persists across URLs rather than resetting per fetch.
+The throttle is *proactive*, not merely reactive. Cloudflare rate-limit rules
+work on windows: once tripped, the client stays blocked for the remainder of
+the rule's window (minutes, not seconds), and requests made inside the window
+are wasted. Running full speed until the first 429 therefore guarantees a
+long stall. Instead the throttle paces **every** request (AIMD — additive
+decrease of the inter-request gap on success, multiplicative increase on
+throttle) with random jitter so the request stream never looks
+machine-regular, and treats a throttle response as a *window* signal:
+
+* Every request first waits the current pace (starts at
+  :data:`_INITIAL_PACE`, decays toward :data:`_MIN_PACE` over clean fetches,
+  doubles per throttle hit up to :data:`_MAX_PACE`), jittered ±50%.
+* HTTP 429 (Cloudflare rate-limit rule) and HTTP 403 (Cloudflare bot/WAF
+  block, which carries no ``Retry-After``) are the same throttle signal.
+  Both are retried **indefinitely** after a cooldown of
+  ``max(Retry-After, 30s doubling per consecutive strike)`` capped at
+  :data:`MAX_COOLDOWN` — retrying every minute inside a multi-minute block
+  window (the old behavior) only burns requests, so consecutive strikes wait
+  out progressively more of the window. Cooldowns are jittered upward so
+  retries don't synchronize with the window boundary.
 * HTTP 5xx and transport errors (DNS, timeout, connection reset): genuine
   faults — retry up to :data:`MAX_5XX_RETRIES` times with exponential backoff
-  before surfacing a :class:`TextFetchError`. These are tracked per fetch and
-  are kept separate from throttling, which never counts against that budget.
+  (capped at :data:`MAX_BACKOFF`) before surfacing a :class:`TextFetchError`.
+  These are tracked per fetch and kept separate from throttling, which never
+  counts against that budget.
 
-Both throttle signals escalate one :class:`AdaptiveThrottle` level per hit and
-relax one level per :data:`_DECAY_AFTER_SUCCESSES` clean fetches, so a steady
-drip of "one 403 per URL" ratchets the backoff up instead of oscillating at the
-floor. Retry decisions are logged via :mod:`logging` (logger ``concord.text``).
+Strikes reset on the first clean fetch, but the *pace* does not: it decays
+additively, so a steady drip of "one 403 per URL" still ratchets the request
+rate down instead of oscillating at the floor. Retry decisions are logged via
+:mod:`logging` (logger ``concord.text``).
 """
 
 import logging
+import random
 import time
 from collections.abc import Callable
 from html.parser import HTMLParser
@@ -54,9 +68,9 @@ from concord.api import (
 from concord.models.runs import Attempt
 from concord.observability import Recorder, active_recorder
 
-#: Cap on a single backoff delay, in seconds. Applied to both the exponential
-#: schedule and Retry-After values so a server-suggested 1-hour wait can't
-#: silently stall the pipeline.
+#: Cap on a single 5xx/transport backoff delay, in seconds. Throttle cooldowns
+#: have their own, much higher cap (:data:`MAX_COOLDOWN`) — a Cloudflare block
+#: window outlasts 60s, but a flapping origin server shouldn't.
 MAX_BACKOFF = 60.0
 
 #: Maximum retries for transient 5xx / transport failures before surfacing
@@ -111,78 +125,120 @@ class _PreExtractor(HTMLParser):
         return "".join(self._chunks).strip()
 
 
-#: Consecutive clean fetches required to relax the throttle one level. Decay is
-#: deliberately slower than the one-level-per-throttle climb so a steady drip of
-#: "one 403 per URL" still ratchets the backoff up rather than oscillating at the
-#: 1s floor (a single success would otherwise cancel a single 403).
-_DECAY_AFTER_SUCCESSES = 3
+#: Inter-request gap, in seconds, when a run starts. Deliberately non-zero:
+#: full speed until the first 429 means entering the Cloudflare block window
+#: at maximum velocity. Low and slow finishes sooner than fast and blocked.
+_INITIAL_PACE = 1.0
 
-#: Cap on the throttle level. At this level the exponential backoff has already
-#: saturated :data:`MAX_BACKOFF`; capping bounds how long recovery takes after a
-#: sustained block (``_MAX_THROTTLE_LEVEL * _DECAY_AFTER_SUCCESSES`` clean
-#: fetches to fully relax).
-_MAX_THROTTLE_LEVEL = 7
+#: Floor the pace decays toward over sustained clean fetches. Never zero —
+#: every request stays paced.
+_MIN_PACE = 0.5
+
+#: Ceiling on the inter-request pace after repeated throttling.
+_MAX_PACE = 30.0
+
+#: Additive pace decrease per clean fetch (the AI half of AIMD). Small on
+#: purpose: recovering the 1s lost to one pace-doubling takes ~20 clean
+#: fetches, so a steady drip of "one 403 per URL" ratchets the rate down
+#: rather than oscillating at the floor.
+_PACE_DECAY = 0.05
+
+#: Multiplicative pace increase per throttle hit (the MD half of AIMD).
+_PACE_GROWTH = 2.0
+
+#: Pace jitter band: each pace wait is ``pace * uniform(LO, HI)``. A
+#: machine-regular request cadence is itself a bot signal; jitter also keeps
+#: retries from synchronizing with the rate-limit window.
+_PACE_JITTER_LO = 0.5
+_PACE_JITTER_HI = 1.5
+
+#: First-strike throttle cooldown, in seconds, doubling per consecutive
+#: strike. A 429/403 means the rate-limit window is already tripped; waits
+#: shorter than the window remainder are pure waste.
+_COOLDOWN_BASE = 30.0
+
+_COOLDOWN_GROWTH = 2.0
+
+#: Cap on a single throttle cooldown and on honored ``Retry-After`` values,
+#: in seconds (15 min — a realistic Cloudflare window, unlike the old 60s cap
+#: that kept re-entering the block window). Bounds how long a misbehaving
+#: server can park the pipeline per retry.
+MAX_COOLDOWN = 900.0
+
+#: Upward-only jitter fraction on cooldowns: waiting slightly longer than the
+#: hint/schedule is cheap; retrying exactly at the window boundary risks
+#: another strike.
+_COOLDOWN_JITTER = 0.25
 
 
 class AdaptiveThrottle:
-    """Client-level adaptive backoff shared across every article fetch in a run.
+    """Client-level AIMD pacer shared across every article fetch in a run.
 
     congress.gov enforces its limit per client, not per request, so a single
-    instance is threaded through all :func:`fetch_text` calls: the level climbs
-    one step per 403/429 and relaxes one step per :data:`_DECAY_AFTER_SUCCESSES`
-    clean fetches. :meth:`pace` proactively slows the *next* request once the
-    level is raised (so a recovered fetch doesn't immediately re-trip the
-    limit); :meth:`penalize` performs the post-throttle retry wait, honoring a
-    server ``Retry-After`` when present and otherwise backing off exponentially.
+    instance is threaded through all :func:`fetch_text` calls. :meth:`pace`
+    waits the current jittered inter-request gap before *every* request — the
+    throttle is proactive, not a reaction to the first 429. :meth:`penalize`
+    handles a throttle response: it doubles the pace and sleeps out a cooldown
+    sized to the Cloudflare block window (``max(Retry-After, escalating
+    schedule)``), doubling per consecutive strike. :meth:`recover` notes a
+    clean fetch: strikes reset, and the pace decays additively toward the
+    floor.
 
-    Throttle waits never count against the 5xx fault budget — being blocked is a
-    wait condition, not a fault. ``sleep`` is injectable so tests don't pay real
-    wall time.
+    Throttle waits never count against the 5xx fault budget — being blocked is
+    a wait condition, not a fault. ``sleep`` and ``rng`` are injectable so
+    tests don't pay real wall time and aren't at the mercy of jitter
+    (``rng()`` must return a float in ``[0, 1)``; the default is
+    :func:`random.random`).
     """
 
-    def __init__(self, *, sleep: Callable[[float], None] = time.sleep) -> None:
+    def __init__(
+        self,
+        *,
+        sleep: Callable[[float], None] = time.sleep,
+        rng: Callable[[], float] = random.random,
+    ) -> None:
         self._sleep = sleep
-        self._level = 0
-        self._ok_streak = 0
+        self._rng = rng
+        self._pace = _INITIAL_PACE
+        self._strikes = 0
 
     @property
-    def level(self) -> int:
-        """Current throttle level (0 when healthy). Exposed for tests/logging."""
-        return self._level
+    def pace_seconds(self) -> float:
+        """Current un-jittered inter-request gap. Exposed for tests/logging."""
+        return self._pace
+
+    @property
+    def strikes(self) -> int:
+        """Consecutive throttle responses since the last clean fetch."""
+        return self._strikes
 
     def pace(self) -> None:
-        """Wait the current throttle delay before a request (no-op when healthy)."""
-        if self._level > 0:
-            self._sleep(self._delay())
+        """Wait the jittered inter-request gap. Applies to every request."""
+        jitter = _PACE_JITTER_LO + (_PACE_JITTER_HI - _PACE_JITTER_LO) * self._rng()
+        self._sleep(self._pace * jitter)
 
     def penalize(self, retry_after: float | None) -> float:
-        """Record a throttle response, sleep the retry wait, return the delay used.
+        """Record a throttle response, sleep out the cooldown, return the delay used.
 
-        Honors ``retry_after`` when the server supplied one (Cloudflare 429s do);
-        otherwise falls back to the exponential schedule for the newly raised
-        level (Cloudflare 403s don't).
+        The cooldown is the larger of the server's ``Retry-After`` (Cloudflare
+        429s carry one; 403s don't) and the escalating per-strike schedule —
+        a hint shorter than the schedule is distrusted, because consecutive
+        strikes mean honoring it just re-entered the block window. Jittered
+        upward, capped at :data:`MAX_COOLDOWN`. Also doubles the pace, so the
+        request rate after recovery stays below whatever tripped the limit.
         """
-        self._level = min(self._level + 1, _MAX_THROTTLE_LEVEL)
-        self._ok_streak = 0
-        delay = retry_after if retry_after is not None else self._delay()
+        self._strikes += 1
+        self._pace = min(self._pace * _PACE_GROWTH, _MAX_PACE)
+        scheduled = _COOLDOWN_BASE * _COOLDOWN_GROWTH ** (self._strikes - 1)
+        base = max(retry_after if retry_after is not None else 0.0, scheduled)
+        delay = min(base * (1.0 + _COOLDOWN_JITTER * self._rng()), MAX_COOLDOWN)
         self._sleep(delay)
         return delay
 
     def recover(self) -> None:
-        """Note a clean fetch; relax one level after enough consecutive successes."""
-        if self._level == 0:
-            return
-        self._ok_streak += 1
-        if self._ok_streak >= _DECAY_AFTER_SUCCESSES:
-            self._level -= 1
-            self._ok_streak = 0
-
-    def _delay(self) -> float:
-        """Exponential backoff for the current level, capped at :data:`MAX_BACKOFF`.
-
-        Level 1 → 1s, 2 → 2s, 3 → 4s, … saturating at the cap.
-        """
-        return min(_BACKOFF_BASE ** (self._level - 1), MAX_BACKOFF)
+        """Note a clean fetch: reset strikes, decay the pace toward the floor."""
+        self._strikes = 0
+        self._pace = max(self._pace - _PACE_DECAY, _MIN_PACE)
 
 
 def fetch_text(
@@ -199,12 +255,13 @@ def fetch_text(
     followed automatically. Transient failures (429, 403, 5xx, transport
     errors) are retried per the module-level policy.
 
-    ``throttle`` is the shared :class:`AdaptiveThrottle` carrying rate-limit
-    state across every fetch in a run; pass one instance for a whole pull so
-    throttling congress.gov slows *subsequent* URLs too. When omitted, a fresh
-    per-call throttle is used (fine for one-off fetches and tests). ``sleep`` is
-    injectable so tests don't pay real wall time; it also seeds the default
-    throttle's clock.
+    ``throttle`` is the shared :class:`AdaptiveThrottle` carrying pacing state
+    across every fetch in a run; pass one instance for a whole pull so the
+    request rate adapts across URLs. When omitted, a fresh per-call throttle is
+    used (fine for one-off fetches and tests, at the cost of the initial ~1s
+    pace — every request is paced, even healthy ones). ``sleep`` is injectable
+    so tests don't pay real wall time; it also seeds the default throttle's
+    clock.
 
     Raises :class:`TextFetchError` on:
 
@@ -242,9 +299,9 @@ def _get_with_retry(
     rec = active_recorder()
     attempts: list[Attempt] = []
 
-    # Proactively wait out any backoff carried over from earlier URLs before the
-    # first attempt — congress.gov rate-limits per client, so hammering the next
-    # URL immediately after a throttle just re-trips the limit.
+    # Every request is paced, healthy or not — the gap carries over from earlier
+    # URLs because congress.gov rate-limits per client, and going full speed
+    # until the first 429 just enters the block window at maximum velocity.
     throttle.pace()
     transient_attempts = 0
     while True:
@@ -273,13 +330,17 @@ def _get_with_retry(
             # do not increment transient_attempts — being blocked is a wait
             # condition, not a fault, and must not burn the 5xx budget.
             _note_attempt(attempts, status=status, message=response.reason_phrase)
-            delay = throttle.penalize(_retry_after_seconds(response))
+            retry_after = _retry_after_seconds(response)
+            delay = throttle.penalize(retry_after)
             _log.warning(
-                "%d from %s (rate-limited?); backing off %.1fs before retry (level %d)",
+                "%d from %s (rate-limited?); cooling down %.1fs before retry "
+                "(Retry-After: %s, strike %d, pace now %.2fs/req)",
                 status,
                 url,
                 delay,
-                throttle.level,
+                _format_retry_after(retry_after),
+                throttle.strikes,
+                throttle.pace_seconds,
             )
             continue
 
@@ -387,9 +448,9 @@ def _retry_after_seconds(response: httpx.Response) -> float | None:
     """Parse the ``Retry-After`` header, if any, as seconds.
 
     Supports the integer-seconds form. Returns ``None`` for the HTTP-date
-    form or when the header is missing/unparseable; callers fall back to
-    exponential backoff in that case. The result is clamped to
-    :data:`MAX_BACKOFF` so a misbehaving server can't park us forever.
+    form or when the header is missing/unparseable; callers fall back to the
+    cooldown schedule in that case. The result is clamped to
+    :data:`MAX_COOLDOWN` so a misbehaving server can't park us forever.
     """
     raw = response.headers.get("retry-after")
     if not raw:
@@ -398,4 +459,13 @@ def _retry_after_seconds(response: httpx.Response) -> float | None:
         seconds = float(raw.strip())
     except ValueError:
         return None
-    return min(max(seconds, 0.0), MAX_BACKOFF)
+    return min(max(seconds, 0.0), MAX_COOLDOWN)
+
+
+def _format_retry_after(retry_after: float | None) -> str:
+    """Render the parsed (clamped) ``Retry-After`` for the throttle log line.
+
+    ``"none"`` when the header was absent or unparseable — so the log shows
+    whether a cooldown came from the server's hint or our own strike schedule.
+    """
+    return "none" if retry_after is None else f"{retry_after:.0f}s"

--- a/src/concord/text.py
+++ b/src/concord/text.py
@@ -159,6 +159,12 @@ _COOLDOWN_BASE = 30.0
 
 _COOLDOWN_GROWTH = 2.0
 
+#: Strikes beyond this stop growing the cooldown schedule — it has already
+#: saturated :data:`MAX_COOLDOWN` (30 x 2^5 = 960 > 900), and an unbounded
+#: exponent would eventually overflow on a permanent block ("retried
+#: indefinitely" means wait forever, not crash at strike 1025).
+_MAX_COOLDOWN_DOUBLINGS = 5
+
 #: Cap on a single throttle cooldown and on honored ``Retry-After`` values,
 #: in seconds (15 min — a realistic Cloudflare window, unlike the old 60s cap
 #: that kept re-entering the block window). Bounds how long a misbehaving
@@ -229,7 +235,8 @@ class AdaptiveThrottle:
         """
         self._strikes += 1
         self._pace = min(self._pace * _PACE_GROWTH, _MAX_PACE)
-        scheduled = _COOLDOWN_BASE * _COOLDOWN_GROWTH ** (self._strikes - 1)
+        doublings = min(self._strikes - 1, _MAX_COOLDOWN_DOUBLINGS)
+        scheduled = _COOLDOWN_BASE * _COOLDOWN_GROWTH**doublings
         base = max(retry_after if retry_after is not None else 0.0, scheduled)
         delay = min(base * (1.0 + _COOLDOWN_JITTER * self._rng()), MAX_COOLDOWN)
         self._sleep(delay)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -358,7 +358,8 @@ def wired_components(
     text_http = httpx.Client(transport=text_transport)
     client = Client(api_key="test", transport=api_transport)
     storage = JsonlStorage(tmp_path / "out.jsonl")
-    return client, lambda url: fetch_text(url, text_http), storage
+    # No-op sleep: fetch_text paces every request now, even healthy ones.
+    return client, lambda url: fetch_text(url, text_http, sleep=lambda _s: None), storage
 
 
 class TestIntegration:
@@ -459,7 +460,7 @@ class TestResume:
             call_count["n"] += 1
             if call_count["n"] > 7:
                 raise RuntimeError("simulated crash")
-            return fetch_text(url, text_http_1)
+            return fetch_text(url, text_http_1, sleep=lambda _s: None)
 
         with client_1, pytest.raises(RuntimeError, match="simulated crash"):
             pull(
@@ -489,7 +490,7 @@ class TestResume:
                 date(2026, 5, 22),
                 date(2026, 5, 22),
                 client=client_2,
-                fetch=lambda url: fetch_text(url, text_http_2),
+                fetch=lambda url: fetch_text(url, text_http_2, sleep=lambda _s: None),
                 storage=storage_2,
                 now=_now,
             )

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -308,7 +308,9 @@ class TestAdaptiveThrottle:
     def test_cooldown_and_pace_are_capped(self) -> None:
         slept: list[float] = []
         throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
-        for _ in range(20):
+        # Far past where 2**strikes would overflow a float if the schedule's
+        # exponent were unbounded — a permanent block must wait, not crash.
+        for _ in range(1100):
             throttle.penalize(None)
         assert throttle.penalize(None) == MAX_COOLDOWN
         assert max(slept) == MAX_COOLDOWN

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 
 from concord.text import (
-    MAX_BACKOFF,
+    MAX_COOLDOWN,
     AdaptiveThrottle,
     TextFetchError,
     fetch_text,
@@ -21,6 +21,15 @@ def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
 
 def _ok(body: str) -> httpx.Response:
     return httpx.Response(200, text=body, headers={"content-type": "text/html"})
+
+
+def _no_sleep(_seconds: float) -> None:
+    """No-op sleep: pacing applies to every request, so tests must opt out."""
+
+
+def _low_jitter() -> float:
+    """rng pinned to the band's low edge: pace x 0.5, cooldown x 1.0."""
+    return 0.0
 
 
 SAMPLE_URL = (
@@ -39,7 +48,7 @@ class TestFetchTextHappyPath:
     def test_extracts_plain_text(self, fixtures_dir: Path, fixture: str) -> None:
         html = (fixtures_dir / fixture).read_text()
         with _client(lambda r: _ok(html)) as client:
-            text = fetch_text(SAMPLE_URL, client)
+            text = fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
         # Real articles always have substantive content; strip removes
         # leading/trailing whitespace inside <pre>.
         assert len(text) > 100
@@ -54,7 +63,7 @@ class TestFetchTextHappyPath:
         # Verify the visible text survives while the anchor tag is dropped.
         html = (fixtures_dir / "articles/house.html").read_text()
         with _client(lambda r: _ok(html)) as client:
-            text = fetch_text(SAMPLE_URL, client)
+            text = fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
         assert "www.gpo.gov" in text
         assert "https://www.gpo.gov" not in text  # the href attribute is dropped
         # Specific content from the fixture survives unchanged.
@@ -63,7 +72,7 @@ class TestFetchTextHappyPath:
     def test_strips_leading_and_trailing_whitespace(self) -> None:
         html = "<pre>\n\n  hello world  \n\n</pre>"
         with _client(lambda r: _ok(html)) as client:
-            text = fetch_text(SAMPLE_URL, client)
+            text = fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
         assert text == "hello world"
 
 
@@ -76,14 +85,14 @@ class TestFetchTextParseErrors:
             _client(lambda r: _ok("<html><body>nothing useful</body></html>")) as client,
             pytest.raises(TextFetchError, match="no <pre> content"),
         ):
-            fetch_text(SAMPLE_URL, client)
+            fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
 
     def test_empty_pre_block_raises(self) -> None:
         with (
             _client(lambda r: _ok("<pre>   \n   </pre>")) as client,
             pytest.raises(TextFetchError, match="no <pre> content"),
         ):
-            fetch_text(SAMPLE_URL, client)
+            fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
 
 
 # -- HTTP / transport errors --------------------------------------------------
@@ -103,7 +112,7 @@ class TestFetchTextNetworkErrors:
             _client(handler) as client,
             pytest.raises(TextFetchError) as exc,
         ):
-            fetch_text(SAMPLE_URL, client, sleep=lambda _s: None)
+            fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
         assert exc.value.status_code == status
         assert calls == 1
 
@@ -120,7 +129,7 @@ class TestFetchTextNetworkErrors:
             _client(handler) as client,
             pytest.raises(TextFetchError) as exc,
         ):
-            fetch_text(SAMPLE_URL, client, sleep=lambda _s: None)
+            fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
         assert exc.value.status_code == status
         # 1 initial + MAX_5XX_RETRIES retries
         assert calls == 6
@@ -128,7 +137,7 @@ class TestFetchTextNetworkErrors:
     def test_5xx_then_success(self) -> None:
         responses = iter([httpx.Response(503), _ok("<pre>recovered</pre>")])
         with _client(lambda r: next(responses)) as client:
-            text = fetch_text(SAMPLE_URL, client, sleep=lambda _s: None)
+            text = fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
         assert text == "recovered"
 
     def test_transport_error_retried_then_surfaces(self) -> None:
@@ -143,41 +152,59 @@ class TestFetchTextNetworkErrors:
             _client(handler) as client,
             pytest.raises(TextFetchError, match="transport error") as exc,
         ):
-            fetch_text(SAMPLE_URL, client, sleep=lambda _s: None)
+            fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
         assert exc.value.status_code is None
         assert calls == 6
 
 
 class TestFetchTextRateLimit:
-    def test_429_retries_until_success(self) -> None:
+    def test_429_cooldowns_escalate_per_strike(self) -> None:
         responses = iter(
             [
                 httpx.Response(429),
                 httpx.Response(429),
-                _ok("<pre>after backoff</pre>"),
+                _ok("<pre>after cooldown</pre>"),
             ]
         )
         slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
         with _client(lambda r: next(responses)) as client:
-            text = fetch_text(SAMPLE_URL, client, sleep=slept.append)
-        assert text == "after backoff"
-        # Two 429s -> two sleeps, and the backoff *escalates* (1s, then 2s)
-        # rather than sitting at a flat 1s — the bug this fix exists for.
-        assert slept == [1.0, 2.0]
+            text = fetch_text(SAMPLE_URL, client, throttle=throttle)
+        assert text == "after cooldown"
+        # Initial pace (1.0s x low-edge jitter 0.5), then window-sized cooldowns
+        # that double per consecutive strike — not the old 1s/2s nibbles that
+        # kept re-entering the Cloudflare block window.
+        assert slept == [0.5, 30.0, 60.0]
 
-    def test_429_honors_retry_after_header(self) -> None:
+    def test_429_honors_retry_after_when_longer_than_schedule(self) -> None:
         responses = iter(
             [
-                httpx.Response(429, headers={"retry-after": "7"}),
+                httpx.Response(429, headers={"retry-after": "300"}),
                 _ok("<pre>ok</pre>"),
             ]
         )
         slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
         with _client(lambda r: next(responses)) as client:
-            fetch_text(SAMPLE_URL, client, sleep=slept.append)
-        assert slept == [7.0]
+            fetch_text(SAMPLE_URL, client, throttle=throttle)
+        assert slept == [0.5, 300.0]
 
-    def test_429_retry_after_clamped_to_max_backoff(self) -> None:
+    def test_429_distrusts_retry_after_shorter_than_schedule(self) -> None:
+        # A 5s hint on the first strike is below the 30s window schedule;
+        # honoring short hints is how the old scheme kept getting re-blocked.
+        responses = iter(
+            [
+                httpx.Response(429, headers={"retry-after": "5"}),
+                _ok("<pre>ok</pre>"),
+            ]
+        )
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
+        with _client(lambda r: next(responses)) as client:
+            fetch_text(SAMPLE_URL, client, throttle=throttle)
+        assert slept == [0.5, 30.0]
+
+    def test_429_retry_after_clamped_to_max_cooldown(self) -> None:
         responses = iter(
             [
                 httpx.Response(429, headers={"retry-after": "99999"}),
@@ -185,100 +212,144 @@ class TestFetchTextRateLimit:
             ]
         )
         slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
         with _client(lambda r: next(responses)) as client:
-            fetch_text(SAMPLE_URL, client, sleep=slept.append)
-        assert slept == [MAX_BACKOFF]
+            fetch_text(SAMPLE_URL, client, throttle=throttle)
+        assert slept == [0.5, MAX_COOLDOWN]
 
     def test_429_does_not_count_against_5xx_budget(self) -> None:
         # Many 429s followed by success: must not exhaust the 5xx retry budget.
         sequence = [httpx.Response(429)] * 20 + [_ok("<pre>finally</pre>")]
         responses = iter(sequence)
         with _client(lambda r: next(responses)) as client:
-            text = fetch_text(SAMPLE_URL, client, sleep=lambda _s: None)
+            text = fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
         assert text == "finally"
 
-    def test_403_retries_until_success(self) -> None:
-        # congress.gov uses 403 as a rate-limit signal; must back off and retry.
+    def test_403_treated_as_throttle_signal(self) -> None:
+        # congress.gov uses 403 as a rate-limit signal; it carries no
+        # Retry-After, so the escalating cooldown schedule is all we have.
         responses = iter(
             [
                 httpx.Response(403),
                 httpx.Response(403),
-                _ok("<pre>after 403 backoff</pre>"),
+                _ok("<pre>after 403 cooldown</pre>"),
             ]
         )
         slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
         with _client(lambda r: next(responses)) as client:
-            text = fetch_text(SAMPLE_URL, client, sleep=slept.append)
-        assert text == "after 403 backoff"
-        # 403s escalate identically to 429s (1s, then 2s) — congress.gov's 403
-        # carries no Retry-After, so our own escalating backoff is all we have.
-        assert slept == [1.0, 2.0]
+            text = fetch_text(SAMPLE_URL, client, throttle=throttle)
+        assert text == "after 403 cooldown"
+        assert slept == [0.5, 30.0, 60.0]
 
-    def test_403_honors_retry_after_header(self) -> None:
+    def test_cooldown_log_reports_retry_after(self, caplog: pytest.LogCaptureFixture) -> None:
+        # The log distinguishes a server-hinted cooldown from our own strike
+        # schedule: 429s carry the parsed Retry-After, 403s log "none".
         responses = iter(
             [
-                httpx.Response(403, headers={"retry-after": "5"}),
+                httpx.Response(429, headers={"retry-after": "300"}),
+                httpx.Response(403),
                 _ok("<pre>ok</pre>"),
             ]
         )
-        slept: list[float] = []
-        with _client(lambda r: next(responses)) as client:
-            fetch_text(SAMPLE_URL, client, sleep=slept.append)
-        assert slept == [5.0]
+        throttle = AdaptiveThrottle(sleep=lambda _s: None, rng=_low_jitter)
+        with (
+            caplog.at_level("WARNING", logger="concord.text"),
+            _client(lambda r: next(responses)) as client,
+        ):
+            fetch_text(SAMPLE_URL, client, throttle=throttle)
+        assert "Retry-After: 300s" in caplog.messages[0]
+        assert "Retry-After: none" in caplog.messages[1]
 
     def test_403_does_not_count_against_5xx_budget(self) -> None:
         # Many 403s followed by success must not exhaust the 5xx retry budget.
         sequence = [httpx.Response(403)] * 20 + [_ok("<pre>finally</pre>")]
         responses = iter(sequence)
         with _client(lambda r: next(responses)) as client:
-            text = fetch_text(SAMPLE_URL, client, sleep=lambda _s: None)
+            text = fetch_text(SAMPLE_URL, client, sleep=_no_sleep)
         assert text == "finally"
 
 
 class TestAdaptiveThrottle:
-    """The client-level backoff that persists across URLs in a run."""
+    """The client-level AIMD pacer that persists across URLs in a run."""
 
-    def test_escalates_and_recovers(self) -> None:
+    def test_paces_every_request_even_when_healthy(self) -> None:
         slept: list[float] = []
-        throttle = AdaptiveThrottle(sleep=slept.append)
-
-        # Healthy: pacing is a no-op.
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
         throttle.pace()
-        assert slept == []
-        assert throttle.level == 0
+        # 1.0s initial pace x 0.5 low-edge jitter: never full speed, even
+        # before the first throttle response.
+        assert slept == [0.5]
 
-        # Each throttle hit escalates the backoff and the level.
-        assert throttle.penalize(None) == 1.0
-        assert throttle.penalize(None) == 2.0
-        assert throttle.penalize(None) == 4.0
-        assert throttle.level == 3
-
-        # A Retry-After header overrides the schedule but still escalates level.
-        assert throttle.penalize(30.0) == 30.0
-        assert throttle.level == 4
-        assert slept == [1.0, 2.0, 4.0, 30.0]
-
-        # Clean fetches relax one level only after _DECAY_AFTER_SUCCESSES of them,
-        # so a single success can't cancel a throttle.
-        throttle.recover()
-        throttle.recover()
-        assert throttle.level == 4
-        throttle.recover()
-        assert throttle.level == 3
-
-    def test_level_and_delay_are_capped(self) -> None:
+    def test_pace_jitter_spans_the_band(self) -> None:
         slept: list[float] = []
-        throttle = AdaptiveThrottle(sleep=slept.append)
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=lambda: 1.0)
+        throttle.pace()
+        # rng at the top of the band: 1.0s pace x 1.5 jitter.
+        assert slept == [1.5]
+
+    def test_penalize_doubles_pace_and_escalates_cooldown(self) -> None:
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
+        assert throttle.penalize(None) == 30.0
+        assert throttle.penalize(None) == 60.0
+        assert throttle.penalize(None) == 120.0
+        assert throttle.strikes == 3
+        # Pace doubled per strike: 1 → 2 → 4 → 8.
+        assert throttle.pace_seconds == 8.0
+
+    def test_cooldown_jitter_is_upward_only(self) -> None:
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=lambda: 1.0)
+        # rng at the top of the band: 30s schedule x 1.25 — retries land past
+        # the window boundary, never before it.
+        assert throttle.penalize(None) == pytest.approx(37.5)
+
+    def test_cooldown_and_pace_are_capped(self) -> None:
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
         for _ in range(20):
             throttle.penalize(None)
-        # Level saturates and the per-wait delay never exceeds MAX_BACKOFF.
-        assert throttle.level == 7
-        assert throttle.penalize(None) == MAX_BACKOFF
-        assert max(slept) == MAX_BACKOFF
+        assert throttle.penalize(None) == MAX_COOLDOWN
+        assert max(slept) == MAX_COOLDOWN
+        assert throttle.pace_seconds == 30.0
 
-    def test_backoff_persists_across_urls(self) -> None:
+    def test_retry_after_overrides_schedule_only_upward(self) -> None:
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
+        # Longer than the 30s first-strike schedule: honored.
+        assert throttle.penalize(120.0) == 120.0
+        # Shorter than the 60s second-strike schedule: distrusted.
+        assert throttle.penalize(5.0) == 60.0
+
+    def test_recover_resets_strikes_but_decays_pace_slowly(self) -> None:
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
+        throttle.penalize(None)
+        assert throttle.strikes == 1
+        throttle.recover()
+        assert throttle.strikes == 0
+        # One clean fetch claws back only _PACE_DECAY of the doubled pace —
+        # a steady drip of "one 403 per URL" still ratchets the rate down.
+        assert throttle.pace_seconds == pytest.approx(1.95)
+        # Strikes reset means the next cooldown starts back at the base…
+        assert throttle.penalize(None) == 30.0
+        # …but the pace keeps compounding.
+        assert throttle.pace_seconds == pytest.approx(3.9)
+
+    def test_pace_decays_to_floor_not_zero(self) -> None:
+        slept: list[float] = []
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
+        for _ in range(100):
+            throttle.recover()
+        assert throttle.pace_seconds == 0.5
+        throttle.pace()
+        # Floor pace x low-edge jitter: still never zero.
+        assert slept == [0.25]
+
+    def test_pacing_persists_across_urls(self) -> None:
         # A shared throttle threaded through two fetches: the first URL's 403s
-        # leave the level raised, so the second URL is *paced* before its very
+        # double the pace, so the second URL is paced harder before its very
         # first request — even though that request would have succeeded.
         responses = iter(
             [
@@ -289,24 +360,33 @@ class TestAdaptiveThrottle:
             ]
         )
         slept: list[float] = []
-        throttle = AdaptiveThrottle(sleep=slept.append)
+        throttle = AdaptiveThrottle(sleep=slept.append, rng=_low_jitter)
         with _client(lambda r: next(responses)) as client:
             first = fetch_text(SAMPLE_URL, client, throttle=throttle)
             second = fetch_text(SAMPLE_URL, client, throttle=throttle)
         assert (first, second) == ("first", "second")
-        # URL 1: penalize 1s, 2s (climbs to level 2). URL 2: pace 2s up front.
-        assert slept == [1.0, 2.0, 2.0]
-        assert throttle.level == 2
+        # URL 1: pace 0.5, cooldowns 30/60 (pace climbs to 4.0), success decays
+        # it to 3.95. URL 2: paced at 3.95 x 0.5 up front; its own success
+        # decays the pace once more.
+        assert slept == pytest.approx([0.5, 30.0, 60.0, 1.975])
+        assert throttle.pace_seconds == pytest.approx(3.90)
 
     def test_per_call_throttle_does_not_leak_state(self) -> None:
-        # Omitting `throttle` gives each call a fresh one — no cross-call pacing.
+        # Omitting `throttle` gives each call a fresh one — no cross-call
+        # pacing. Default throttles keep real jitter, so assert on shape
+        # (sleep count, cooldown magnitude) rather than exact values.
         responses = iter([httpx.Response(403), _ok("<pre>a</pre>"), _ok("<pre>b</pre>")])
-        slept: list[float] = []
+        slept_first: list[float] = []
+        slept_second: list[float] = []
         with _client(lambda r: next(responses)) as client:
-            fetch_text(SAMPLE_URL, client, sleep=slept.append)
-            fetch_text(SAMPLE_URL, client, sleep=slept.append)
-        # Only the first call's single 403 slept; the second starts fresh (no pace).
-        assert slept == [1.0]
+            fetch_text(SAMPLE_URL, client, sleep=slept_first.append)
+            fetch_text(SAMPLE_URL, client, sleep=slept_second.append)
+        # First call: one pace + one 403 cooldown.
+        assert len(slept_first) == 2
+        assert slept_first[1] >= 30.0
+        # Second call: a fresh throttle paces once and never cools down.
+        assert len(slept_second) == 1
+        assert slept_second[0] < 30.0
 
 
 # -- redirect handling --------------------------------------------------------
@@ -328,7 +408,7 @@ class TestFetchTextRedirects:
             return _ok("<pre>redirected content</pre>")
 
         with _client(handler) as client:
-            text = fetch_text("https://example.com/start", client)
+            text = fetch_text("https://example.com/start", client, sleep=_no_sleep)
 
         assert text == "redirected content"
         # Both URLs were hit — proving redirect was followed.


### PR DESCRIPTION
## Problem

`concord scrape proceedings` was stalling indefinitely on congress.gov 429s. The old `AdaptiveThrottle` was purely reactive and mis-modeled Cloudflare: it ran full speed until the first 429, then retried on a 1/2/4/…/60s schedule with `MAX_BACKOFF = 60` clamping everything — including `Retry-After`. Cloudflare rate-limit rules are window-based: once tripped, the client stays blocked for the remainder of the window (minutes), so retrying every 60s inside the window looped forever at "level 7":

```
429 from <url> (rate-limited?); backing off 60.0s before retry (level 7)
429 from <url> (rate-limited?); backing off 60.0s before retry (level 7)
429 from <url> (rate-limited?); backing off 60.0s before retry (level 7)
```

## Approach

`AdaptiveThrottle` is now a proactive AIMD pacer — low and slow beats fast and blocked:

- **Every request is paced**, healthy or not: 1s initial gap, additive 0.05s decay toward a 0.5s floor per clean fetch, doubling per throttle hit up to 30s. Decay is much slower than the doubling, so a steady drip of occasional 403s ratchets the rate down instead of oscillating.
- **Jitter everywhere**: pace waits × uniform(0.5, 1.5) — a machine-regular cadence is itself a bot signal — and cooldowns get upward-only jitter (×1.0–1.25) so retries never land exactly on the window boundary.
- **Window-sized cooldowns**: a 429/403 waits `max(Retry-After, 30s doubling per consecutive strike)`, capped at a new `MAX_COOLDOWN` of 15 min. Hints shorter than the schedule are distrusted. Strikes reset on the first clean fetch; the elevated pace persists.
- `MAX_BACKOFF` (60s) now applies only to 5xx/transport retries, where it belongs.
- The log line reports the effective cooldown, the parsed `Retry-After` (or `none`), strike count, and current pace.

Unchanged: 429/403 retry indefinitely without burning the 5xx budget; one shared throttle per run; observability recording.

## Trade-off

A full pull now has a throughput floor of ~0.5–1s per article (~30–50 min for ~2,800 articles) even with zero throttling — deliberate, since the old runs weren't finishing at all.

## Testing

- `tests/test_text.py` rewritten for the new behavior: escalating cooldowns, Retry-After honored only upward, the 15-min clamp, pace doubling/decay/floor, jitter bands, cross-URL persistence, and the log format. The throttle takes an injectable `rng` so tests pin jitter deterministically.
- Since healthy requests are now paced too, `fetch_text` call sites in `tests/test_pipeline.py` inject no-op sleeps.
- `ruff check`, `ruff format --check`, `mypy src` (strict), and the full suite (866 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)