### PR TITLE
Bump to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "congress-concord"
-version = "0.7.1rc1"
+version = "0.7.1"
 description = "Collect, index, and search U.S. Congress data — Congressional Record, Members, Bills, Votes — via api.congress.gov."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Step 4 of the release loop in docs/releases.md: drop the rc suffix for the real 0.7.1 release. The 0.7.1rc1 TestPyPI dry-run passed the smoke test (install, CLI, version, schema bootstrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)