### PR TITLE
Bump to 0.7.1rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "congress-concord"
-version = "0.7.0"
+version = "0.7.1rc1"
 description = "Collect, index, and search U.S. Congress data — Congressional Record, Members, Bills, Votes — via api.congress.gov."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Step 1 of the release loop in docs/releases.md: bump `[project].version` to `0.7.1rc1` for the TestPyPI dry-run of 0.7.1.

Changes since v0.7.0: throttle fix (#137), bills section-catalogue refactor (#134), smoke-test script (#133), release docs (#132). No CLI-surface changes, hence a patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)